### PR TITLE
SAIC-166 Add hostnames to devenv VMs

### DIFF
--- a/devlab/Vagrantfile
+++ b/devlab/Vagrantfile
@@ -40,11 +40,14 @@ Vagrant.require_version '>= 1.6.0'
 
 Vagrant.configure(2) do |config|
   config.vm.provision "shell", path: "./provision/prerequisites.sh"
+  etc_hosts = nodes.map { |name, data| [data["ip"], name].join(' ') }.join("\n")
 
   nodes.each do |nodename, nodedata|
     config.vm.define nodename do |thisnode|
       thisnode.vm.box = nodedata['box']
       thisnode.vm.hostname = nodename
+
+      thisnode.vm.provision "shell", inline: "echo '#{etc_hosts}' >> /etc/hosts"
 
       case nodedata.fetch("role")
         when "openstack"


### PR DESCRIPTION
Adds hostnames to /etc/hosts for all VMs so that CloudFerry scripts
could reach destination using hostname, not just IP address.