### PR TITLE
SAIC-105 missing path to import "action"

### DIFF
--- a/cloudferrylib/base/__init__.py
+++ b/cloudferrylib/base/__init__.py
@@ -1,7 +1,1 @@
-import action
-import compute
-import identity
-import image
-import network
-import resource
-import storage
+

--- a/cloudferrylib/base/action/converter.py
+++ b/cloudferrylib/base/action/converter.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-import action
+from cloudferrylib.base.action import action
 
 
 class Converter(action.Action):

--- a/cloudferrylib/os/__init__.py
+++ b/cloudferrylib/os/__init__.py
@@ -1,1 +1,1 @@
-import actions
+


### PR DESCRIPTION
All other files in the directory have path defined:

grep "import action" *

converter.py:import action
copy_var.py:from cloudferrylib.base.action import action
create_reference.py:from cloudferrylib.base.action import action
get_info_iter.py:from cloudferrylib.base.action import action
is_end_iter.py:from cloudferrylib.base.action import action
is_option.py:from cloudferrylib.base.action import action
merge.py:from cloudferrylib.base.action import action
rename_info.py:from cloudferrylib.base.action import action
transporter.py:from cloudferrylib.base.action import action
