### PR TITLE
Fixed SAIC-322: CF failed on checkSSH step

### DIFF
--- a/cloudferrylib/os/actions/check_ssh.py
+++ b/cloudferrylib/os/actions/check_ssh.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 
-from fabric.api import run
 from fabric.api import settings
 
 from cloudferrylib.base.action import action
+from cloudferrylib.utils import remote_runner
 from cloudferrylib.utils import utils as utl
 
 
@@ -29,9 +29,9 @@ class CheckSSH(action.Action):
         return self.cloud.resources[utl.COMPUTE_RESOURCE].get_hypervisors()
 
     def check_access(self, node):
-        with settings(host_string=node,
-                      abort_on_prompts=True,
-                      user=self.cloud.cloud_config.cloud.ssh_user,
-                      password=self.cloud.cloud_config.cloud.ssh_sudo_password,
+        cfg = self.cloud.cloud_config.cloud
+        runner = remote_runner.RemoteRunner(node, cfg.ssh_user,
+                                            password=cfg.ssh_sudo_password)
+        with settings(abort_on_prompts=True,
                       gateway=self.cloud.getIpSsh()):
-            run("echo")
+            runner.run('echo')

--- a/devlab/tests/migrate.yaml
+++ b/devlab/tests/migrate.yaml
@@ -3,6 +3,25 @@ namespace:
       instances: {}
 
 preparation:
+  - pre_migration_test:
+      - src_test:
+          - check_src_ssh_access: True
+          - act_check_bandwidth_src: True
+          - check_src_sql: True
+          - check_src_rabbit: True
+          - act_get_info_images_src: True
+          - act_get_info_inst_src: True
+          - act_get_info_volumes_src: True
+          - act_get_info_objects_src: False
+      - dst_test:
+          - check_dst_ssh_access: True
+          - act_check_bandwidth_dst: True
+          - check_dst_sql: True
+          - check_dst_rabbit: True
+          - act_get_info_images_dst: True
+          - act_get_info_inst_dst: True
+          - act_get_info_volumes_dst: True
+          - act_get_info_objects_dst: False
   - create_snapshot: True
   - create_vm_snapshot_src: True
   - create_vm_snapshot_dst: True
@@ -15,25 +34,6 @@ rollback:
   - restore_from_snapshot: True
 
 process:
-  - pre_migration_test:
-      - src_test:
-          - act_get_info_images_src: True
-          - act_get_info_inst_src: True
-          - act_get_info_volumes_src: True
-          - act_get_info_objects_src: False
-          - act_check_bandwidth_src: True
-          - check_src_ssh_access: True
-          - check_src_sql: True
-          - check_src_rabbit: True
-      - dst_test:
-          - act_get_info_images_dst: True
-          - act_get_info_inst_dst: True
-          - act_get_info_volumes_dst: True
-          - act_get_info_objects_dst: False
-          - act_check_bandwidth_dst: True
-          - check_dst_ssh_access: True
-          - check_dst_sql: True
-          - check_dst_rabbit: True
   - task_resources_transporting:
       - act_identity_trans: True
       - task_images_trans:


### PR DESCRIPTION
checkSSH uses remote runner and raised exception if needed.
Changed migrate scenario: run all checks before creating snapshot.