### PR TITLE
SAIC-190 Fix VM migration for VMs with ERROR state

### DIFF
--- a/cloudferrylib/os/compute/nova_compute.py
+++ b/cloudferrylib/os/compute/nova_compute.py
@@ -122,9 +122,10 @@ class NovaCompute(compute.Compute):
         info = {'instances': {}}
 
         for instance in self.get_instances_list(search_opts=search_opts):
-            info['instances'][instance.id] = self.convert(instance,
-                                                          self.config,
-                                                          self.cloud)
+            if instance.status != 'ERROR':
+                info['instances'][instance.id] = self.convert(instance,
+                                                              self.config,
+                                                              self.cloud)
 
         return info
 


### PR DESCRIPTION
In case SRC has VMs with ERROR state, migration procedure fails accessing
the compute host where the VM is expected to be run. This patch fixes
the issue by verifying the VM is not in error state.