### PR TITLE
Fix for [SAIC-276]: migration fails for neutron security group rules

### DIFF
--- a/cloudferrylib/os/network/neutron.py
+++ b/cloudferrylib/os/network/neutron.py
@@ -786,8 +786,11 @@ class NeutronNetwork(network.Network):
         for sec_gr in sec_groups:
             ex_secgr = \
                 self.get_res_by_hash(ex_secgrs, sec_gr['res_hash'])
-            exrules_hlist = \
-                [r['rule_hash'] for r in ex_secgr['security_group_rules']]
+            if ex_secgr:
+                exrules_hlist = \
+                    [r['rule_hash'] for r in ex_secgr['security_group_rules']]
+            else:
+                exrules_hlist = []
             for rule in sec_gr['security_group_rules']:
                 if rule['protocol'] \
                         and (rule['rule_hash'] not in exrules_hlist):


### PR DESCRIPTION
The issue is that the migration process is failed when there is
security group for service tenant on SRC but there is no one on
DST for service tenant. A new check provides an empty list of
rule hashes for further step and rules will be created as usual.