### PR TITLE
Saic 12: Group VMs

### DIFF
--- a/cfglib.py
+++ b/cfglib.py
@@ -98,7 +98,9 @@ migrate_opts = [
     cfg.IntOpt('time_wait', default=5,
                help='Time wait if except Performing error'),
     cfg.IntOpt('ssh_chunk_size', default=100,
-               help='Size of one chunk to transfer via SSH')
+               help='Size of one chunk to transfer via SSH'),
+    cfg.StrOpt('group_file_path',
+               help='Path to file with the groups of VMs'),
 ]
 
 mail = cfg.OptGroup(name='mail',

--- a/cloud/grouping.py
+++ b/cloud/grouping.py
@@ -1,0 +1,139 @@
+# Copyright (c) 2015 Mirantis Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the License);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an AS IS BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and#
+# limitations under the License.
+
+
+import cloud
+
+from cloudferrylib.os.identity import keystone
+from cloudferrylib.os.network import neutron
+from cloudferrylib.os.compute import nova_compute
+from cloudferrylib.utils import utils
+
+
+LOG = utils.get_log(__name__)
+
+
+class Grouping(object):
+    def __init__(self, config, group_file, cloud_id):
+        self.config = config
+        self.group_config = utils.read_yaml_file(group_file)
+        resources = {'identity': keystone.KeystoneIdentity,
+                     'network': neutron.NeutronNetwork,
+                     'compute': nova_compute.NovaCompute}
+        self.cloud = cloud.Cloud(resources, cloud_id, config)
+
+        self.network = self.cloud.resources['network']
+        self.compute = self.cloud.resources['compute']
+        self.identity = self.cloud.resources['identity']
+
+        self.groups = {}
+
+    def group(self, validate=False):
+        group_by = self.group_config.pop('group_by')
+
+        for step, grouping in enumerate(group_by):
+            groups = self._group_by(grouping, step)
+            if not step:
+                self.groups = groups
+
+        self._walk(self.groups, self._normalize)
+        self._make_users_group(self.groups, validate=validate)
+
+        utils.write_yaml_file(self.config.migrate.group_file_path, self.groups)
+
+    def _group_by(self, target, step):
+        group_rules_map = {'tenant': self._group_nested_tenant,
+                           'network': self._group_nested_network,
+                           }
+        group_func = group_rules_map.get(target)
+
+        if not group_func:
+            raise RuntimeError("There is no such grouping option. Use 'tenant'"
+                               " or 'network' values in the 'group_by' section"
+                               " of the group config file")
+
+        if not step:
+            return group_func()
+        else:
+            self._walk(self.groups, group_func)
+            return self.groups
+
+    def _group_nested_tenant(self, instances_list=None):
+        groups = {}
+
+        tenant_list = self.identity.get_tenants_list()
+        search_list = (instances_list if instances_list else
+                       self.compute.get_instances_list(
+                           search_opts={"all_tenants": True}))
+        for tenant in tenant_list:
+            LOG.info('Processing tenant %s', tenant.id)
+            groups[str(tenant.id)] = [vm for vm in search_list
+                                      if vm.tenant_id == tenant.id]
+
+        return groups
+
+    def _group_nested_network(self, instances_list=None):
+        groups = {}
+
+        network_list = self.network.get_networks_list()
+        search_list = (instances_list if instances_list else
+                       self.compute.get_instances_list(
+                           search_opts={"all_tenants": True}))
+        for network in network_list:
+            LOG.info('Processing network %s', network['name'])
+            groups[str(network['name'])] = [vm for vm in search_list
+                                            if network['name'] in vm.networks]
+
+        return groups
+
+    def _make_users_group(self, static_group, validate):
+        vms = self.group_config.values()
+        user_defined_vms = reduce(lambda res, x: x + res, vms, [])
+
+        if validate:
+            user_defined_vms = filter(self.compute.is_nova_instance,
+                                      user_defined_vms)
+            # remove duplicates
+            for user_group, vms_list in self.group_config.items():
+                self.group_config[user_group] = [vm for vm in set(vms_list)
+                                                 if vm in user_defined_vms]
+
+        self._walk_user_defined(static_group, user_defined_vms)
+
+        static_group.update(self.group_config)
+
+    def _walk(self, groups, nested_func):
+        for key, value in groups.items():
+            if isinstance(value, dict):
+                self._walk(value, nested_func)
+            else:
+                if not value:
+                    # exclude empty groups
+                    groups.pop(key)
+                    continue
+
+                groups[key] = nested_func(value)
+
+    def _walk_user_defined(self, groups, user_vms):
+        for key, value in groups.items():
+            if isinstance(value, dict):
+                self._walk_user_defined(value, user_vms)
+            else:
+                if value:
+                    same = set(value) & set(user_vms)
+                    [value.remove(i) for i in same if i in value]
+
+    @staticmethod
+    def _normalize(instance_list):
+        return [str(instance.id) for instance in instance_list]

--- a/cloudferrylib/os/actions/get_filter.py
+++ b/cloudferrylib/os/actions/get_filter.py
@@ -21,8 +21,8 @@ class GetFilter(action.Action):
     def run(self, **kwargs):
         search_opts = None
         filter_path = self.cfg.migrate.filter_path
-        if utl.get_filter_config(filter_path):
-            filter_config = utl.get_filter_config(filter_path)
+        if utl.read_yaml_file(filter_path):
+            filter_config = utl.read_yaml_file(filter_path)
             if utl.INSTANCES_TYPE in filter_config:
                 search_opts = filter_config[utl.INSTANCES_TYPE]
         return {

--- a/cloudferrylib/os/network/neutron.py
+++ b/cloudferrylib/os/network/neutron.py
@@ -500,7 +500,7 @@ class NeutronNetwork(network.Network):
         return result
 
     def get_networks(self):
-        networks = self.neutron_client.list_networks()['networks']
+        networks = self.get_networks_list()
         networks_info = []
 
         for net in networks:
@@ -508,6 +508,9 @@ class NeutronNetwork(network.Network):
             networks_info.append(cf_net)
 
         return networks_info
+
+    def get_networks_list(self):
+        return self.neutron_client.list_networks()['networks']
 
     def get_subnets(self):
         subnets = self.neutron_client.list_subnets()['subnets']

--- a/cloudferrylib/utils/utils.py
+++ b/cloudferrylib/utils/utils.py
@@ -461,9 +461,14 @@ def get_ext_ip(ext_cidr, init_host, compute_host):
 def check_file(file_path):
     return os.path.isfile(file_path)
 
-def get_filter_config(file_path):
-    if check_file(file_path):
-        return yaml.load(open(file_path, 'r'))
-    else:
-        return None
 
+def read_yaml_file(yaml_file_path):
+    if not check_file(yaml_file_path):
+        return None
+    with open(yaml_file_path) as yfile:
+        return yaml.load(yfile)
+
+
+def write_yaml_file(file_name, content):
+    with open(file_name, 'w') as yfile:
+        yaml.dump(content, yfile)

--- a/configs/config.ini
+++ b/configs/config.ini
@@ -17,6 +17,7 @@ keep_lbaas = no
 ssh_chunk_size = 100
 retry = 5
 time_wait = 5
+group_file_path = configs/grouping_result.yaml
 
 [mail]
 server = <server_name:port_number>

--- a/configs/groups.yaml
+++ b/configs/groups.yaml
@@ -1,0 +1,7 @@
+group_by:
+    - network
+user_defined_group_1:
+    - <server1>
+    - <server2>
+user_defined_group_2:
+    - <server3>

--- a/fabfile.py
+++ b/fabfile.py
@@ -20,6 +20,7 @@ from cloudferrylib.utils import utils as utl
 from cloudferrylib.utils import utils
 from cloudferrylib.scheduler.scenario import Scenario
 from cloud import cloud_ferry
+from cloud import grouping
 from dry_run import chain
 env.forward_agent = True
 env.user = 'root'
@@ -53,6 +54,26 @@ def get_info(name_config, debug=False):
 @task
 def dry_run():
     chain.process_test_chain()
+
+
+
+@task
+def get_groups(name_config=None, group_file=None, cloud_id='src',
+               validate_users_group=False):
+    """
+    Function to group VM's by any of those dependencies (f.e. tenants,
+    networks, etc.).
+
+    :param name_config: name of config ini-file, example 'config.ini',
+    :param group_file: name of groups defined yaml-file, example 'groups.yaml',
+    :param validate_users_group: Remove dublicate id's and check if valid
+           VM id specified. Takes more time because of nova API multiple calls
+    :return: yaml-file with tree-based groups defined based on grouping rules.
+    """
+    cfglib.collector_configs_plugins()
+    cfglib.init_config(name_config)
+    group = grouping.Grouping(cfglib.CONF, group_file, cloud_id)
+    group.group(validate_users_group)
 
 
 if __name__ == '__main__':

--- a/tests/cloud/test_grouping.py
+++ b/tests/cloud/test_grouping.py
@@ -1,0 +1,140 @@
+# Copyright 2015: Mirantis Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+
+import os
+
+import mock
+
+from oslotest import mockpatch
+
+from cloud import cloud
+from cloud import grouping
+from cloudferrylib import utils
+from tests import test
+
+
+RESULT_FILE = 'tests/grouping_result'
+FILE_NAME = 'tests/groups'
+FAKE_CONFIG = utils.ext_dict(src=utils.ext_dict({'user': 'fake_user',
+                                                 'password': 'fake_password',
+                                                 'tenant': 'fake_tenant',
+                                                 'host': '1.1.1.1'}),
+                             migrate=utils.ext_dict(
+                                 {'group_file_path': RESULT_FILE}))
+
+
+class GroupingTestCase(test.TestCase):
+    def setUp(self):
+        super(GroupingTestCase, self).setUp()
+
+        self.network = mock.Mock()
+        self.compute = mock.Mock()
+        self.identity = mock.Mock()
+
+        self.fake_tenant1 = mock.Mock()
+        self.fake_tenant1.id = 't1'
+        self.fake_tenant2 = mock.Mock()
+        self.fake_tenant2.id = 't2'
+
+        self.identity.get_tenants_list.return_value = [self.fake_tenant1,
+                                                       self.fake_tenant2]
+
+        self.fake_network_1 = {'name': 'net1'}
+        self.fake_network_2 = {'name': 'net3'}
+
+        self.network.get_networks_list.return_value = [self.fake_network_1,
+                                                       self.fake_network_2]
+
+        self.fake_instance1 = mock.Mock()
+        self.fake_instance1.id = 's1'
+        self.fake_instance1.networks = ['net1']
+        self.fake_instance1.tenant_id = 't1'
+        self.fake_instance2 = mock.Mock()
+        self.fake_instance2.id = 's2'
+        self.fake_instance2.networks = ['net3']
+        self.fake_instance2.tenant_id = 't2'
+        self.fake_instance3 = mock.Mock()
+        self.fake_instance3.id = 's3'
+        self.fake_instance3.tenant_id = 't1'
+        self.fake_instance3.networks = ['net1']
+
+        self.cloud = mock.Mock()
+        self.cloud().resources = {'network': self.network,
+                                  'compute': self.compute,
+                                  'identity': self.identity}
+
+        self.cloud_patch = mockpatch.PatchObject(cloud, 'Cloud',
+                                                 new=self.cloud)
+        self.useFixture(self.cloud_patch)
+
+    def tearDown(self):
+        super(GroupingTestCase, self).tearDown()
+        os.remove(FILE_NAME)
+        if utils.check_file(RESULT_FILE):
+            os.remove(RESULT_FILE)
+
+    def make_group_file(self, group_rules):
+        group_file = open(FILE_NAME, 'w')
+        group_file.write(group_rules)
+
+    def test_group_by_tenant(self):
+        group_rules = """
+        group_by:
+            - tenant
+        """
+
+        self.make_group_file(group_rules)
+        group = grouping.Grouping(FAKE_CONFIG, FILE_NAME, 'src')
+        group.compute.get_instances_list.return_value = [self.fake_instance1,
+                                                         self.fake_instance2,
+                                                         self.fake_instance3]
+
+        group.group()
+
+        expected_result = {'t2': ['s2'], 't1': ['s1', 's3']}
+
+        result = utils.read_yaml_file(RESULT_FILE)
+        self.assertEquals(expected_result, result)
+
+    def test_group_by_network(self):
+        group_rules = """
+        group_by:
+            - network
+        """
+
+        self.make_group_file(group_rules)
+        group = grouping.Grouping(FAKE_CONFIG, FILE_NAME, 'src')
+        group.compute.get_instances_list.return_value = [self.fake_instance1,
+                                                         self.fake_instance2,
+                                                         self.fake_instance3]
+        group.group()
+
+        expected_result = {'net1': ['s1', 's3'], 'net3': ['s2']}
+
+        result = utils.read_yaml_file(RESULT_FILE)
+        self.assertEquals(expected_result, result)
+
+    def test_invalid_group(self):
+        group_rules = """
+        group_by:
+            - some_group
+        """
+
+        self.make_group_file(group_rules)
+        group = grouping.Grouping(FAKE_CONFIG, FILE_NAME, 'src')
+
+        with self.assertRaisesRegexp(RuntimeError, 'no such grouping option'):
+            group.group()

--- a/tests/cloudferrylib/os/compute/test_nova.py
+++ b/tests/cloudferrylib/os/compute/test_nova.py
@@ -85,13 +85,13 @@ class NovaComputeTestCase(test.TestCase):
     def test_get_instances_list(self):
         fake_instances_list = [self.fake_instance_0, self.fake_instance_1]
         self.mock_client().servers.list.return_value = fake_instances_list
-
-        instances_list = self.nova_client.get_instances_list()
-
         test_args = {'marker': None,
                      'detailed': True,
                      'limit': None,
                      'search_opts': None}
+
+        instances_list = self.nova_client.get_instances_list(**test_args)
+
         self.mock_client().servers.list.assert_called_once_with(**test_args)
         self.assertEqual(fake_instances_list, instances_list)
 


### PR DESCRIPTION
- add 'get_group' task into the fabfile
- provide file config/groups.yaml with the grouping rules
- add new parameter to the config.ini's migrate section (group_file_path)
- implement grouping engine for VMs.
- implement nested gropings support.
- at this moment tenant or network (or both together) are supported as
     grouping params.
- extend nova resource functionality:
  - add possibility to get instances list by tenant's id or network's name
- add 'get_networks_list' method to the neutron resource