### PR TITLE
Fix bug with temporary directories path

### DIFF
--- a/cloudferrylib/os/actions/check_bandwidth.py
+++ b/cloudferrylib/os/actions/check_bandwidth.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 
+import os
 import subprocess
 import uuid
 
@@ -36,9 +37,10 @@ class CheckBandwidth(action.Action):
         factor = self.cloud.cloud_config.initial_check.factor
         req_bandwidth = claimed_bandw * factor
         temp_file_name = str(uuid.uuid4())
-        local_file_path = '/tmp/' + temp_file_name
-        remote_file_path = '%s/%s' % (self.cloud.cloud_config.cloud.temp,
-                                      temp_file_name)
+
+        local_file_path = os.path.join('/tmp', temp_file_name)
+        remote_file_path = os.path.join(self.cloud.cloud_config.cloud.temp,
+                                        temp_file_name)
 
         scp_upload = cmd_cfg.scp_cmd('',
                                      ssh_user,

--- a/cloudferrylib/utils/drivers/ssh_chunks.py
+++ b/cloudferrylib/utils/drivers/ssh_chunks.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 
+import os
+
 from fabric.api import env
 from fabric.api import hide
 from fabric.api import run
@@ -49,8 +51,8 @@ class SSHChunksTransfer(driver_transporter.DriverTransporter):
         ssh_user_dst = self.cfg.dst.ssh_user
         ssh_sudo_pass_dst = self.cfg.dst.ssh_sudo_password
 
-        src_temp_dir = self.cfg.src.temp
-        dst_temp_dir = self.cfg.dst.temp
+        src_temp_dir = os.path.join(self.cfg.src.temp, '')
+        dst_temp_dir = os.path.join(self.cfg.dst.temp, '')
 
         attempts_count = self.cfg.migrate.retry
         part_size = self.cfg.migrate.ssh_chunk_size


### PR DESCRIPTION
Fix binding to slash ('/') in the path of temporary directories, defined
by user in the config. So, from now there is a possibility to specify
there path either with the slash in the end of temp dir path
(f.e. '/tmp/') and without it (f.e. '/tmp').