### PR TITLE
[SAIC-266] CF fails when try to filter by non-existing VM id

### DIFF
--- a/cloudferrylib/os/compute/nova_compute.py
+++ b/cloudferrylib/os/compute/nova_compute.py
@@ -504,10 +504,13 @@ class NovaCompute(compute.Compute):
                 detailed=detailed, search_opts=search_opts, marker=marker,
                 limit=limit)
         else:
-            if type(ids) is list:
-                instances = [self.nova_client.servers.get(i) for i in ids]
-            else:
-                instances = [self.nova_client.servers.get(ids)]
+            ids = ids if type(ids) is list else [ids]
+            instances = []
+            for i in ids:
+                try:
+                    instances.append(self.nova_client.servers.get(i))
+                except nova_exc.NotFound:
+                    LOG.warning("No server with ID of '%s' exists." % i)
 
         instances = filter_down_hosts(
             down_hosts(self.get_client()), instances,


### PR DESCRIPTION
When you try to run CF with non-existing VM id in filter config it will fail with:
> NotFound: Instance could not be found (HTTP 404) (Request-ID: req-5cb28e1c-8bab-40ac-ba57-29a96e475791)

This pull makes the error more useful:
>  NotFound: No server with ID of '<some id>' exists.