### PR TITLE
SAIC-270: Implement custom DB settings for compute

### DIFF
--- a/cfglib.py
+++ b/cfglib.py
@@ -211,7 +211,17 @@ src_compute_opts = [
     cfg.BoolOpt('block_migration', default=False,
                 help='live-migration without shared_storage'),
     cfg.StrOpt('host_eph_drv', default='-',
-               help='host ephemeral drive')
+               help='host ephemeral drive'),
+    cfg.StrOpt('connection', default='mysql+mysqlconnector',
+               help='driver for db connection'),
+    cfg.StrOpt('host', default='',
+               help='compute mysql node ip address'),
+    cfg.StrOpt('database_name', default='',
+               help='compute database name'),
+    cfg.StrOpt('user', default='',
+               help='user for db access'),
+    cfg.StrOpt('password', default='',
+               help='password for db access'),
 ]
 
 
@@ -341,7 +351,17 @@ dst_compute_opts = [
     cfg.FloatOpt('ram_allocation_ratio', default='1',
                  help='ram allocation ratio'),
     cfg.FloatOpt('disk_allocation_ratio', default='0.9',
-                 help='disk allocation ratio')
+                 help='disk allocation ratio'),
+    cfg.StrOpt('connection', default='mysql+mysqlconnector',
+               help='driver for db connection'),
+    cfg.StrOpt('host', default='',
+               help='compute mysql node ip address'),
+    cfg.StrOpt('database_name', default='',
+               help='compute database name'),
+    cfg.StrOpt('user', default='',
+               help='user for db access'),
+    cfg.StrOpt('password', default='',
+               help='password for db access'),
 ]
 
 

--- a/cloudferrylib/os/compute/nova_compute.py
+++ b/cloudferrylib/os/compute/nova_compute.py
@@ -75,8 +75,7 @@ class NovaCompute(compute.Compute):
         self.config = config
         self.cloud = cloud
         self.identity = cloud.resources['identity']
-        self.mysql_connector = mysql_connector.MysqlConnector(config.mysql,
-                                                              'nova')
+        self.mysql_connector = self.get_db_connection()
         self.nova_client = self.proxy(self.get_client(), config)
 
     def get_client(self, params=None):
@@ -88,6 +87,17 @@ class NovaCompute(compute.Compute):
                                   params.cloud.password,
                                   params.cloud.tenant,
                                   params.cloud.auth_url)
+
+    def get_db_connection(self):
+        if not hasattr(self.cloud.config, self.cloud.position + '_compute'):
+            LOG.debug('Running on default mysql settings')
+            return mysql_connector.MysqlConnector(self.config.mysql, 'nova')
+        else:
+            LOG.debug('Running on custom mysql settings')
+            my_settings = getattr(self.cloud.config,
+                                  self.cloud.position + '_compute')
+            return mysql_connector.MysqlConnector(my_settings,
+                                                  my_settings.database_name)
 
     def _read_info_quotas(self):
         service_tenant_id = self.identity.get_tenant_id_by_name(

--- a/configs/config.ini
+++ b/configs/config.ini
@@ -82,6 +82,11 @@ convert_ephemeral_disk = qcow2
 host_eph_drv = <src_host_epehem_drv>
 block_migration = True
 disk_overcommit = False
+connection = mysql+mysqlconnector
+host = <nova_db_host>
+database_name = nova
+user = <nova_db_user>
+password = <nova_db_password>
 
 [src_storage]
 service = cinder
@@ -151,6 +156,11 @@ ram_allocation_ratio = 1
 disk_allocation_ratio = 0.9
 block_migration = True
 disk_overcommit = False
+connection = mysql+mysqlconnector
+host = <nova_db_host>
+database_name = nova
+user = <nova_db_user>
+password = <nova_db_password>
 
 [dst_storage]
 service = cinder

--- a/devlab/config.template
+++ b/devlab/config.template
@@ -60,6 +60,11 @@ backend = iscsi
 convert_diff_file = qcow2
 convert_ephemeral_disk = qcow2
 host_eph_drv = <grizzly_ip>
+connection = mysql+mysqlconnector
+host = <grizzly_ip>
+database_name = nova
+user = <src_mysql_user>
+password = <src_mysql_password>
 
 [src_storage]
 service = cinder
@@ -115,6 +120,11 @@ backend = iscsi
 convert_diff_file = qcow2
 convert_ephemeral_disk = qcow2
 host_eph_drv = <icehouse_ip>
+connection = mysql+mysqlconnector
+host = <icehouse_ip>
+database_name = nova
+user = <dst_mysql_user>
+password = <dst_mysql_password>
 
 [dst_rabbit]
 password = <dst_rabbit_password>

--- a/tests/cloudferrylib/os/compute/test_nova.py
+++ b/tests/cloudferrylib/os/compute/test_nova.py
@@ -51,6 +51,7 @@ class NovaComputeTestCase(test.TestCase):
 
         self.fake_cloud = mock.Mock()
         self.fake_cloud.resources = dict(identity=self.identity_mock)
+        self.fake_cloud.position = 'src'
 
         with mock.patch(
                 'cloudferrylib.os.compute.nova_compute.mysql_connector'):


### PR DESCRIPTION
Not always CloudFerry node has remote root access to the source and/or
destination clouds databases. And not always all OpenStack services
databases are located on the same host. This patch provides possibility
to specify custom settings (driver, host, user, password, database name)
to the Nova compute databases for both src and dst clouds.