### PR TITLE
Add unittests for image resource and actions

### DIFF
--- a/tests/cloudferrylib/os/actions/test_converter_image_to_volume.py
+++ b/tests/cloudferrylib/os/actions/test_converter_image_to_volume.py
@@ -16,26 +16,27 @@
 
 import mock
 
-from cloudferrylib.os.actions import convertor_image_to_volume
+from cloudferrylib.os.actions import converter_image_to_volume
 from tests import test
 
 
-class ConvertorImageToVolumeTest(test.TestCase):
+class ConverterImageToVolumeTest(test.TestCase):
     def setUp(self):
-        super(ConvertorImageToVolumeTest, self).setUp()
+        super(ConverterImageToVolumeTest, self).setUp()
         self.fake_cloud = mock.Mock()
         self.fake_storage = mock.Mock()
         self.fake_storage.deploy = mock.Mock()
         vol1 = mock.Mock(id="id1")
         self.fake_storage.deploy.return_value = [vol1]
         volume = 'volume_body_dst'
-        self.fake_storage.read_info.return_value = {'storage': {'volumes': [{'volume': volume, 'meta': {}}]}}
+        self.fake_storage.read_info.return_value = {
+            'storage': {'volumes': [{'volume': volume, 'meta': {}}]}}
         self.fake_image = mock.Mock()
         self.fake_cloud.resources = {'storage': self.fake_storage,
                                      'image': self.fake_image}
 
     def test_action(self):
-        action = convertor_image_to_volume.ConvertorImageToVolume()
+        action = converter_image_to_volume.ConverterImageToVolume()
         images_fake = dict(image=dict(images=[{
             'image': 'image_body',
             'meta': {
@@ -43,7 +44,9 @@ class ConvertorImageToVolumeTest(test.TestCase):
             }
         }]))
         res = action.run(images_fake, self.fake_cloud)
-        self.assertEqual('volume_body_dst', res['volumes_info']['storage']['volumes'][0]['volume'])
-        self.assertEqual('image_body', res['volumes_info']['storage']['volumes'][0]['meta']['image'])
-
-
+        self.assertEqual(
+            'volume_body_dst',
+            res['volumes_info']['storage']['volumes'][0]['volume'])
+        self.assertEqual(
+            'image_body',
+            res['volumes_info']['storage']['volumes'][0]['meta']['image'])

--- a/tests/cloudferrylib/os/actions/test_convertor_volume_to_image.py
+++ b/tests/cloudferrylib/os/actions/test_convertor_volume_to_image.py
@@ -20,18 +20,20 @@ from cloudferrylib.os.actions import converter_volume_to_image
 from tests import test
 
 
-class ConvertorVolumeToImageTest(test.TestCase):
+class ConverterVolumeToImageTest(test.TestCase):
     def setUp(self):
-        super(ConvertorVolumeToImageTest, self).setUp()
+        super(ConverterVolumeToImageTest, self).setUp()
         self.fake_cloud = mock.Mock()
         self.fake_storage = mock.Mock()
         self.fake_storage.deploy = mock.Mock()
-        self.fake_storage.upload_volume_to_image.return_value = ('resp', 'image_id')
+        self.fake_storage.upload_volume_to_image.return_value = (
+            'resp', 'image_id')
         self.fake_storage.get_backend.return_value = 'ceph'
         self.fake_image = mock.Mock()
         self.fake_image.wait_for_status = mock.Mock()
         self.fake_image.read_info = mock.Mock()
-        self.fake_image.read_info.return_value = {'image': {'images': [{'image': 'image_body', 'meta': {}}]}}
+        self.fake_image.read_info.return_value = {
+            'image': {'images': [{'image': 'image_body', 'meta': {}}]}}
         self.fake_image.patch_image = mock.Mock()
         self.fake_cloud.resources = {'storage': self.fake_storage,
                                      'image': self.fake_image}
@@ -51,9 +53,12 @@ class ConvertorVolumeToImageTest(test.TestCase):
         }
 
     def test_action(self):
-        fake_action = converter_volume_to_image.ConverterVolumeToImage("QCOW2", self.fake_cloud)
+        fake_action = converter_volume_to_image.ConverterVolumeToImage(
+            "QCOW2",
+            self.fake_cloud)
         res = fake_action.run(self.fake_volumes_info)
-        self.assertEqual('image_body', res['images_info']['image']['images'][0]['image'])
-        self.assertEqual('dis1', res['images_info']['image']['images'][0]['meta']['volume']['display_name'])
-
-
+        self.assertEqual('image_body',
+                         res['images_info']['image']['images'][0]['image'])
+        self.assertEqual('dis1',
+                         res['images_info']['image']['images'][0]['meta'][
+                             'volume']['display_name'])

--- a/tests/cloudferrylib/os/actions/test_copy_g2g.py
+++ b/tests/cloudferrylib/os/actions/test_copy_g2g.py
@@ -1,0 +1,56 @@
+# Copyright 2014: Mirantis Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+
+import mock
+
+from cloudferrylib.os.actions import copy_g2g
+from tests import test
+
+
+class CopyFromGlanceToGlanceTestCase(test.TestCase):
+    def setUp(self):
+        super(CopyFromGlanceToGlanceTestCase, self).setUp()
+
+        self.fake_input_info = {'image_data': {'fake_key': 'fake_value'}}
+        self.fake_result_info = {'image_data': {
+            'image': {'images': [{'image': 'image_body', 'meta': {}}]}}}
+
+        self.fake_image = mock.Mock()
+        self.fake_image.deploy.return_value = self.fake_result_info
+        self.src_cloud = mock.Mock()
+        self.dst_cloud = mock.Mock()
+        self.dst_cloud.resources = {'image': self.fake_image}
+
+    def test_run_with_info(self):
+        fake_action = copy_g2g.CopyFromGlanceToGlance(self.src_cloud,
+                                                      self.dst_cloud)
+        new_info = fake_action.run(image_info=self.fake_input_info)
+
+        self.assertEqual(self.fake_result_info, new_info)
+        self.fake_image.deploy.assert_called_once_with(
+            {'fake_key': 'fake_value'})
+
+    @mock.patch('cloudferrylib.os.actions.get_info_images.GetInfoImages')
+    def test_run_no_info(self, mock_info):
+        mock_info().run.return_value = self.fake_input_info
+
+        fake_action = copy_g2g.CopyFromGlanceToGlance(self.src_cloud,
+                                                      self.dst_cloud)
+        new_info = fake_action.run()
+
+        self.assertEqual(self.fake_result_info, new_info)
+        self.fake_image.deploy.assert_called_once_with(
+            {'fake_key': 'fake_value'})

--- a/tests/cloudferrylib/os/actions/test_get_info_images.py
+++ b/tests/cloudferrylib/os/actions/test_get_info_images.py
@@ -1,0 +1,41 @@
+# Copyright 2014: Mirantis Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+
+import mock
+
+from cloudferrylib.os.actions import get_info_images
+from tests import test
+
+
+class GetInfoImagesTestCase(test.TestCase):
+    def setUp(self):
+        super(GetInfoImagesTestCase, self).setUp()
+
+        self.fake_info = {
+            'image': {'images': [{'image': 'image_body', 'meta': {}}]}}
+        self.fake_image = mock.Mock()
+        self.fake_image.read_info.return_value = self.fake_info
+        self.fake_cloud = mock.Mock()
+        self.fake_cloud.resources = {'image': self.fake_image}
+
+    def test_run(self):
+        expected_result = {'image_data': self.fake_info}
+
+        fake_action = get_info_images.GetInfoImages(self.fake_cloud)
+        image_info = fake_action.run(fake_arg='fake')
+
+        self.assertEqual(expected_result, image_info)
+        self.fake_image.read_info.assert_called_once_with(fake_arg='fake')


### PR DESCRIPTION
- Extend glance_image resource's unittests
- Add unittests for get_info_images action
- Add unittests for copy_g2g action
- Fix converters unittests (import fail, pep8)
