### PR TITLE
SAIC-169 Key pair migration

### DIFF
--- a/cloudferrylib/os/compute/instances.py
+++ b/cloudferrylib/os/compute/instances.py
@@ -1,0 +1,21 @@
+# Copyright 2015 Mirantis Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def update_user_ids_for_instance(db, instance_id, user_id):
+    sql = ("UPDATE nova.instances "
+           "SET nova.instances.user_id = '{user_id}' "
+           "WHERE nova.instances.uuid = '{instance_id}';").format(
+        user_id=user_id, instance_id=instance_id)
+    db.execute(sql)

--- a/cloudferrylib/os/compute/keypairs.py
+++ b/cloudferrylib/os/compute/keypairs.py
@@ -1,0 +1,133 @@
+# Copyright 2015 Mirantis Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from cloudferrylib.utils import utils as utl
+
+
+LOG = utl.get_log(__name__)
+
+
+class KeyPair(dict):
+    """Represents nova key pair based on DB schema:
+    +-------------+--------------+------+-----+---------+----------------+
+    | Field       | Type         | Null | Key | Default | Extra          |
+    +-------------+--------------+------+-----+---------+----------------+
+    | created_at  | datetime     | YES  |     | NULL    |                |
+    | updated_at  | datetime     | YES  |     | NULL    |                |
+    | deleted_at  | datetime     | YES  |     | NULL    |                |
+    | id          | int(11)      | NO   | PRI | NULL    | auto_increment |
+    | name        | varchar(255) | YES  |     | NULL    |                |
+    | user_id     | varchar(255) | YES  | MUL | NULL    |                |
+    | fingerprint | varchar(255) | YES  |     | NULL    |                |
+    | public_key  | mediumtext   | YES  |     | NULL    |                |
+    | deleted     | int(11)      | YES  |     | NULL    |                |
+    +-------------+--------------+------+-----+---------+----------------+
+    """
+
+    FIELDS = ['created_at', 'updated_at', 'deleted_at', 'id', 'name',
+              'user_id', 'fingerprint', 'public_key', 'deleted']
+    AUTO_FIELDS = ['id']
+
+    def __init__(self, **kwargs):
+        super(KeyPair, self).__init__(**kwargs)
+        for field in self.FIELDS:
+            value = kwargs.get(field)
+            setattr(self, field, value)
+            self[field] = value
+
+    @classmethod
+    def from_tuple(cls, fetched_data):
+        """Builds KeyPair object from sqlalchemy-returned tuple"""
+        if len(fetched_data) != len(cls.FIELDS):
+            raise ValueError("Invalid value provided to KeyPair")
+
+        kp = KeyPair()
+        for i, key in enumerate(cls.FIELDS):
+            setattr(kp, key, fetched_data[i])
+        return kp
+
+    def to_dict(self, allow_auto_fields=False):
+        d = {}
+        fields = (self.FIELDS
+                  if allow_auto_fields
+                  else filter(lambda s: s not in self.AUTO_FIELDS,
+                              self.FIELDS))
+        for key in fields:
+            if getattr(self, key) is not None:
+                d[key] = getattr(self, key)
+        return d
+
+
+class DBBroker(object):
+    """Defines DB methods. Moved to a class to ease unit tests mocking."""
+
+    NOVA_KEYPAIRS = "nova.key_pairs"
+    NOVA_INSTANCES = "nova.instances"
+
+    @classmethod
+    def get_all_keypairs(cls, cloud):
+        db = DBBroker._get_db(cloud)
+        sql = "SELECT * FROM {key_pairs} WHERE deleted = 0;".format(
+            key_pairs=cls.NOVA_KEYPAIRS)
+        return map(KeyPair.from_tuple, db.execute(sql).fetchall())
+
+    @classmethod
+    def store_keypair(cls, key_pair, cloud):
+        db = DBBroker._get_db(cloud)
+
+        key_pair_dict = key_pair.to_dict()
+        kp_fields = str(key_pair.to_dict().keys()).translate(None, "[]'")
+        kp_values = ','.join(['"{}"'.format(kp)
+                              for kp in key_pair_dict.values()])
+
+        sql = ("INSERT INTO {nova_keypairs} ({fields}) "
+               "VALUES ({values}) ON DUPLICATE KEY UPDATE id=id;"
+               ).format(nova_keypairs=cls.NOVA_KEYPAIRS,
+                        fields=kp_fields,
+                        values=kp_values)
+
+        LOG.info("Storing keypair '%s' in DB", key_pair.name)
+        LOG.debug(sql)
+
+        db.execute(sql)
+
+    @classmethod
+    def add_keypair_to_instance(cls, cloud, key_name, user_id, instance_id):
+        db = DBBroker._get_db(cloud)
+
+        sql = ("UPDATE {instances} "
+               "INNER JOIN {key_pairs} "
+               "ON {instances}.user_id = {key_pairs}.user_id "
+               "   AND {instances}.uuid='{instance_id}' "
+               "   AND {key_pairs}.user_id='{user_id}' "
+               "   AND {instances}.user_id='{user_id}' "
+               "   AND {instances}.deleted = 0 "
+               "   AND {key_pairs}.deleted = 0 "
+               "SET {instances}.key_name='{key_name}', "
+               "    {instances}.key_data={key_pairs}.public_key;"
+               ).format(
+            instances=cls.NOVA_INSTANCES,
+            key_pairs=cls.NOVA_KEYPAIRS,
+            key_name=key_name,
+            user_id=user_id,
+            instance_id=instance_id)
+
+        LOG.info("Adding keypair '%s' to instance '%s'", key_name, instance_id)
+        LOG.debug(sql)
+
+        db.execute(sql)
+
+    @classmethod
+    def _get_db(cls, cloud):
+        return cloud.resources[utl.COMPUTE_RESOURCE].mysql_connector

--- a/scenario/migrate.yaml
+++ b/scenario/migrate.yaml
@@ -39,6 +39,7 @@ process:
           - act_deploy_images: True
       - act_comp_res_trans: True
       - act_network_trans: True
+      - transport_key_pairs: True
   - transport_instances_and_dependency_resources:
       - act_get_filter: True
       - act_get_info_inst: True
@@ -76,6 +77,7 @@ process:
                   - act_convert_image: True
                   - act_f_to_i: True
               - act_deploy_instances: True
+              - add_key_pairs_to_instances: True
               - act_is_not_copy_diff_file: ['act_transport_ephemeral']
               - act_trans_diff_file: True
               - act_transport_ephemeral: True

--- a/scenario/tasks.yaml
+++ b/scenario/tasks.yaml
@@ -75,3 +75,5 @@ tasks:
    act_check_bandwidth_dst: ['CheckBandwidth', 'dst_cloud']
    get_volumes_db_data: ["GetVolumesDb", 'src_cloud']
    write_volumes_db_data: ["WriteVolumesDb", 'dst_cloud']
+   transport_key_pairs: ["TransportKeyPairs"]
+   add_key_pairs_to_instances: ["SetKeyPairsForInstances"]

--- a/tests/cloudferrylib/os/actions/test_keypair_migration.py
+++ b/tests/cloudferrylib/os/actions/test_keypair_migration.py
@@ -1,0 +1,179 @@
+# Copyright 2015 Mirantis Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import keystoneclient
+import mock
+from cloudferrylib.os.compute import keypairs
+
+from tests import test
+from cloudferrylib.os.actions import transport_compute_resources as tcr
+from cloudferrylib.utils import utils as utl
+
+
+class KeyPairObjectTestCase(test.TestCase):
+    def test_key_pair_does_not_include_autoincrement_fields(self):
+        kp_db = (
+            "Jan 1st 1970",       # created_at
+            None,                 # updated_at
+            None,                 # deleted_at
+            "keypair-id",         # id
+            "keypair-name",       # name
+            "user-id",            # user_id
+            "aa:bb:cc:dd:ee:ff",  # fingerprint
+            "public-key-data",    # public_key
+            0,                    # deleted
+        )
+        kp = keypairs.KeyPair.from_tuple(kp_db)
+        kp_dict = kp.to_dict(allow_auto_fields=False)
+        self.assertTrue('id' not in kp_dict.keys())
+
+    def test_all_fields_are_accessible_through_attributes(self):
+        kp = keypairs.KeyPair()
+
+        try:
+            for field in kp.FIELDS:
+                getattr(kp, field)
+        except AttributeError:
+            self.fail("KeyPair object must have all fields accessible as "
+                      "attributes")
+
+    def test_value_error_is_risen_in_case_db_value_is_incorrect(self):
+        # user id, fingerprint, public key and deleted keys missing
+        db_kp = ("datetime", None, None, "id", "keypair name")
+        self.assertRaises(ValueError, keypairs.KeyPair.from_tuple, db_kp)
+
+        db_kp = ("datetime", None, None, "id", "keypair name", "user id",
+                 "fingerprint", "public key", 0, "invalid argument")
+        self.assertRaises(ValueError, keypairs.KeyPair.from_tuple, db_kp)
+
+    def test_fields_are_settable_as_attributes(self):
+        try:
+            kp = keypairs.KeyPair()
+
+            public_key_value = "random public key"
+            fingerprint_value = "fingerprint"
+            deleted_value = 1
+
+            kp.public_key = public_key_value
+            kp.fingerprint = fingerprint_value
+            kp.deleted = deleted_value
+
+            self.assertEqual(kp.public_key, public_key_value)
+            self.assertEqual(kp.fingerprint, fingerprint_value)
+            self.assertEqual(kp.deleted, deleted_value)
+        except AttributeError:
+            self.fail("Key pair fields must be settable as attributes")
+
+    def test_key_pair_has_dict_support(self):
+        try:
+            kp = keypairs.KeyPair()
+
+            public_key_value = "random public key"
+            fingerprint_value = "fingerprint"
+            deleted_value = 1
+
+            kp['public_key'] = public_key_value
+            kp['fingerprint'] = fingerprint_value
+            kp['deleted'] = deleted_value
+
+            self.assertEqual(kp['public_key'], public_key_value)
+            self.assertEqual(kp['fingerprint'], fingerprint_value)
+            self.assertEqual(kp['deleted'], deleted_value)
+        except KeyError:
+            self.fail("Key pair fields must be settable as dict item")
+
+
+class KeyPairMigrationTestCase(test.TestCase):
+    @mock.patch('cloudferrylib.os.identity.keystone.'
+                'get_dst_user_from_src_user_id')
+    def test_non_existing_user_does_not_break_migration(self, _):
+        try:
+            db_broker = mock.Mock()
+            db_broker.get_all_keypairs.return_value = [keypairs.KeyPair(),
+                                                       keypairs.KeyPair()]
+
+            tkp = tcr.TransportKeyPairs(init=mock.MagicMock(),
+                                        kp_db_broker=db_broker)
+
+            tkp.src_cloud = mock.MagicMock()
+            tkp.dst_cloud = mock.MagicMock()
+            src_users = tkp.src_cloud.resources[
+                utl.IDENTITY_RESOURCE].keystone_client.users
+            src_users.find.side_effect = keystoneclient.exceptions.NotFound
+
+            dst_users = tkp.dst_cloud.resources[
+                utl.IDENTITY_RESOURCE].keystone_client.users
+            dst_users.find.side_effect = keystoneclient.exceptions.NotFound
+
+            tkp.run()
+        except Exception as e:
+            self.fail("Unexpected exception caught: %s" % e)
+
+    def test_update_sql_gets_called_for_each_keypair(self):
+        num_keypairs = 5
+
+        db_broker = mock.Mock()
+        db_broker.get_all_keypairs.return_value = [
+            keypairs.KeyPair() for _ in xrange(num_keypairs)]
+        db_broker.store_keypair = mock.Mock()
+
+        tkp = tcr.TransportKeyPairs(init=mock.MagicMock(),
+                                    kp_db_broker=db_broker)
+        tkp.src_cloud = mock.MagicMock()
+        tkp.dst_cloud = mock.MagicMock()
+        tkp.run()
+
+        self.assertTrue(db_broker.store_keypair.call_count == num_keypairs)
+
+
+class KeyPairForInstancesTestCase(test.TestCase):
+    def test_does_nothing_if_no_info_provided(self):
+        db_broker = mock.Mock()
+        task = tcr.SetKeyPairsForInstances(init=mock.MagicMock(),
+                                           kp_db_broker=db_broker)
+        task.run()
+
+        self.assertFalse(db_broker.add_keypair_to_instance.called)
+
+    def test_keypair_is_added_to_instance(self):
+        db_broker = mock.Mock()
+
+        num_instances_with_keys = 5
+        num_instances_without_keys = 5
+
+        instances = {
+            'instance1%d' % i: {
+                'instance': {
+                    'key_name': 'key%d' % i,
+                    'user_id': 'user%d' % i
+                }
+            } for i in xrange(num_instances_with_keys)
+        }
+
+        instances.update({
+            'instance2%d' % j: {
+                'instance': {
+                    'user_id': 'user%d' % j
+                }
+            } for j in xrange(num_instances_without_keys)}
+        )
+
+        info = {utl.INSTANCES_TYPE: instances}
+
+        task = tcr.SetKeyPairsForInstances(init=mock.MagicMock(),
+                                           kp_db_broker=db_broker)
+        task.run(info=info)
+
+        self.assertTrue(db_broker.add_keypair_to_instance.called)
+        self.assertEqual(db_broker.add_keypair_to_instance.call_count,
+                         num_instances_with_keys)

--- a/tests/cloudferrylib/os/compute/test_nova.py
+++ b/tests/cloudferrylib/os/compute/test_nova.py
@@ -80,7 +80,8 @@ class NovaComputeTestCase(test.TestCase):
 
         instance_id = self.nova_client.create_instance(name='fake_instance',
                                                        image='fake_image',
-                                                       flavor='fake_flavor')
+                                                       flavor='fake_flavor',
+                                                       user_id='some-id')
 
         self.assertEqual('fake_instance_id', instance_id)
 


### PR DESCRIPTION
Key pairs are only accessible by user created them, admin user has no
access to user key pairs. Because of that migration fails for non-admin
VMs which have keypair associated.