### PR TITLE
SAIC-86 Fix broken rollback

### DIFF
--- a/cloudferrylib/scheduler/scheduler.py
+++ b/cloudferrylib/scheduler/scheduler.py
@@ -142,7 +142,9 @@ class SchedulerThread(BaseScheduler):
         namespace = self.namespace.fork(is_deep_copy)
         scheduler = self.__class__(namespace=namespace,
                                    thread_task=thread_task,
-                                   cursor=Cursor(thread_task.getNet()),
+                                   preparation=self.preparation,
+                                   migration=Cursor(thread_task.getNet()),
+                                   rollback=self.rollback,
                                    scheduler_parent=self)
         self.namespace.vars[CHILDREN][thread_task] = {
             'namespace': namespace,

--- a/dry_run/chain.py
+++ b/dry_run/chain.py
@@ -7,4 +7,4 @@ from cloudferrylib.scheduler import scheduler
 def process_test_chain():
     chain = (AddNumbers(1, 2) >> DivideNumbers(4, 3) >>
              MultiplyNumbers(4, 2) >> DivisionByZero())
-    scheduler.Scheduler(cursor=cursor.Cursor(chain)).start()
+    scheduler.Scheduler(migration=cursor.Cursor(chain)).start()


### PR DESCRIPTION
Rollback patch modified scheduler constructor signature but did not
modify all the calling code according to new signature. This patch fixes
all these cases and adds several test cases which verify the correctness
of rollbacks.