### PR TITLE
[SAIC-349] Update python-novaclient to version 2.16.0

### DIFF
--- a/cloudferrylib/os/compute/nova_compute.py
+++ b/cloudferrylib/os/compute/nova_compute.py
@@ -676,12 +676,6 @@ class NovaCompute(compute.Compute):
             if quota_items[i] == existing_default_quotas[i]:
                 quota_items.pop(i)
 
-        # FIXME: There is no availability to provide 'fixed_ips' argument to
-        # nova_client.quota_classes.update in python-novaclient==2.15.0
-        # Fixed in 2.16.0
-        if 'fixed_ips' in quota_items:
-            quota_items.pop('fixed_ips')
-
         return self.nova_client.quota_classes.update('default', **quota_items)
 
     def get_interface_list(self, server_id):

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ python-cinderclient==1.0.9
 python-glanceclient==0.12.0
 python-keystoneclient==0.9.0
 python-neutronclient==2.3.4
-python-novaclient==2.15.0
+python-novaclient==2.16.0
 python-swiftclient==2.3.1
 pyyaml
 redis


### PR DESCRIPTION
Also, `update_default_quotas` method from `nova_compute` resource has
been fixed due to new version of Nova client.