### PR TITLE
SAIC-171 Make migration scenario configurable

### DIFF
--- a/cfglib.py
+++ b/cfglib.py
@@ -121,7 +121,14 @@ migrate_opts = [
     cfg.BoolOpt('skip_down_hosts', default=True,
                 help="If set to True, removes unreachable compute hosts from "
                      "nova hypervisor list. Otherwise migration process fails "
-                     "with unrecoverable error if host is down.")
+                     "with unrecoverable error if host is down."),
+    cfg.StrOpt('scenario', default='scenario/migrate.yaml',
+               help='Path to a scenario file, which holds the whole migration '
+                    'procedure. Must be YAML format'),
+    cfg.StrOpt('tasks_mapping', default='scenario/tasks.yaml',
+               help='Path to a file which holds CloudFerry python code tasks '
+                    'mapped to migration scenario items. Items defined in '
+                    'this file must be used in the migration scenario.')
 ]
 
 mail = cfg.OptGroup(name='mail',

--- a/cloudferrylib/scheduler/scenario.py
+++ b/cloudferrylib/scheduler/scenario.py
@@ -26,7 +26,7 @@ from cloudferrylib.base.action import action
 
 
 class Scenario(object):
-    def __init__(self, path_tasks='scenario/tasks.yaml', path_scenario='scenario/migrate.yaml'):
+    def __init__(self, path_tasks, path_scenario):
         self.path_tasks = path_tasks
         self.path_scenario = path_scenario
 

--- a/configs/config.ini
+++ b/configs/config.ini
@@ -1,4 +1,11 @@
 [migrate]
+
+# Path to scenario file to be used for migration. 'scenario/migrate.yaml' by default
+scenario = scenario/migrate.yaml
+
+# Path to tasks mapping file. 'scenario/tasks.yaml' by default
+tasks_mapping = scenario/tasks.yaml
+
 keep_user_passwords = False
 ssh_transfer_port = 9990-9999
 key_filename = <path to ssh private key>

--- a/devlab/config.ini
+++ b/devlab/config.ini
@@ -1,5 +1,7 @@
 # Modify this file with you environment parameters.
 
+scenario_file = devlab/tests/migrate.yaml
+tasks_file = scenario/tasks.yaml
 public_key_path = .ssh/id_rsa.pub
 # This is relative to user's $HOME, will be replaced with ${HOME}/${cloudferry_path}
 cloudferry_path = Documents
@@ -18,7 +20,7 @@ src_tenant = admin
 src_temp = /root/temp
 
 src_mysql_user = root
-src_mysql_password = secret 
+src_mysql_password = secret
 
 src_rabbit_password = guest
 
@@ -32,8 +34,8 @@ dst_password = admin
 dst_tenant = admin
 dst_temp = /root/merge
 
-dst_mysql_user = root 
-dst_mysql_password = secret 
+dst_mysql_user = root
+dst_mysql_password = secret
 
 dst_rabbit_password = guest
 

--- a/devlab/config.template
+++ b/devlab/config.template
@@ -1,6 +1,9 @@
 # Do not modify. This is template file. To change parameters please use 'config.ini'.
 
 [migrate]
+scenario = <scenario_file>
+tasks_mapping = <tasks_file>
+
 keep_user_passwords = False
 ssh_transfer_port = 9990-9999
 key_filename = <migrate_key_filename>

--- a/devlab/provision/cloudferry.sh
+++ b/devlab/provision/cloudferry.sh
@@ -57,17 +57,7 @@ else
     echo "CloudFerry venv is already present, skipping"
 fi
 
-echo "Preparing configuration for CloudFerry"
-cp devlab/config.template configuration.ini
-
-while read key value
-do
-    value=($value)
-    value=${value[1]}
-    if [[ -n $value ]]; then
-      sed -i "s|<${key}>|${value}|g" configuration.ini
-    fi
-done < devlab/config.ini
+source generate_config.sh
 
 popd
 

--- a/devlab/provision/generate_config.sh
+++ b/devlab/provision/generate_config.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+cloudferry_dir=$(cd "$( dirname "${BASH_SOURCE[0]}" )/../.." && pwd)
+result_config=${cloudferry_dir}/configuration.ini
+
+echo "Preparing configuration for CloudFerry"
+cp ${cloudferry_dir}/devlab/config.template ${result_config}
+
+while read key value
+do
+    value=($value)
+    value=${value[1]}
+    if [[ -n ${value} ]]; then
+      sed -i "s|<${key}>|${value}|g" ${result_config}
+    fi
+done < ${cloudferry_dir}/devlab/config.ini
+
+echo "CloudFerry config is saved in ${result_config}"

--- a/devlab/tests/migrate.yaml
+++ b/devlab/tests/migrate.yaml
@@ -1,0 +1,92 @@
+namespace:
+  info_result:
+      instances: {}
+
+preparation:
+  - create_snapshot: True
+  - create_vm_snapshot_src: True
+  - create_vm_snapshot_dst: True
+
+rollback:
+  - restore_from_vm_snapshot_dst: True
+  - restore_from_vm_snapshot_src: True
+  - restore_from_snapshot: True
+
+process:
+  - pre_migration_test:
+      - src_test:
+          - act_get_info_images_src: True
+          - act_get_info_inst_src: True
+          - act_get_info_volumes_src: True
+          - act_get_info_objects_src: False
+          - act_check_bandwidth_src: True
+          - check_src_ssh_access: True
+          - check_src_sql: True
+          - check_src_rabbit: True
+      - dst_test:
+          - act_get_info_images_dst: True
+          - act_get_info_inst_dst: True
+          - act_get_info_volumes_dst: True
+          - act_get_info_objects_dst: False
+          - act_check_bandwidth_dst: True
+          - check_dst_ssh_access: True
+          - check_dst_sql: True
+          - check_dst_rabbit: True
+  - task_resources_transporting:
+      - act_identity_trans: True
+      - task_images_trans:
+          - act_get_info_images: True
+          - act_deploy_images: True
+      - act_comp_res_trans: True
+      - act_network_trans: True
+      - get_volumes_db_data: True
+      - write_volumes_db_data: True
+      - transport_key_pairs: True
+  - transport_instances_and_dependency_resources:
+      - act_get_filter: True
+      - act_get_info_inst: True
+      - init_iteration_instance:
+          - init_iteration_instance_copy_var: True
+          - init_iteration_instance_ref: True
+      - check_needed_compute_resources: True
+      - check_instances: ['rename_info_iter']
+      - get_next_instance: True
+      - trans_one_inst:
+          - act_stop_vms: True
+          - transport_resource_inst:
+              - transport_images:
+                  - act_conv_comp_img: True
+                  - act_copy_inst_images: True
+                  - act_conv_image_comp: True
+              - task_transport_volumes:
+                  - act_convert_c_to_v: True
+                  - act_convert_v_to_i: True
+                  - act_copy_g2g_vols: True
+                  - act_convert_i_to_v: True
+                  - act_convert_v_to_c: True
+          - transport_inst:
+              - act_net_prep: True
+              - act_map_com_info: True
+              - act_is_not_trans_image: ['act_is_not_merge_diff']
+              - process_transport_image:
+                  - act_transfer_file: True
+                  - act_f_to_i_after_transfer: True
+              - act_is_not_merge_diff: ['act_deploy_instances']
+              - process_merge_diff_and_base:
+                  - act_i_to_f: True
+                  - trans_file_to_file: True
+                  - act_merge: True
+                  - act_convert_image: True
+                  - act_f_to_i: True
+              - act_deploy_instances: True
+              - add_key_pairs_to_instances: True
+              - act_is_not_copy_diff_file: ['act_transport_ephemeral']
+              - act_trans_diff_file: True
+              - act_transport_ephemeral: True
+          - act_attaching: True
+          - act_dissociate_floatingip: True
+          - act_start_vms: True
+      - save_result_migrate_instances: True
+      - is_instances: ['get_next_instance']
+      - rename_info_iter: True
+      - act_cleanup_images: True

--- a/fabfile.py
+++ b/fabfile.py
@@ -40,7 +40,8 @@ def migrate(name_config=None, name_instance=None, debug=False):
     utils.init_singletones(cfglib.CONF)
     env.key_filename = cfglib.CONF.migrate.key_filename
     cloud = cloud_ferry.CloudFerry(cfglib.CONF)
-    cloud.migrate(Scenario())
+    cloud.migrate(Scenario(path_scenario=cfglib.CONF.migrate.scenario,
+                           path_tasks=cfglib.CONF.migrate.tasks_mapping))
 
 
 @task


### PR DESCRIPTION
Config options added:
 - `migrate.scenario`: allows specifying migration scenario path
 - `migrate.tasks_mapping`: allows specifying tasks mapping, which is
   then used in migration scenario file

Also updated devlab environment to support custom migration scenario.