### PR TITLE
Revert "Default nova quotas migration fix"

### DIFF
--- a/cloudferrylib/os/compute/nova_compute.py
+++ b/cloudferrylib/os/compute/nova_compute.py
@@ -791,12 +791,8 @@ class NovaCompute(compute.Compute):
         for i in existing_default_quotas:
             if quota_items[i] == existing_default_quotas[i]:
                 quota_items.pop(i)
-        try:
-            return self.nova_client.quota_classes.update('default', **quota_items)
-        except nova_exc.BadRequest:
-            # FIXME temporary fix for default quotas migration in case those
-            # already exist on destination
-            pass
+
+        return self.nova_client.quota_classes.update('default', **quota_items)
 
     def get_interface_list(self, server_id):
         return self.nova_client.servers.interface_list(server_id)


### PR DESCRIPTION
Actual error appeard due to invalid environment set. The fix is not
applicable, and must be done by setting up environment properly.

This reverts commit 489330c446704f46304e8897bc38e598a837d031.