### PR TITLE
Role migration for admin user

### DIFF
--- a/cloudferrylib/os/identity/keystone.py
+++ b/cloudferrylib/os/identity/keystone.py
@@ -485,10 +485,6 @@ class KeystoneIdentity(identity.Identity):
 
         for _user in users:
             user = _user['user']
-            # FIXME should be deleted after determining how
-            # to change self role without logout
-            if user['name'] == self.keystone_client.username:
-                continue
             if user['name'] not in dst_users:
                 continue
             for _tenant in tenants:


### PR DESCRIPTION
Fixes role migration for admin user. Previously if admin was added to a
tenant as member all the auth tokens exipred and migration process
failed. This patch uses new keystone clien for each request so we don't
have that problem anymore and all roles are migrated successfully.