### PR TITLE
SAIC-400 Rollback for VM in 'verify resize' state

### DIFF
--- a/cloudferrylib/os/compute/nova_compute.py
+++ b/cloudferrylib/os/compute/nova_compute.py
@@ -691,7 +691,9 @@ class NovaCompute(compute.Compute):
                 'suspended': (func_restore['start'],
                               func_restore['status']('active'),
                               func_restore['suspended'],
-                              func_restore['status']('suspended'))
+                              func_restore['status']('suspended')),
+                'verify_resize': (func_restore['start'],
+                                  func_restore['status']('active'))
             },
             'verify_resize': {
                 'shutoff': (func_restore['confirm_resize'],

--- a/tests/cloudferrylib/os/compute/test_nova.py
+++ b/tests/cloudferrylib/os/compute/test_nova.py
@@ -169,6 +169,16 @@ class NovaComputeTestCase(test.TestCase):
         self.nova_client.change_status('stop', instance=self.fake_instance_0)
         self.assertFalse(self.fake_instance_0.stop.called)
 
+    @mock.patch('cloudferrylib.os.compute.nova_compute.NovaCompute.'
+                'wait_for_status')
+    def test_shutoff_to_verify_resize_brings_instance_active(self, _):
+        self.mock_client().servers.get('fake_instance_id').status = 'shutoff'
+
+        self.nova_client.change_status('verify_resize',
+                                       instance=self.fake_instance_0)
+
+        self.assertTrue(self.fake_instance_0.start.called)
+
     def test_get_flavor_from_id(self):
         self.mock_client().flavors.find.return_value = self.fake_flavor_0
 


### PR DESCRIPTION
Fixes issue when rolling back failed migration fails itself with `KeyError`.
The issue appeared because there was no transition from 'shutdown' to
'verify_resize' state defined in code.