### PR TITLE
SAIC-312 Floating IP migration

### DIFF
--- a/cfglib.py
+++ b/cfglib.py
@@ -284,7 +284,19 @@ src_network = cfg.OptGroup(name='src_network',
 src_network_opts = [
     cfg.StrOpt('service', default='auto',
                help='name service for network, '
-                    'auto - detect avaiable service')
+                    'auto - detect avaiable service'),
+    cfg.StrOpt('host', default='localhost',
+               help='Neutron DB node host'),
+    cfg.IntOpt('port', default='3306',
+               help='port for mysql connection'),
+    cfg.StrOpt('password', default='',
+               help='Neutron DB password'),
+    cfg.StrOpt('database_name', default='neutron',
+               help='Neutron database name'),
+    cfg.StrOpt('connection', default='mysql+mysqlconnector',
+               help='Neutron DB connection type'),
+    cfg.StrOpt('user', default="root",
+               help="DB user for the networking backend")
 ]
 
 src_objstorage = cfg.OptGroup(name='src_objstorage',
@@ -436,7 +448,19 @@ dst_network_opts = [
                help='name service for network, '
                     'auto - detect available service'),
     cfg.ListOpt('interfaces_for_instance', default='net04',
-                help='list interfaces for connection to instance')
+                help='list interfaces for connection to instance'),
+    cfg.StrOpt('host', default='localhost',
+               help='Neutron DB node host'),
+    cfg.IntOpt('port', default='3306',
+               help='port for mysql connection'),
+    cfg.StrOpt('password', default='',
+               help='Neutron DB password'),
+    cfg.StrOpt('database_name', default='neutron',
+               help='Neutron database name'),
+    cfg.StrOpt('connection', default='mysql+mysqlconnector',
+               help='Neutron DB connection type'),
+    cfg.StrOpt('user', default="root",
+               help="DB user for the networking backend")
 ]
 
 dst_objstorage = cfg.OptGroup(name='dst_objstorage',

--- a/cloudferrylib/os/image/glance_image.py
+++ b/cloudferrylib/os/image/glance_image.py
@@ -50,8 +50,11 @@ class GlanceImage(image.Image):
         self.identity_client = cloud.resources['identity']
         # get mysql settings
         self.mysql_connector = self.get_db_connection()
-        self.glance_client = self.proxy(self.get_client(), config)
         super(GlanceImage, self).__init__(config)
+
+    @property
+    def glance_client(self):
+        return self.proxy(self.get_client(), self.config)
 
     def get_db_connection(self):
         if not hasattr(

--- a/cloudferrylib/os/network/nova_network.py
+++ b/cloudferrylib/os/network/nova_network.py
@@ -27,8 +27,11 @@ from cloudferrylib.utils.utils import forward_agent
 class NovaNetwork(network.Network):
     def __init__(self, config, cloud):
         super(NovaNetwork, self).__init__(config)
-        self.nova_client = self.proxy(self.get_client(), config)
         self.cloud = cloud
+
+    @property
+    def nova_client(self):
+        return self.proxy(self.get_client(), self.config)
 
     def get_client(self):
         return nova_client.Client(

--- a/cloudferrylib/os/storage/cinder_database.py
+++ b/cloudferrylib/os/storage/cinder_database.py
@@ -45,7 +45,6 @@ class CinderStorage(cinder_storage.CinderStorage):
         self.config = config
         self.cloud = cloud
         self.identity_client = cloud.resources['identity']
-        self.cinder_client = self.proxy(self.get_client(config), config)
         self.mysql_connector = self.get_db_connection()
 
         # FIXME This class holds logic for all these tables. These must be

--- a/cloudferrylib/os/storage/cinder_storage.py
+++ b/cloudferrylib/os/storage/cinder_storage.py
@@ -41,8 +41,11 @@ class CinderStorage(storage.Storage):
         self.cloud = cloud
         self.identity_client = cloud.resources[utl.IDENTITY_RESOURCE]
         self.mysql_connector = self.get_db_connection()
-        self.cinder_client = self.proxy(self.get_client(config), config)
         super(CinderStorage, self).__init__(config)
+
+    @property
+    def cinder_client(self):
+        return self.proxy(self.get_client(self.config), self.config)
 
     def get_client(self, params=None):
 

--- a/devlab/config.template
+++ b/devlab/config.template
@@ -94,6 +94,11 @@ service = keystone
 [src_network]
 service = auto
 interfaces_for_instance = <src_network_interfaces_for_instance>
+user = <src_mysql_user>
+password = <src_mysql_password>
+host = <grizzly_ip>
+connection = mysql+mysqlconnector
+database_name = quantum
 
 [src_objstorage]
 service =
@@ -162,6 +167,11 @@ service = keystone
 [dst_network]
 service=auto
 interfaces_for_instance = <dst_network_interfaces_for_instance>
+user = <dst_mysql_user>
+password = <dst_mysql_password>
+host = <icehouse_ip>
+connection = mysql+mysqlconnector
+database_name = neutron
 
 [import_rules]
 key = {name:dest-key-1}

--- a/tests/cloudferrylib/os/compute/test_nova.py
+++ b/tests/cloudferrylib/os/compute/test_nova.py
@@ -80,9 +80,11 @@ class NovaComputeTestCase(test.TestCase):
         self.assertEqual(self.mock_client(), client)
 
     def test_create_instance(self):
-        self.mock_client().servers.create.return_value = self.fake_instance_0
+        ncli = mock.Mock()
+        ncli.servers.create.return_value = self.fake_instance_0
 
-        instance_id = self.nova_client.create_instance(name='fake_instance',
+        instance_id = self.nova_client.create_instance(nclient=ncli,
+                                                       name='fake_instance',
                                                        image='fake_image',
                                                        flavor='fake_flavor',
                                                        user_id='some-id')

--- a/tests/cloudferrylib/os/identity/test_keystone.py
+++ b/tests/cloudferrylib/os/identity/test_keystone.py
@@ -99,18 +99,10 @@ class KeystoneIdentityTestCase(test.TestCase):
         self.fake_same_user.id = 'fake_same_id'
         self.fake_same_user.name = 'fake_same_name'
 
-    def test_get_client(self):
-        self.mock_client().auth_ref = {'token': {'id': 'fake_id'}}
-
-        client = self.keystone_client.get_client()
-
-        mock_calls = [
-            mock.call(username='fake_user', tenant_name='fake_tenant',
-                      password='fake_password',
-                      auth_url='http://1.1.1.1:35357/v2.0/'),
-            mock.call(token='fake_id', endpoint='http://1.1.1.1:35357/v2.0/')]
-        self.mock_client.assert_has_calls(mock_calls, any_order=True)
-        self.assertEqual(self.mock_client(), client)
+    def test_get_client_generates_new_token(self):
+        client1 = self.keystone_client.keystone_client
+        client2 = self.keystone_client.keystone_client
+        self.assertFalse(client1 == client2)
 
     def test_get_tenants_list(self):
         fake_tenants_list = [self.fake_tenant_0, self.fake_tenant_1]
@@ -207,7 +199,7 @@ class KeystoneIdentityTestCase(test.TestCase):
 
     def test_auth_token_from_user(self):
         fake_auth_token = 'fake_auth_token'
-        self.mock_client().auth_token_from_user = fake_auth_token
+        self.mock_client().auth_token = fake_auth_token
 
         self.assertEquals(fake_auth_token,
                           self.keystone_client.get_auth_token_from_user())


### PR DESCRIPTION
Allows floating IP migration with IP addresses reserved.

Process:
 1. Create floating IP using neutron APIs;
 2. Update neutron database using SQL with correct address.

When admin user gets added to a tenant as member, all it's current tokens get revoked. This is the primary reason for replacing all the openstack services client code to not use single token, but generate one on each operation instead.