### PR TITLE
[SAIC-349] Fix `skip_down_hosts` for `check_ssh`

### DIFF
--- a/cloudferrylib/os/actions/check_ssh.py
+++ b/cloudferrylib/os/actions/check_ssh.py
@@ -26,7 +26,7 @@ class CheckSSH(action.Action):
             self.check_access(node)
 
     def get_compute_nodes(self):
-        return self.cloud.resources[utl.COMPUTE_RESOURCE].get_hypervisors()
+        return self.cloud.resources[utl.COMPUTE_RESOURCE].get_compute_hosts()
 
     def check_access(self, node):
         cfg = self.cloud.cloud_config.cloud

--- a/cloudferrylib/os/compute/nova_compute.py
+++ b/cloudferrylib/os/compute/nova_compute.py
@@ -733,10 +733,10 @@ class NovaCompute(compute.Compute):
     def get_hypervisor_statistics(self):
         return self.nova_client.hypervisors.statistics()
 
-    def get_hypervisors(self):
-        hypervisors = [hypervisor.hypervisor_hostname for hypervisor in
-                       self.nova_client.hypervisors.list()]
-        return filter_down_hosts(down_hosts(self.get_client()), hypervisors)
+    def get_compute_hosts(self):
+        computes = self.nova_client.services.list(binary='nova-compute')
+        compute_hosts = map(attrgetter('host'), computes)
+        return filter_down_hosts(down_hosts(self.get_client()), compute_hosts)
 
     def get_free_vcpus(self):
         hypervisor_statistics = self.get_hypervisor_statistics()


### PR DESCRIPTION
Add new `get_compute_hosts` method to the Nova Compute resource and use
it in the `check_ssh` action. This was done because we actually need to
operate computes in this check, but not hypervisors.
Also, `get_hypervisors` method has been deleted from `nova_compute`
resource, because it is not used anywhere else in the project.