### PR TITLE
[SAIC-280] Grouping may produce invalid results if tenant has multiple networks with the same name

### DIFF
--- a/cloud/grouping.py
+++ b/cloud/grouping.py
@@ -90,14 +90,20 @@ class Grouping(object):
     def _group_nested_network(self, instances_list=None):
         groups = {}
 
-        network_list = self.network.get_networks_list()
         search_list = (instances_list if instances_list else
                        self.compute.get_instances_list(
                            search_opts={"all_tenants": True}))
-        for network in network_list:
-            LOG.info('Processing network %s', network['name'])
-            groups[str(network['name'])] = [vm for vm in search_list
-                                            if network['name'] in vm.networks]
+        for instance in search_list:
+            LOG.info('Processing instance %s', instance.name)
+            for (network_name, network_ips) in instance.networks.items():
+                network = self.network.get_network({'ip': network_ips[0]},
+                                                   instance.tenant_id,
+                                                   True)
+                network_id = network['id']
+                if network_id in groups:
+                    groups[network_id].append(instance)
+                else:
+                    groups[network_id] = [instance]
 
         return groups
 

--- a/cloudferrylib/utils/utils.py
+++ b/cloudferrylib/utils/utils.py
@@ -494,7 +494,7 @@ def read_yaml_file(yaml_file_path):
 
 def write_yaml_file(file_name, content):
     with open(file_name, 'w') as yfile:
-        yaml.dump(content, yfile)
+        yaml.safe_dump(content, yfile)
 
 
 def timer(func, *args, **kwargs):

--- a/tests/cloud/test_grouping.py
+++ b/tests/cloud/test_grouping.py
@@ -55,21 +55,24 @@ class GroupingTestCase(test.TestCase):
         self.fake_network_1 = {'name': 'net1'}
         self.fake_network_2 = {'name': 'net3'}
 
-        self.network.get_networks_list.return_value = [self.fake_network_1,
-                                                       self.fake_network_2]
+        network_ip_to_network = {'1.1.1.1': {'id': 'net1_id'},
+                                 '1.1.1.2': {'id': 'net1_id'},
+                                 '1.1.3.1': {'id': 'net3_id'}}
+        self.network.get_network = lambda ip, tenant_id, keep: \
+            network_ip_to_network[ip['ip']]
 
         self.fake_instance1 = mock.Mock()
         self.fake_instance1.id = 's1'
-        self.fake_instance1.networks = ['net1']
+        self.fake_instance1.networks = {'net1': ['1.1.1.1']}
         self.fake_instance1.tenant_id = 't1'
         self.fake_instance2 = mock.Mock()
         self.fake_instance2.id = 's2'
-        self.fake_instance2.networks = ['net3']
+        self.fake_instance2.networks = {'net3': ['1.1.3.1']}
         self.fake_instance2.tenant_id = 't2'
         self.fake_instance3 = mock.Mock()
         self.fake_instance3.id = 's3'
         self.fake_instance3.tenant_id = 't1'
-        self.fake_instance3.networks = ['net1']
+        self.fake_instance3.networks = {'net1': ['1.1.1.2']}
 
         self.cloud = mock.Mock()
         self.cloud().resources = {'network': self.network,
@@ -122,7 +125,7 @@ class GroupingTestCase(test.TestCase):
                                                          self.fake_instance3]
         group.group()
 
-        expected_result = {'net1': ['s1', 's3'], 'net3': ['s2']}
+        expected_result = {'net1_id': ['s1', 's3'], 'net3_id': ['s2']}
 
         result = utils.read_yaml_file(RESULT_FILE)
         self.assertEquals(expected_result, result)


### PR DESCRIPTION
Now grouping based on network id.