### PR TITLE
 SAIC-97, To avoid DHCP taking IP used by an instance

### DIFF
--- a/cloudferrylib/os/actions/prepare_networks.py
+++ b/cloudferrylib/os/actions/prepare_networks.py
@@ -31,6 +31,13 @@ class PrepareNetworks(action.Action):
         keep_ip = self.cfg.migrate.keep_ip
 
         instances = info_compute[utl.INSTANCES_TYPE]
+        # disable DHCP in all subnets
+        subnets = network_resource.get_subnets()
+        for snet in subnets:
+            if snet['tenant_name'] == self.cfg.dst.tenant:
+                network_resource. \
+                    reset_subnet_dhcp(snet['id'], False)
+
         for (id_inst, inst) in instances.iteritems():
             params = []
             networks_info = inst[utl.INSTANCE_BODY][utl.INTERFACES]
@@ -65,6 +72,11 @@ class PrepareNetworks(action.Action):
                 params.append({'net-id': dst_net['id'], 'port-id': port['id']})
             instances[id_inst][utl.INSTANCE_BODY]['nics'] = params
         info_compute[utl.INSTANCES_TYPE] = instances
+        # reset dhcp to the original setting
+        for snet in subnets:
+            if snet['tenant_name'] == self.cfg.dst.tenant:
+                network_resource.\
+                    reset_subnet_dhcp(snet['id'], snet['enable_dhcp'])
         return {
             'info': info_compute
         }

--- a/cloudferrylib/os/network/neutron.py
+++ b/cloudferrylib/os/network/neutron.py
@@ -518,6 +518,15 @@ class NeutronNetwork(network.Network):
 
         return subnets_info
 
+    def reset_subnet_dhcp(self, subnet_id, dhcp_flag):
+        subnet_info = {
+            'subnet':
+            {
+                'enable_dhcp': dhcp_flag
+            }
+        }
+        return self.neutron_client.update_subnet(subnet_id, subnet_info)
+
     def get_routers(self):
         routers = self.neutron_client.list_routers()['routers']
         routers_info = []


### PR DESCRIPTION
Since the creation order of a DHCP port and an instance port can be
random, sometimes, the DHCP port can take the IP used by an instance
in source could. To avoid it, this fix will disable DHCP and free its
IP before instance port creation, then re-enable the DHCP.