### PR TITLE
SAIC-207: Change Glance client authentication process

### DIFF
--- a/cloudferrylib/os/identity/keystone.py
+++ b/cloudferrylib/os/identity/keystone.py
@@ -25,8 +25,6 @@ from cloudferrylib.utils import utils as utl
 
 LOG = utl.get_log(__name__)
 
-NOVA_SERVICE = 'nova'
-
 
 class KeystoneIdentity(identity.Identity):
     """The main class for working with OpenStack Keystone Identity Service."""
@@ -34,6 +32,7 @@ class KeystoneIdentity(identity.Identity):
     def __init__(self, config, cloud):
         super(KeystoneIdentity, self).__init__()
         self.config = config
+        self._ks_client_creds = self.proxy(self._get_client_by_creds(), config)
         self.keystone_client = self.proxy(self.get_client(), config)
         self.mysql_connector = cloud.mysql_connector
         self.cloud = cloud
@@ -122,45 +121,38 @@ class KeystoneIdentity(identity.Identity):
         print 'Finished'
 
     def get_client(self):
-        """ Getting keystone client """
+        """ Getting keystone client using authentication with admin auth token.
 
-        ks_client_for_token = keystone_client.Client(
-            username=self.config.cloud.user,
-            password=self.config.cloud.password,
-            tenant_name=self.config.cloud.tenant,
-            auth_url=self.config.cloud.auth_url)
+        :return: OpenStack Keystone Client instance
+        """
 
         return keystone_client.Client(
-            token=ks_client_for_token.auth_ref['token']['id'],
+            token=self._ks_client_creds.auth_ref['token']['id'],
             endpoint=self.config.cloud.auth_url)
 
-    def get_service_name_by_type(self, service_type):
-        """Getting service_name from keystone. """
+    def _get_client_by_creds(self):
+        """Authenticating with a user name and password.
 
-        for service in self.get_services_list():
-            if service.type == service_type:
-                return service.name
-        return NOVA_SERVICE
+        :return: OpenStack Keystone Client instance
+        """
 
-    def get_public_endpoint_service_by_id(self, service_id):
-        """Getting endpoint public URL from keystone. """
+        return keystone_client.Client(username=self.config.cloud.user,
+                                      password=self.config.cloud.password,
+                                      tenant_name=self.config.cloud.tenant,
+                                      auth_url=self.config.cloud.auth_url)
 
-        for endpoint in self.keystone_client.endpoints.list():
-            if endpoint.service_id == service_id:
-                return endpoint.publicurl
+    def get_endpoint_by_service_type(self, service_type, endpoint_type):
+        """Getting endpoint URL by service type.
 
-    def get_service_id(self, service_name):
-        """Getting service_id from keystone. """
+        :param service_type: OpenStack service type (image, compute etc.)
+        :param endpoint_type: publicURL or internalURL
 
-        for service in self.get_services_list():
-            if service.name == service_name:
-                return service.id
+        :return: String endpoint of specified OpenStack service
+        """
 
-    def get_endpoint_by_service_name(self, service_name):
-        """ Getting endpoint public URL by service name from keystone. """
-
-        service_id = self.get_service_id(service_name)
-        return self.get_public_endpoint_service_by_id(service_id)
+        return self._ks_client_creds.service_catalog.url_for(
+            service_type=service_type,
+            endpoint_type=endpoint_type)
 
     def get_tenants_func(self):
         tenants = {tenant.id: tenant.name for tenant in
@@ -188,11 +180,6 @@ class KeystoneIdentity(identity.Identity):
         """ Getting tenant by id from keystone. """
 
         return self.keystone_client.tenants.get(tenant_id)
-
-    def get_services_list(self):
-        """ Getting list of available services from keystone. """
-
-        return self.keystone_client.services.list()
 
     def get_tenants_list(self):
         """ Getting list of tenants from keystone. """

--- a/cloudferrylib/os/image/glance_image.py
+++ b/cloudferrylib/os/image/glance_image.py
@@ -68,8 +68,10 @@ class GlanceImage(image.Image):
     def get_client(self):
         """ Getting glance client """
 
-        endpoint_glance = self.identity_client.get_endpoint_by_service_name(
-            'glance')
+        endpoint_glance = self.identity_client.get_endpoint_by_service_type(
+            service_type='image',
+            endpoint_type='publicURL')
+
         # we can figure out what version of client to use from url
         # check if we have "v1" or "v2" in the end of url
         m = re.search("(.*)/v(\d)", endpoint_glance)

--- a/tests/cloudferrylib/os/identity/test_keystone.py
+++ b/tests/cloudferrylib/os/identity/test_keystone.py
@@ -78,17 +78,6 @@ class KeystoneIdentityTestCase(test.TestCase):
         self.fake_role_1.name = 'role_name_1'
         self.fake_role_1.id = 'role_id_1'
 
-        self.fake_service_0 = mock.Mock()
-        self.fake_service_1 = mock.Mock()
-        self.fake_service_0.type = 'fake_type'
-        self.fake_service_0.name = 'fake_name'
-        self.fake_service_0.id = 'fake_id'
-
-        self.fake_endpoint_0 = mock.Mock()
-        self.fake_endpoint_1 = mock.Mock()
-        self.fake_endpoint_0.service_id = 'fake_id'
-        self.fake_endpoint_0.publicurl = 'example.com'
-
     def test_get_client(self):
         self.mock_client().auth_ref = {'token': {'id': 'fake_id'}}
 
@@ -99,7 +88,7 @@ class KeystoneIdentityTestCase(test.TestCase):
                       password='fake_password',
                       auth_url='http://1.1.1.1:35357/v2.0/'),
             mock.call(token='fake_id', endpoint='http://1.1.1.1:35357/v2.0/')]
-        self.mock_client.assert_has_calls(mock_calls)
+        self.mock_client.assert_has_calls(mock_calls, any_order=True)
         self.assertEqual(self.mock_client(), client)
 
     def test_get_tenants_list(self):
@@ -109,75 +98,6 @@ class KeystoneIdentityTestCase(test.TestCase):
         tenant_list = self.keystone_client.get_tenants_list()
 
         self.assertEqual(fake_tenants_list, tenant_list)
-
-    def test_get_services_list(self):
-        fake_services_list = [self.fake_service_0, self.fake_service_1]
-        self.mock_client().services.list.return_value = fake_services_list
-
-        services_list = self.keystone_client.get_services_list()
-
-        self.assertEqual(fake_services_list, services_list)
-
-    def test_get_service_name_by_type(self):
-        fake_services_list = [self.fake_service_0, self.fake_service_1]
-        self.mock_client().services.list.return_value = fake_services_list
-
-        service_name = self.keystone_client.get_service_name_by_type(
-            'fake_type')
-
-        self.assertEqual('fake_name', service_name)
-
-    def test_get_service_name_by_type_default(self):
-        self.mock_client().services.list.return_value = []
-
-        service_name = self.keystone_client.get_service_name_by_type(
-            'fake_type')
-
-        self.assertEqual('nova', service_name)
-
-    def test_get_public_endpoint_service_by_id(self):
-        fake_endpoints_list = [self.fake_endpoint_0, self.fake_endpoint_1]
-        self.mock_client().endpoints.list.return_value = fake_endpoints_list
-
-        endpoint = self.keystone_client.get_public_endpoint_service_by_id(
-            'fake_id')
-
-        self.assertEqual('example.com', endpoint)
-
-    def test_get_public_endpoint_service_by_id_default(self):
-        self.mock_client().endpoints.list.return_value = []
-
-        endpoint = self.keystone_client.get_public_endpoint_service_by_id(
-            'fake_service_id')
-
-        self.assertIsNone(endpoint)
-
-    def test_get_service_id(self):
-        fake_services_list = [self.fake_service_0, self.fake_service_1]
-        self.mock_client().services.list.return_value = fake_services_list
-
-        service_id = self.keystone_client.get_service_id('fake_name')
-
-        self.assertEqual('fake_id', service_id)
-
-    def test_get_service_id_default(self):
-        self.mock_client().services.list.return_value = []
-
-        service_id = self.keystone_client.get_service_id('fake_name')
-
-        self.assertIsNone(service_id)
-
-    def test_get_endpoint_by_service_name(self):
-        fake_services_list = [self.fake_service_0, self.fake_service_1]
-        self.mock_client().services.list.return_value = fake_services_list
-
-        fake_endpoints_list = [self.fake_endpoint_0, self.fake_endpoint_1]
-        self.mock_client().endpoints.list.return_value = fake_endpoints_list
-
-        endpoint = self.keystone_client.get_endpoint_by_service_name(
-            'fake_name')
-
-        self.assertEqual('example.com', endpoint)
 
     def test_get_tenant_by_name(self):
         fake_tenants_list = [self.fake_tenant_0, self.fake_tenant_1]

--- a/tests/cloudferrylib/os/image/test_glance_image.py
+++ b/tests/cloudferrylib/os/image/test_glance_image.py
@@ -48,7 +48,7 @@ class GlanceImageTestCase(test.TestCase):
             new=self.glance_mock_client)
         self.useFixture(self.glance_client_patch)
         self.identity_mock = mock.Mock()
-        self.identity_mock.get_endpoint_by_service_name = mock.Mock(
+        self.identity_mock.get_endpoint_by_service_type = mock.Mock(
             return_value="http://192.168.1.2:9696/v2")
         self.identity_mock.get_tenant_by_id = mock.Mock(
             return_value=utils.ext_dict(name="fake_tenant_name"))
@@ -110,7 +110,7 @@ class GlanceImageTestCase(test.TestCase):
     def test_get_glance_client(self):
         fake_endpoint = 'fake_endpoint'
         fake_auth_token = 'fake_auth_token'
-        self.identity_mock.get_endpoint_by_service_name.return_value = (
+        self.identity_mock.get_endpoint_by_service_type.return_value = (
             fake_endpoint)
         self.identity_mock.get_auth_token_from_user.return_value = (
             fake_auth_token)


### PR DESCRIPTION
In some configurations there are no availability to retrieve OpenStack
services list via Keystone. But Glance authentication was completely
dependent on the services manipulations via Keystone API. That's why we
need to change the way of the Glance authentication. From now it gets
public endpoint URL directly using service type (image).

Also, 'get_endpoint_by_service_type' method was added to Keystone
resource.