### PR TITLE
[SAIC-239] Fix requirements.txt for download custom paramiko

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,5 @@ pyyaml
 redis
 sqlalchemy
 oslo.config==1.15.0
+# see https://github.com/paramiko/paramiko/issues/570 and https://github.com/paramiko/paramiko/pull/571
+-e git://github.com/mirrorcoder/paramiko.git#egg=paramiko


### PR DESCRIPTION
This patch download custom paramiko from my github-repo, because native paramiko has bug(race condition)
Issue - https://github.com/paramiko/paramiko/issues/570
Pull - https://github.com/paramiko/paramiko/pull/571