### PR TITLE
Minor fix: Use destination user as default for keypairs

### DIFF
--- a/cloudferrylib/os/identity/keystone.py
+++ b/cloudferrylib/os/identity/keystone.py
@@ -444,9 +444,9 @@ def get_dst_user_from_src_user_id(src_keystone, dst_keystone, src_user_id,
         src_user = src_keystone.keystone_client.users.find(id=src_user_id)
         src_user_name = src_user.name
     except keystoneclient.exceptions.NotFound:
-        LOG.warning("User '%s' not found on source!", src_user_id)
+        LOG.warning("User '%s' not found on SRC!", src_user_id)
         if fallback_to_admin:
-            LOG.warning("Replacing user '%s' with admin", src_user_id)
+            LOG.warning("Replacing user '%s' with SRC admin", src_user_id)
             src_user_name = cfglib.CONF.src.user
         else:
             return
@@ -456,4 +456,8 @@ def get_dst_user_from_src_user_id(src_keystone, dst_keystone, src_user_id,
         return dst_user
     except keystoneclient.exceptions.NotFound:
         LOG.warning("User '%s' not found on DST!", src_user_name)
-        return
+        if fallback_to_admin:
+            LOG.warning("Replacing user '%s' with DST admin", src_user_name)
+            dst_user = dst_keystone.keystone_client.users.find(
+                name=cfglib.CONF.dst.user)
+            return dst_user

--- a/tests/cloudferrylib/os/identity/test_keystone.py
+++ b/tests/cloudferrylib/os/identity/test_keystone.py
@@ -16,9 +16,11 @@
 
 import mock
 
+from keystoneclient import exceptions
 from keystoneclient.v2_0 import client as keystone_client
 from oslotest import mockpatch
 
+import cfglib
 from cloudferrylib.os.identity import keystone
 from cloudferrylib.utils import utils
 from tests import test
@@ -78,6 +80,24 @@ class KeystoneIdentityTestCase(test.TestCase):
         self.fake_role_1 = mock.Mock(spec=keystone_client.roles.Role)
         self.fake_role_1.name = 'role_name_1'
         self.fake_role_1.id = 'role_id_1'
+
+        self.fake_src_keystone = mock.Mock()
+        self.fake_dst_keystone = mock.Mock()
+        self.fake_src_keystone.keystone_client.users.find.side_effect = (
+            self.mock_user_find)
+        self.fake_dst_keystone.keystone_client.users.find.side_effect = (
+            self.mock_user_find)
+
+        cfglib.init_config()
+        cfglib.CONF.src.user = 'src_admin_user'
+        cfglib.CONF.dst.user = 'dst_admin_user'
+
+        self.fake_src_admin_user = mock.Mock()
+        self.fake_dst_admin_user = mock.Mock()
+
+        self.fake_same_user = mock.Mock()
+        self.fake_same_user.id = 'fake_same_id'
+        self.fake_same_user.name = 'fake_same_name'
 
     def test_get_client(self):
         self.mock_client().auth_ref = {'token': {'id': 'fake_id'}}
@@ -288,3 +308,122 @@ class KeystoneIdentityTestCase(test.TestCase):
                           'id': role},
                  'meta': {}})
         return fake_info
+
+    def mock_user_find(self, id=None, name=None):
+        map_dict = {'user_id_0': self.fake_user_0,
+                    'user_name_1': self.fake_user_1,
+                    'fake_same_id': self.fake_same_user,
+                    'fake_same_name': self.fake_same_user,
+                    'src_admin_user_id': self.fake_src_admin_user,
+                    'dst_admin_user': self.fake_dst_admin_user}
+        key = id or name
+        try:
+            return map_dict[key]
+        except KeyError:
+            raise exceptions.NotFound
+
+    def test_get_dst_user_from_src_user_id_0(self):
+        """
+        fallback_to_admin   0
+        src_user            0
+        dst_user            0
+        """
+
+        user = keystone.get_dst_user_from_src_user_id(self.fake_src_keystone,
+                                                      self.fake_dst_keystone,
+                                                      'fake_user_id',
+                                                      fallback_to_admin=False)
+        self.assertIsNone(user)
+
+    def test_get_dst_user_from_src_user_id_1(self):
+        """
+        fallback_to_admin   0
+        src_user            0
+        dst_user            1
+        """
+
+        user = keystone.get_dst_user_from_src_user_id(self.fake_src_keystone,
+                                                      self.fake_dst_keystone,
+                                                      'user_id_1',
+                                                      fallback_to_admin=False)
+        self.assertIsNone(user)
+
+    def test_get_dst_user_from_src_user_id_2(self):
+        """
+        fallback_to_admin   0
+        src_user            1
+        dst_user            0
+        """
+
+        user = keystone.get_dst_user_from_src_user_id(self.fake_src_keystone,
+                                                      self.fake_dst_keystone,
+                                                      'user_id_0',
+                                                      fallback_to_admin=False)
+        self.assertIsNone(user)
+
+    def test_get_dst_user_from_src_user_id_3(self):
+        """
+        fallback_to_admin   0
+        src_user            1
+        dst_user            1
+        """
+
+        user = keystone.get_dst_user_from_src_user_id(self.fake_src_keystone,
+                                                      self.fake_dst_keystone,
+                                                      'fake_same_id',
+                                                      fallback_to_admin=False)
+        self.assertEquals(self.fake_same_user, user)
+
+    def test_get_dst_user_from_src_user_id_4(self):
+        """
+        fallback_to_admin   1
+        src_user            0
+        dst_user            0
+        """
+
+        user = keystone.get_dst_user_from_src_user_id(self.fake_src_keystone,
+                                                      self.fake_dst_keystone,
+                                                      'fake_user_id',
+                                                      fallback_to_admin=True)
+
+        self.assertEquals(self.fake_dst_admin_user, user)
+
+    def test_get_dst_user_from_src_user_id_5(self):
+        """
+        fallback_to_admin   1
+        src_user            0
+        dst_user            1
+        """
+
+        user = keystone.get_dst_user_from_src_user_id(self.fake_src_keystone,
+                                                      self.fake_dst_keystone,
+                                                      'user_id_1',
+                                                      fallback_to_admin=True)
+        self.assertEquals(self.fake_dst_admin_user, user)
+
+    def test_get_dst_user_from_src_user_id_6(self):
+        """
+        fallback_to_admin   1
+        src_user            1
+        dst_user            0
+        """
+
+        user = keystone.get_dst_user_from_src_user_id(self.fake_src_keystone,
+                                                      self.fake_dst_keystone,
+                                                      'user_id_0',
+                                                      fallback_to_admin=True)
+
+        self.assertEquals(self.fake_dst_admin_user, user)
+
+    def test_get_dst_user_from_src_user_id_7(self):
+        """
+        fallback_to_admin   1
+        src_user            1
+        dst_user            1
+        """
+
+        user = keystone.get_dst_user_from_src_user_id(self.fake_src_keystone,
+                                                      self.fake_dst_keystone,
+                                                      'fake_same_id',
+                                                      fallback_to_admin=True)
+        self.assertEquals(self.fake_same_user, user)


### PR DESCRIPTION
If keypair was created with user, that has been deleted, we use source
admin user (that is specified in the config) as a default for such
keypairs. But in this case we can face up with 2 situations:
 - when source and destination admin users, specified in the config, are
 not the same;
 - If there is no such admin user on the destination, as on source.

In these cases destination admin user, specified in the config, will be
set up as default for such keypairs.