### PR TITLE
Box repackage script creates public key if it doesn't exist

### DIFF
--- a/devlab/utils/repackage_box.sh
+++ b/devlab/utils/repackage_box.sh
@@ -44,6 +44,10 @@ ssh_opts='-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLeve
 insecure_pub_key=~/.vagrant.d/vagrant.pub
 insecure_private_key=~/.vagrant.d/insecure_private_key
 
+if [[ ! -f $insecure_pub_key ]]; then
+    ssh-keygen -f $insecure_private_key -y > $insecure_pub_key
+fi
+
 ssh_cmd() {
     local private_key="$1"
     local cmd="$2"


### PR DESCRIPTION
The code in box repackage script relied on having public key stored in
vagrant directory. This patch removes this dependency and generates
public key from private key in case public key does not exist.