### PR TITLE
Check scenario before run migration

### DIFF
--- a/cloudferrylib/scheduler/scenario.py
+++ b/cloudferrylib/scheduler/scenario.py
@@ -23,6 +23,9 @@ import addons
 import cloudferrylib
 
 from cloudferrylib.base.action import action
+from cloudferrylib.utils import utils
+
+LOG = utils.get_log(__name__)
 
 
 class Scenario(object):
@@ -65,7 +68,10 @@ class Scenario(object):
         result = {}
         for key in ['migration', 'preparation', 'rollback']:
             if hasattr(self, key) and getattr(self, key):
-                result.update({key: self.construct_net(getattr(self, key), self.tasks)})
+                scenario = getattr(self, key)
+                checker = ScenarioChecker(self.tasks.keys(), key, scenario)
+                checker.check()
+                result.update({key: self.construct_net(scenario, self.tasks)})
         return result
 
     def construct_net(self, process, tasks):
@@ -73,8 +79,8 @@ class Scenario(object):
         for item in process:
             name, value = item.items()[0]
             elem = tasks[name] if name in tasks else None
-            if type(value) is type(list()):
-                if type(value[0]) is type(dict()):
+            if isinstance(value, list):
+                if isinstance(value[0], dict):
                     elem = self.construct_net(value, tasks)
                 else:
                     for task in value:
@@ -117,3 +123,84 @@ class Scenario(object):
         process = migrate['process']
         namespace = migrate['namespace']
         return process, namespace
+
+
+class ScenarioChecker():
+    def __init__(self, tasks, key, scenario):
+        self.tasks = tasks
+        self.key = key
+        self.scenario = scenario
+        self.missed_tasks = set()
+        self.duplicated_tasks = set()
+        self.missed_links = set()
+        self.links = set()
+        self.active_tasks = set()
+
+    def check(self):
+        self.check_dict_list(self.scenario)
+
+        # check missed links
+        for link in self.links:
+            if link not in self.active_tasks:
+                self.missed_links.add(link)
+
+        throw_exception = False
+        # log all errors if needed
+        if self.missed_links:
+            LOG.error("Scenario has missed links: %s",
+                      ", ".join(self.missed_links))
+            throw_exception = True
+
+        if self.duplicated_tasks:
+            LOG.error("Scenario has duplicated tasks: %s",
+                      ", ".join(self.duplicated_tasks))
+            throw_exception = True
+
+        if self.missed_tasks:
+            LOG.error("Following tasks not described in tasks.yaml: %s",
+                      ", ".join(self.missed_tasks))
+            throw_exception = True
+
+        if throw_exception:
+            raise ScenarioError(self)
+
+    def check_string_list(self, node_list):
+        for node in node_list:
+            self.links.add(node)
+
+    def check_node(self, node):
+        key, value = node
+        if isinstance(value, list):
+            list_value = value[0]
+            if isinstance(list_value, str):
+                self.check_task(key)
+                self.check_string_list(value)
+                return
+            if isinstance(list_value, dict):
+                self.check_dict_list(value)
+                return
+            return
+        if isinstance(value, bool):
+            if value:
+                self.check_task(key)
+            return
+
+    def check_dict_list(self, node):
+        for item in node:
+            dict_items = item.items()
+            self.check_node(dict_items[0])
+
+    def check_task(self, task_name):
+        if task_name in self.active_tasks:
+            self.duplicated_tasks.add(task_name)
+        if task_name not in self.tasks:
+            self.missed_tasks.add(task_name)
+        self.active_tasks.add(task_name)
+
+
+class ScenarioError(RuntimeError):
+    def __init__(self, scenario_checker):
+        self.missed_tasks = scenario_checker.missed_tasks
+        self.duplicated_tasks = scenario_checker.duplicated_tasks
+        self.missed_links = scenario_checker.missed_links
+        super(ScenarioError, self).__init__("Not valid scenario")


### PR DESCRIPTION
Check if scenario is correct. Can catch following errors:
* duplicating active tasks
* links on inactive tasks or on not presented tasks
* using tasks which not described in tasks.yaml