### PR TITLE
Updated neutron.py to return subnet info of external net

### DIFF
--- a/cloudferrylib/os/network/neutron.py
+++ b/cloudferrylib/os/network/neutron.py
@@ -127,7 +127,8 @@ class NeutronNetwork(network.Network):
         if keep_ip:
             instance_addr = ipaddr.IPAddress(network_info['ip'])
             for snet in self.neutron_client.list_subnets()['subnets']:
-                if snet['tenant_id'] == tenant_id:
+                network = self.get_network({"id": snet['network_id']}, None)
+                if snet['tenant_id'] == tenant_id or network['shared']:
                     if ipaddr.IPNetwork(snet['cidr']).Contains(instance_addr):
                         return self.neutron_client.\
                             list_networks(id=snet['network_id'])['networks'][0]


### PR DESCRIPTION
Fixed neutron.py in order to return subnet info of external net
'shared_net'.