### PR TITLE
Fix for [SAIC-269]: recreate removed flavor on dest

### DIFF
--- a/cloudferrylib/os/actions/check_needed_compute_resources.py
+++ b/cloudferrylib/os/actions/check_needed_compute_resources.py
@@ -29,7 +29,7 @@ class CheckNeededComputeResources(action.Action):
         cnt_map = collections.defaultdict(int)
         for instance in objs.values():
             cnt_map[instance['instance']['flavor_id']] += 1
-        self.check_in_use_flavor(objs)
+        self.check_in_use_flavor(objs, info)
         needed_cpu = 0
         needed_ram = 0
         needed_hdd = 0
@@ -55,17 +55,26 @@ class CheckNeededComputeResources(action.Action):
                                                name, have, units, needed,
                                                units))
 
-    def check_in_use_flavor(self, objs):
+    def check_in_use_flavor(self, objs, info):
         # when a flavor is updated, the flavor id will change. If an instance
         # is in this flavor, it will keep the old flavor id, can not be matched
         # to existing flavors
         src_compute = self.src_cloud.resources[utl.COMPUTE_RESOURCE]
         src_flavors = [flavor.id for flavor in src_compute.get_flavor_list()]
+        dst_compute = self.dst_cloud.resources[utl.COMPUTE_RESOURCE]
+        dst_flavors = [flavor.id for flavor in dst_compute.get_flavor_list()]
 
         for instance in objs.values():
-            if instance['instance']['flavor_id'] not in src_flavors:
-                LOG.error("The flavor ID of instance %s does not match to any"
-                          " flavor. Please resize the instance.",
-                          instance['instance']['id'])
-                raise RuntimeError("Obsolete flavor ID",
-                                   instance['instance']['flavor_id'])
+            if instance['instance']['flavor_id'] not in src_flavors \
+                    and instance['instance']['flavor_id'] not in dst_flavors:
+                _instance = instance['instance']
+                instance_id = _instance['id']
+                flav_details = \
+                    info['instances'][instance_id]['instance']['flav_details']
+                dst_compute.create_flavor(name=flav_details['name'],
+                                          flavorid=_instance['flavor_id'],
+                                          ram=flav_details['memory_mb'],
+                                          vcpus=flav_details['vcpus'],
+                                          disk=flav_details['root_gb'],
+                                          ephemeral=flav_details['ephemeral_gb'])
+                src_flavors.append(_instance['flavor_id'])

--- a/cloudferrylib/os/actions/map_compute_info.py
+++ b/cloudferrylib/os/actions/map_compute_info.py
@@ -40,9 +40,11 @@ class MapComputeInfo(action.Action):
 
         for instance_id, instance in new_compute_info[utl.INSTANCES_TYPE].iteritems():
             _instance = instance['instance']
-            flavor_name = src_flavors_dict[_instance['flavor_id']]
-            _instance['flavor_id'] = dst_flavors_dict[flavor_name]
-            path_dst = "%s/%s" % (self.dst_cloud.cloud_config.cloud.temp, "temp%s_base" % instance_id)
+            if _instance['flavor_id'] in src_flavors_dict:
+                flavor_name = src_flavors_dict[_instance['flavor_id']]
+                _instance['flavor_id'] = dst_flavors_dict[flavor_name]
+            path_dst = "%s/%s" % (self.dst_cloud.cloud_config.cloud.temp,
+                                  "temp%s_base" % instance_id)
             instance[DIFF][PATH_DST] = path_dst
             instance[DIFF][HOST_DST] = self.dst_cloud.getIpSsh()
         return {

--- a/cloudferrylib/os/compute/instances.py
+++ b/cloudferrylib/os/compute/instances.py
@@ -29,6 +29,20 @@ def update_user_ids_for_instance(db, instance_id, user_id):
     db.execute(sql)
 
 
+def get_flav_details(db, instance_id):
+    sql = ("SELECT vcpus,memory_mb,root_gb,ephemeral_gb "
+           "FROM nova.instances "
+           "WHERE nova.instances.uuid = '{instance_id}' "
+           "AND NOT nova.instances.vm_state = 'deleted';").format(
+        instance_id=instance_id)
+    res = db.execute(sql)
+    for row in res:
+        return {'vcpus': row['vcpus'],
+                'memory_mb': row['memory_mb'],
+                'root_gb': row['root_gb'],
+                'ephemeral_gb': row['ephemeral_gb']}
+
+
 def nova_live_migrate_vm(nova_client, config, vm_id, dest_host):
     LOG.info("migrating {vm} to {host} using nova live migrate".format(
         vm=vm_id,

--- a/cloudferrylib/os/compute/nova_compute.py
+++ b/cloudferrylib/os/compute/nova_compute.py
@@ -244,6 +244,10 @@ class NovaCompute(compute.Compute):
                 instance,
                 instance_block_info,
                 is_ceph_ephemeral=is_ceph)
+        flav_details = instances.get_flav_details(compute_res.mysql_connector,
+                                                  instance.id)
+        flav_name = compute_res.get_flavor_from_id(instance.flavor['id']).name
+        flav_details.update({'name': flav_name})
 
         inst = {'instance': {'name': instance.name,
                              'instance_name': instance_name,
@@ -253,6 +257,7 @@ class NovaCompute(compute.Compute):
                                  instance.tenant_id),
                              'status': instance.status,
                              'flavor_id': instance.flavor['id'],
+                             'flav_details': flav_details,
                              'image_id': instance.image[
                                  'id'] if instance.image else None,
                              'boot_mode': (utl.BOOT_FROM_IMAGE


### PR DESCRIPTION
The process of migration instances is failed
if their flavor was removed previously. The
fix is to create the same flavor on the
destination environment. Appropriate flavor
information is getting from the DB.