### PR TITLE
Specified oslo.config version to be instaled.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ python-swiftclient==2.3.1
 pyyaml
 redis
 sqlalchemy
+oslo.config==1.15.0


### PR DESCRIPTION
Specified oslo.config version to be instaled, because oslo.config
got updated and is breaking migration process.