### PR TITLE
SAIC-27: Quantum support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ automatically) or list new networks for instances in config.yaml file in overwri
 
 
 Cloudferry also allow keep ip addresses of instances and transfer security groups (with rules) with automatic detection
-of network manager on source and destination clouds (neutron, quantum or nova).
+of network manager on source and destination clouds (quantum/neutron or nova).
 
 
 All functions are configured in yaml file, you can see the examples in configs directory.

--- a/cloudferrylib/os/network/neutron.py
+++ b/cloudferrylib/os/network/neutron.py
@@ -37,7 +37,6 @@ class NeutronNetwork(network.Network):
         super(NeutronNetwork, self).__init__(config)
         self.cloud = cloud
         self.identity_client = cloud.resources['identity']
-        # TODO: implement switch to quantumclient if we have quantum-server
         self.neutron_client = self.proxy(self.get_client(), config)
 
     def get_client(self):

--- a/configs/config.ini
+++ b/configs/config.ini
@@ -16,6 +16,7 @@ direct_compute_transfer=yes
 keep_lbaas = no
 ssh_chunk_size = 100
 retry = 5
+migrate_extnets = True
 time_wait = 5
 
 [mail]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-ecdsa
 --allow-external mysql-connector-python
 colorlog
+ecdsa
 fabric>=1.8.2
 ipaddr
 jinja2


### PR DESCRIPTION
- Test networks migration from Grizzly (Quantum) to Icehouse (Neutron).
   Result: Networks migrated successfully
- Fix README.md
- Delete obsolete TODO's about Quantum