### PR TITLE
SAIC-95: Add flag 'all_vms' to config

### DIFF
--- a/cfglib.py
+++ b/cfglib.py
@@ -107,6 +107,10 @@ migrate_opts = [
                help='Path to file with the groups of VMs'),
     cfg.BoolOpt('all_networks', default=False,
                 help="Migrate all network resources from all tenants"),
+    cfg.BoolOpt('all_vms', default=False,
+                help="Migrate all VM's from all tenants. User, specified in "
+                     "the 'dst' section of config also should have admin role "
+                     "in all tenants."),
 ]
 
 mail = cfg.OptGroup(name='mail',

--- a/cloudferrylib/os/compute/nova_compute.py
+++ b/cloudferrylib/os/compute/nova_compute.py
@@ -114,6 +114,11 @@ class NovaCompute(compute.Compute):
             raise ValueError('Only "resources" or "instances" values allowed')
 
         search_opts = kwargs.get('search_opts')
+
+        if self.config.migrate.all_vms:
+            search_opts = search_opts if search_opts else {}
+            search_opts.update(all_tenants=True)
+
         info = {'instances': {}}
 
         for instance in self.get_instances_list(search_opts=search_opts):
@@ -402,15 +407,12 @@ class NovaCompute(compute.Compute):
         nova_tenants_clients = {
             self.config['cloud']['tenant']: self.nova_client}
 
-        params = {'user': self.config['cloud']['user'],
-                  'password': self.config['cloud']['password'],
-                  'tenant': self.config['cloud']['tenant'],
-                  'host': self.config['cloud']['host']}
+        params = copy.deepcopy(self.config)
 
         for _instance in info_compute['instances'].itervalues():
             tenant_name = _instance['instance']['tenant_name']
             if tenant_name not in nova_tenants_clients:
-                params['tenant'] = tenant_name
+                params.cloud.tenant = tenant_name
                 nova_tenants_clients[tenant_name] = self.get_client(params)
 
         for _instance in info_compute['instances'].itervalues():

--- a/configs/config.ini
+++ b/configs/config.ini
@@ -19,6 +19,7 @@ retry = 5
 migrate_extnets = True
 time_wait = 5
 group_file_path = configs/grouping_result.yaml
+all_vms = False
 all_networks = False
 
 [mail]

--- a/tests/cloudferrylib/os/compute/test_nova.py
+++ b/tests/cloudferrylib/os/compute/test_nova.py
@@ -32,7 +32,8 @@ FAKE_CONFIG = utils.ext_dict(
     mysql=utils.ext_dict({'host': '1.1.1.1'}),
     migrate=utils.ext_dict({'speed_limit': '10MB',
                             'retry': '7',
-                            'time_wait': 5}))
+                            'time_wait': 5,
+                            'all_vms': False}))
 
 
 class NovaComputeTestCase(test.TestCase):


### PR DESCRIPTION
Add availability to migrate all VMs with flag 'all_vms=True' in the
'migrate' section of config. It is possible if destination user,
specified in the 'dst' section of config, has admin role in all
destination tenants, otherwise it will fail with 'Unauthorized' error
(Actually, it was required by CloudFerry before to migrate instances
to the different from 'admin' tenant).