### PR TITLE
SAIC-89, keeping all network vlan-id in migration

### DIFF
--- a/cloudferrylib/os/network/neutron.py
+++ b/cloudferrylib/os/network/neutron.py
@@ -794,8 +794,8 @@ class NeutronNetwork(network.Network):
                         rule['meta']['id'] = new_rule['security_group_rule']['id']
 
     def upload_networks(self, networks):
-        existing_nets_hashlist = \
-            [ex_net['res_hash'] for ex_net in self.get_networks()]
+        existing_nets_hashlist = (
+            [ex_net['res_hash'] for ex_net in self.get_networks()])
         for net in networks:
             tenant_id = \
                 self.identity_client.get_tenant_id_by_name(net['tenant_name'])
@@ -805,24 +805,22 @@ class NeutronNetwork(network.Network):
                     'name': net['name'],
                     'admin_state_up': net['admin_state_up'],
                     'tenant_id': tenant_id,
-                    'shared': net['shared']
+                    'shared': net['shared'],
+                    'router:external': net['router:external'],
+                    'provider:physical_network': \
+                       net['provider:physical_network'],
+                    'provider:network_type':  net['provider:network_type']
                 }
             }
             if net['router:external']:
                 if not self.config.migrate.migrate_extnets:
                     continue
-                network_info['network']['router:external'] = \
-                    net['router:external']
-                network_info['network']['provider:physical_network'] = \
-                    net['provider:physical_network']
-                network_info['network']['provider:network_type'] = \
-                    net['provider:network_type']
-                if net['provider:network_type'] == 'vlan':
-                    network_info['network']['provider:segmentation_id'] = \
-                        net['provider:segmentation_id']
+            if net['provider:network_type'] == 'vlan':
+                network_info['network']['provider:segmentation_id'] = (
+                    net['provider:segmentation_id'])
             if net['res_hash'] not in existing_nets_hashlist:
-                net['meta']['id'] = self.neutron_client.\
-                    create_network(network_info)['network']['id']
+                net['meta']['id'] = (self.neutron_client.
+                    create_network(network_info)['network']['id'])
             else:
                 LOG.info("| Dst cloud already has the same network "
                          "with name %s in tenant %s" %

--- a/tests/cloudferrylib/os/network/test_neutron.py
+++ b/tests/cloudferrylib/os/network/test_neutron.py
@@ -463,7 +463,11 @@ class NeutronTestCase(test.TestCase):
             'network': {'name': 'fake_network_name_1',
                         'admin_state_up': True,
                         'tenant_id': 'fake_tenant_id_1',
-                        'shared': False}}
+                        'shared': False,
+                        'router:external': False,
+                        'provider:physical_network': None,
+                        'provider:network_type': 'gre' 
+                        }}
 
         self.neutron_network_client.upload_networks([self.net_1_info])
 


### PR DESCRIPTION
This is for the issue SAIC-89.
CF sometimes uses wrong Segmentation ID, causing public network creation failure.
The reason for this issue is that CF does not record segmentation ID for internal network. Instead, it uses next the available one.
If a privat network is created before public network, it will take the ID 1000.
If the source cloud's public network has vlan-id 1000, then the following error will occurs.

To fix this, we record also the old vlan-id used by internal networks in the source cloud, so there won't be a conflict during migration.