### PR TITLE
SAIC-214 Ignore hosts in down state

### DIFF
--- a/cfglib.py
+++ b/cfglib.py
@@ -117,7 +117,11 @@ migrate_opts = [
                      "the 'dst' section of config also should have admin role "
                      "in all tenants."),
     cfg.BoolOpt('all_images', default=False,
-                help='Migrate images of all tenants')
+                help='Migrate images of all tenants'),
+    cfg.BoolOpt('skip_down_hosts', default=True,
+                help="If set to True, removes unreachable compute hosts from "
+                     "nova hypervisor list. Otherwise migration process fails "
+                     "with unrecoverable error if host is down.")
 ]
 
 mail = cfg.OptGroup(name='mail',

--- a/cloudferrylib/os/compute/nova_compute.py
+++ b/cloudferrylib/os/compute/nova_compute.py
@@ -14,12 +14,14 @@
 
 
 import copy
+from operator import attrgetter
 import time
 from sqlalchemy import exc
 
 from novaclient.v1_1 import client as nova_client
 from novaclient import exceptions as nova_exc
 
+import cfglib
 from cloudferrylib.base import compute
 from cloudferrylib.utils import mysql_connector
 from cloudferrylib.utils import timeout_exception
@@ -33,6 +35,8 @@ DISK = "disk"
 LOCAL = ".local"
 LEN_UUID_INSTANCE = 36
 INTERFACES = "interfaces"
+
+INSTANCE_HOST_ATTRIBUTE = 'OS-EXT-SRV-ATTR:host'
 
 
 class NovaCompute(compute.Compute):
@@ -135,7 +139,7 @@ class NovaCompute(compute.Compute):
         compute_res = cloud.resources[utl.COMPUTE_RESOURCE]
 
         instance_name = getattr(instance, "OS-EXT-SRV-ATTR:instance_name")
-        instance_host = getattr(instance, 'OS-EXT-SRV-ATTR:host')
+        instance_host = getattr(instance, INSTANCE_HOST_ATTRIBUTE)
 
         get_tenant_name = identity_res.get_tenants_func()
 
@@ -458,14 +462,20 @@ class NovaCompute(compute.Compute):
         """
         ids = search_opts.get('id', None) if search_opts else None
         if not ids:
-            return self.nova_client.servers.list(detailed=detailed,
-                                                 search_opts=search_opts,
-                                                 marker=marker, limit=limit)
+            instances = self.nova_client.servers.list(
+                detailed=detailed, search_opts=search_opts, marker=marker,
+                limit=limit)
         else:
             if type(ids) is list:
-                return [self.nova_client.servers.get(i) for i in ids]
+                instances = [self.nova_client.servers.get(i) for i in ids]
             else:
-                return [self.nova_client.servers.get(ids)]
+                instances = [self.nova_client.servers.get(ids)]
+
+        instances = filter_down_hosts(
+            down_hosts(self.get_client()), instances,
+            hostname_attribute=INSTANCE_HOST_ATTRIBUTE)
+
+        return instances
 
     def is_nova_instance(self, object_id):
         """
@@ -635,8 +645,9 @@ class NovaCompute(compute.Compute):
         return self.nova_client.hypervisors.statistics()
 
     def get_hypervisors(self):
-        return [hypervisor.hypervisor_hostname for hypervisor in
-                self.nova_client.hypervisors.list()]
+        hypervisors = [hypervisor.hypervisor_hostname for hypervisor in
+                       self.nova_client.hypervisors.list()]
+        return filter_down_hosts(down_hosts(self.get_client()), hypervisors)
 
     def get_free_vcpus(self):
         hypervisor_statistics = self.get_hypervisor_statistics()
@@ -658,3 +669,19 @@ class NovaCompute(compute.Compute):
 
     def delete_vm_by_id(self, vm_id):
         self.nova_client.servers.delete(vm_id)
+
+
+def down_hosts(novaclient):
+    services = novaclient.services.list()
+    return set(map(attrgetter('host'),
+                   filter(lambda h: h.state != 'up', services)))
+
+
+def filter_down_hosts(hosts_down, elements, hostname_attribute=''):
+    """Removes elements which run on hosts in down state according to nova
+    service-list"""
+    if cfglib.CONF.migrate.skip_down_hosts:
+        elements = filter(
+            lambda e: getattr(e, hostname_attribute, e) not in hosts_down,
+            elements)
+    return elements

--- a/cloudferrylib/os/network/nova_network.py
+++ b/cloudferrylib/os/network/nova_network.py
@@ -20,6 +20,7 @@ from fabric.api import settings
 from novaclient.v1_1 import client as nova_client
 
 from cloudferrylib.base import network
+from cloudferrylib.os.compute import nova_compute
 from cloudferrylib.utils.utils import forward_agent
 
 
@@ -77,7 +78,7 @@ class NovaNetwork(network.Network):
         return lambda x: next(list_mac)
 
     def get_mac_addresses(self, instance):
-        compute_node = getattr(instance, 'OS-EXT-SRV-ATTR:host')
+        compute_node = getattr(instance, nova_compute.INSTANCE_HOST_ATTRIBUTE)
         libvirt_name = getattr(instance, 'OS-EXT-SRV-ATTR:instance_name')
 
         with settings(host_string=self.config['host']):

--- a/condensation/scripts/nova_collector.py
+++ b/condensation/scripts/nova_collector.py
@@ -14,6 +14,7 @@
 
 from novaclient import client
 import json
+from cloudferrylib.os.compute import nova_compute
 
 
 username = ""
@@ -27,7 +28,7 @@ flavors = cli.flavors.list()
 result = {"vms": {i.id:
                   {"id": i.id,
                    "flavor": i.flavor.get("id"),
-                   "host": getattr(i, 'OS-EXT-SRV-ATTR:host')
+                   "host": getattr(i, nova_compute.INSTANCE_HOST_ATTRIBUTE)
                    } for i in servers
                   },
           "flavors": {i.id:

--- a/configs/config.ini
+++ b/configs/config.ini
@@ -24,6 +24,10 @@ all_networks = False
 cinder_migration_strategy = cloudferrylib.os.storage.cinder_storage.CinderStorage
 all_images = True
 
+# If set to True removes unreachable compute hosts from `nova hypervisor-list`.
+# Set to False only if you're 100% sure there are no hosts down in the cloud.
+skip_down_hosts = True
+
 [mail]
 server = <server_name:port_number>
 username = <username>


### PR DESCRIPTION
All instances and hypervisors assumed hosts are always
accessible which resulted in SSH connection issues in case
node hosting VM is actually down or not accessible. This patch
fixes this by introducing new checks to verify the node is not
down.