### PR TITLE
SAIC-260 Fabric dependency resolution with pip>=7.0.0 fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,9 @@ git clone https://github.com/MirantisWorkloadMobility/CloudFerry.git
 cd CloudFerry
 virtualenv .venv
 source .venv/bin/activate
-pip --upgrade pip
+
+# for some reason fabric has dependency resolution problems with pip>=7.0.0
+pip install pip==6.1.1
 pip install --allow-all-external -r requirements.txt
 pip install -r test-requirements.txt
 ```

--- a/devlab/provision/cloudferry.sh
+++ b/devlab/provision/cloudferry.sh
@@ -48,7 +48,8 @@ if [[ ! -d .ubuntu-venv ]]; then
 
     apt-get install python-dev libffi-dev -y
     run virtualenv .ubuntu-venv
-    run PATH=$(pwd)/.ubuntu-venv/bin:$PATH env pip install --upgrade pip
+    # pip>=7.0.0 causes fabric to fail dependency resolution (paramiko)
+    run PATH=$(pwd)/.ubuntu-venv/bin:$PATH env pip install pip==6.1.1
     run PATH=$(pwd)/.ubuntu-venv/bin:$PATH env pip install --allow-all-external -r requirements.txt
     run PATH=$(pwd)/.ubuntu-venv/bin:$PATH env pip install -r test-requirements.txt
     run PATH=$(pwd)/.ubuntu-venv/bin:$PATH env pip install pylint pep8 flake8


### PR DESCRIPTION
pip>=7.0.0 causes fabric to miss dependencies (paramiko). This patch
fixes pip version used throughout the code.