### PR TITLE
SAIC-405 Fix nova flavor migration

### DIFF
--- a/cloudferrylib/os/actions/check_needed_compute_resources.py
+++ b/cloudferrylib/os/actions/check_needed_compute_resources.py
@@ -35,7 +35,8 @@ class CheckNeededComputeResources(action.Action):
         needed_hdd = 0
         src_nova = self.src_cloud.resources[utl.COMPUTE_RESOURCE]
         for flavor_id, count in cnt_map.items():
-            flavor = src_nova.get_flavor_from_id(flavor_id)
+            flavor = src_nova.get_flavor_from_id(flavor_id,
+                                                 include_deleted=True)
             needed_cpu += flavor.vcpus * count
             needed_hdd += (flavor.disk + flavor.ephemeral) * count
             if flavor.swap:  # if flavor not specified '' is here

--- a/tests/cloudferrylib/os/compute/test_nova.py
+++ b/tests/cloudferrylib/os/compute/test_nova.py
@@ -170,7 +170,7 @@ class NovaComputeTestCase(test.TestCase):
         self.assertFalse(self.fake_instance_0.stop.called)
 
     def test_get_flavor_from_id(self):
-        self.mock_client().flavors.get.return_value = self.fake_flavor_0
+        self.mock_client().flavors.find.return_value = self.fake_flavor_0
 
         flavor = self.nova_client.get_flavor_from_id('fake_flavor_id')
 


### PR DESCRIPTION
The issue was caused by invalid novaclient.flavors.get() behavior, which
returns deleted flavors if flavor ID matches. Replaced with
novaclient.flavors.find(), which raises 404 `NotFound` if flavor is
deleted.