### PR TITLE
Minor fix: Disable 'scp' strict host key checking

### DIFF
--- a/cloudferrylib/os/actions/snapshots.py
+++ b/cloudferrylib/os/actions/snapshots.py
@@ -45,8 +45,9 @@ class MysqlDump(action.Action):
             'user_src': self.cloud.cloud_config.cloud.ssh_user,
             'key': self.cloud.config.migrate.key_filename,
             'path_dst': self.cloud.cloud_config.snapshot.snapshot_path}
-        command = ("scp -i {key} {user_src}@{host_src}:{path_src} "
-                   "{path_dst}".format(**context))
+        command = (
+            "scp -o StrictHostKeyChecking=no -i {key} "
+            "{user_src}@{host_src}:{path_src} {path_dst}".format(**context))
         LOG.info("EXECUTING {command} local".format(command=command))
         local(command)
         return {}


### PR DESCRIPTION
Fix small issue in the MysqlDump. Currently, if there is no destination
cloud's public ssh key in the '~/.ssh/known_hosts' of the CloudFerry
node, we have a prompt for the user to confirm the establishment of
connection to the cloud to perform MysqlDump action. This fix avoids
this prompt and adds cloud's public ssh key to the 'known_hosts'
automatically.