### PR TITLE
SAIC-337 Same networks have different hashes

### DIFF
--- a/cloudferrylib/os/network/neutron.py
+++ b/cloudferrylib/os/network/neutron.py
@@ -14,6 +14,7 @@
 import pprint
 
 import ipaddr
+import netaddr
 from neutronclient.common import exceptions as neutron_exc
 from neutronclient.v2_0 import client as neutron_client
 
@@ -1178,6 +1179,9 @@ class NeutronNetwork(network.Network):
         list_info = list()
         for arg in args:
             if type(neutron_resource[arg]) is not list:
+                if arg == 'cidr':
+                    cidr = str(netaddr.IPNetwork(neutron_resource[arg]).cidr)
+                    neutron_resource[arg] = cidr
                 list_info.append(neutron_resource[arg])
             else:
                 for argitem in arg:

--- a/tests/cloudferrylib/os/network/test_neutron.py
+++ b/tests/cloudferrylib/os/network/test_neutron.py
@@ -599,3 +599,10 @@ class NeutronTestCase(test.TestCase):
         self.neutron_mock_client().add_interface_router.\
             assert_called_once_with('fake_router_id_2',
                                     {'subnet_id': 'fake_subnet_id_2'})
+
+    def test_hash_is_equal_for_nets_with_different_cidrs(self):
+        net1 = {'cidr': "192.168.1.11/22"}
+        net2 = {'cidr': "192.168.1.0/22"}
+        net1_hash = neutron.NeutronNetwork.get_resource_hash(net1, 'cidr')
+        net2_hash = neutron.NeutronNetwork.get_resource_hash(net2, 'cidr')
+        self.assertEqual(net1_hash, net2_hash)


### PR DESCRIPTION
In case network on source has incorrectly defined CIDR, migrated network
will have CIDR changed to correct, which will break the network
comparison.

Example:
 - source net CIDR: 64.143.228.11/22
 - migrated net CIDR: 64.143.228.0/22

In the given example networks are the same, yet CF incorrectly compares
equality of these networks by their string representation.

This patch fixes this behavior.