### PR TITLE
SAIC-278: Fix issue with unreachable images data

### DIFF
--- a/cloudferrylib/base/exception.py
+++ b/cloudferrylib/base/exception.py
@@ -15,3 +15,7 @@
 
 class OutOfResources(Exception):
     pass
+
+
+class ImageDownloadError(Exception):
+    pass


### PR DESCRIPTION
Image can be deleted directly from the backend and there is a situation
can occur, when Glance doesn't know about it and continues to consider
that everything is fine. So, from now we will skip such images and will
not migrate them.