### PR TITLE
[SAIC-192] VM migration should transfer VM state

### DIFF
--- a/cloudferrylib/os/actions/start_vm_if_needed.py
+++ b/cloudferrylib/os/actions/start_vm_if_needed.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2014 Mirantis Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the License);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an AS IS BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and#
+# limitations under the License.
+
+from cloudferrylib.base.action import action
+
+
+class StartVmsIfNeeded(action.Action):
+
+    def run(self, info, **kwargs):
+        compute_resource = self.cloud.resources['compute']
+        for (instance_id, instance) in info['instances'].items():
+            compute_resource.change_status_if_needed(instance)

--- a/cloudferrylib/os/actions/transport_instance.py
+++ b/cloudferrylib/os/actions/transport_instance.py
@@ -101,6 +101,8 @@ class TransportInstance(action.Action):
 
             new_instance['old_id'] = old_id
             new_instance['meta'] = old_instance['meta']
+            new_instance['meta']['source_status'] = \
+                old_instance['instance']['status']
             new_instance[utl.INSTANCE_BODY]['key_name'] = \
                 old_instance[utl.INSTANCE_BODY]['key_name']
         info = self.prepare_ephemeral_drv(info, new_info, new_ids)

--- a/devlab/tests/migrate.yaml
+++ b/devlab/tests/migrate.yaml
@@ -83,7 +83,7 @@ process:
               - act_transport_ephemeral: True
           - act_attaching: True
           - act_dissociate_floatingip: True
-          - act_start_vms: True
+          - act_start_vms_if_needed: True
       - save_result_migrate_instances: True
       - is_instances: ['get_next_instance']
       - rename_info_iter: True

--- a/scenario/migrate.yaml
+++ b/scenario/migrate.yaml
@@ -86,7 +86,7 @@ process:
               - act_transport_ephemeral: True
           - act_attaching: True
           - act_dissociate_floatingip: True
-          - act_start_vms: True
+          - act_start_vms_if_needed: True
       - save_result_migrate_instances: True
       - is_instances: ['get_next_instance']
       - rename_info_iter: True

--- a/scenario/tasks.yaml
+++ b/scenario/tasks.yaml
@@ -9,6 +9,7 @@ tasks:
    detach_volumes_on_source: ['DetachVolumesCompute', 'src_cloud']
    act_stop_vms: ['StopVms', 'src_cloud']
    act_start_vms: ['StartVms', 'dst_cloud']
+   act_start_vms_if_needed: ['StartVmsIfNeeded', 'dst_cloud']
    act_dissociate_floatingip: ['DissociateFloatingip', 'src_cloud']
    act_map_com_info: ['MapComputeInfo']
    act_net_prep: ['PrepareNetworks', 'dst_cloud']


### PR DESCRIPTION
 Overview
-------------------
Currently cloudferry sets VM state to ACTIVE regardless of original VM state. This should be modified to keep original state on DST.

See http://docs.openstack.org/developer/nova/devref/vmstates.html for VM states reference.

States to support (DST must have VMs in the same state as on SRC):
-------------------
 - Active
 - Shutoff/Stopped
 - Stopped
 - Resized (?)

Special case:
-------------------
 - Suspended
 - Paused

For these states:
 # Move VM to SHUTOFF state;
 # Do cold migration
 # On the destination these VMs should be in SHUTOFF state

States which are *not* migrated (VMs are simply skipped):
-------------------
 - Error
 - Build
 - Deleting
 - Soft deleted
 - Rescued

Instances which are not migrated must be noted in the logs

States transfer map
-------------------
Source VM state|Dest VM state
------------ | -------------
Active|Active
Shutoff/Stopped|Shutoff/Stopped
Resized|Active
Suspended|Shutoff/Stopped
Paused|Shutoff/Stopped
Shelved|Shutoff/Stopped
Shelved Offloaded|Shutoff/Stopped
Soft deleted|-
Error|-
Build|-
Deleting|-
Rescued|-