### PR TITLE
SAIC-228: Fix `get_image_info` for non-existing tenants

### DIFF
--- a/cloudferrylib/os/image/glance_image.py
+++ b/cloudferrylib/os/image/glance_image.py
@@ -146,11 +146,13 @@ class GlanceImage(image.Image):
             ) if k in CREATE_PARAMS}
         # we need to pass resource to destination to copy image
         gl_image.update({'resource': resource})
+
         # at this point we write name of owner of this tenant
         # to map it to different tenant id on destination
         gl_image.update(
-            {'owner_name': keystone.get_tenant_by_id(
-                glance_image.owner).name})
+            {'owner_name': keystone.try_get_tenant_name_by_id(
+                glance_image.owner, default=cloud.cloud_config.cloud.tenant)})
+
         if resource.is_snapshot(glance_image):
             # for snapshots we need to write snapshot username to namespace
             # to map it later to new user id

--- a/tests/cloudferrylib/os/image/test_glance_image.py
+++ b/tests/cloudferrylib/os/image/test_glance_image.py
@@ -50,8 +50,8 @@ class GlanceImageTestCase(test.TestCase):
         self.identity_mock = mock.Mock()
         self.identity_mock.get_endpoint_by_service_type = mock.Mock(
             return_value="http://192.168.1.2:9696/v2")
-        self.identity_mock.get_tenant_by_id = mock.Mock(
-            return_value=utils.ext_dict(name="fake_tenant_name"))
+        self.identity_mock.try_get_tenant_name_by_id = mock.Mock(
+            return_value="fake_tenant_name")
         self.identity_mock.keystone_client.users.list = mock.Mock(
             return_value=[])
         self.image_mock = mock.Mock()


### PR DESCRIPTION
From now, all images created in the tenant, that currently does not
exist (f.e. has been deleted), will be bound to tenant, specified in
the src/dst section of config.