### PR TITLE
Fixed SAIC-165: re-create deleted image on dst

### DIFF
--- a/cloudferrylib/os/actions/convert_file_to_image.py
+++ b/cloudferrylib/os/actions/convert_file_to_image.py
@@ -1,24 +1,13 @@
 
 from cloudferrylib.base.action import action
-from fabric.api import run, settings
+from cloudferrylib.utils import utils
+from cloudferrylib.utils import remote_runner
 
 
 class ConvertFileToImage(action.Action):
 
     def run(self, file_path=None, image_format=None, image_name=None, **kwargs):
-
+        image_resource = self.cloud.resources[utils.IMAGE_RESOURCE]
         cfg = self.cloud.cloud_config.cloud
-        with settings(host_string=cfg.host):
-            out = run(("glance --os-username=%s --os-password=%s --os-tenant-name=%s " +
-                       "--os-auth-url=%s " +
-                       "image-create --name %s --disk-format=%s --container-format=bare --file %s| " +
-                       "grep id") %
-                      (cfg.user,
-                       cfg.password,
-                       cfg.tenant,
-                       cfg.auth_url,
-                       image_name,
-                       image_format,
-                       file_path))
-            image_id = out.split("|")[2].replace(' ', '')
-            return image_id
+        runner = remote_runner.RemoteRunner(cfg.host, cfg.ssh_user)
+        return image_resource.glance_img_create(runner, image_name, image_format, file_path)

--- a/cloudferrylib/os/actions/is_boot_image_deleted.py
+++ b/cloudferrylib/os/actions/is_boot_image_deleted.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2015 Mirantis Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the License);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an AS IS BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and#
+# limitations under the License.
+
+
+from cloudferrylib.base.action import action
+
+PATH_RECREATE_IMAGE = 0
+DEFAULT = 1
+
+
+class IsBootImageDeleted(action.Action):
+    def run(self, info=None, missing_images=None, **kwargs):
+        self.set_next_path(DEFAULT)
+        if missing_images is not None:
+            self.set_next_path(PATH_RECREATE_IMAGE)

--- a/cloudferrylib/os/actions/recreate_boot_image.py
+++ b/cloudferrylib/os/actions/recreate_boot_image.py
@@ -1,0 +1,110 @@
+# Copyright (c) 2015 Mirantis Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the License);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an AS IS BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and#
+# limitations under the License.
+
+from cloudferrylib.base.action import action
+from cloudferrylib.utils import files
+from cloudferrylib.utils import remote_runner
+from cloudferrylib.utils.drivers.ssh_chunks import verified_file_copy, remote_md5_sum
+from cloudferrylib.utils import utils
+import copy
+import os
+
+
+LOG = utils.get_log(__name__)
+
+
+class ReCreateBootImage(action.Action):
+
+    def __init__(self, init, cloud=None):
+        super(ReCreateBootImage, self).__init__(init, cloud)
+        self.src_user = self.cfg.src.ssh_user
+        src_password = self.cfg.src.ssh_sudo_password
+        self.src_host = self.cfg.src.ssh_host
+        self.dst_user = self.cfg.dst.ssh_user
+        dst_password = self.cfg.dst.ssh_sudo_password
+        self.dst_host = self.cfg.dst.ssh_host
+        self.src_runner = remote_runner.RemoteRunner(self.src_host,
+                                                     self.src_user,
+                                                     password=src_password,
+                                                     sudo=True)
+        self.dst_runner = remote_runner.RemoteRunner(self.dst_host,
+                                                     self.dst_user,
+                                                     password=dst_password,
+                                                     sudo=True)
+
+    def run(self, images_info=None, compute_ignored_images={}, missing_images={}, **kwargs):
+        """
+        Create boot image on destination based on root disk of instance.
+         Use diff&base images, commit all changes from diff to base,
+         copy base and add as a glance image.
+         Image ID from source is used as a name of new image because we can't get name of deleted image.
+        :param images_info: dict with all images on source
+        :param compute_ignored_images: not used, just resending to down level
+        :param missing_images: dict with images that has been removed on source
+        :param kwargs: not used
+        :return: images_info and compute_ignored_images
+        """
+        images_info = copy.deepcopy(images_info)
+        for vm_id in missing_images:
+            img_id = missing_images[vm_id]
+            for image_id_src, gl_image in images_info['images'].iteritems():
+                if image_id_src == img_id and not gl_image['image']:
+                    diff = gl_image['meta']['instance'][0]['diff']['path_src']
+                    img_src_host = gl_image['meta']['instance'][0]['diff']['host_src']
+                    if img_src_host != self.src_host:
+                        LOG.warning('Different host information. ' +
+                                    'Image is located on host {img_src_host},' +
+                                    'but host in the configuration file {src_host}.'.format(img_src_host,
+                                                                                            self.src_host))
+                        continue
+                    new_img = self.process_image(img_id, diff)
+                    gl_image['image']['id'] = new_img['id']
+                    gl_image['image']['resource'] = None
+                    gl_image['image']['checksum'] = new_img['checksum']
+                    gl_image['image']['name'] = img_id
+        return {
+            'images_info': images_info,
+            'compute_ignored_images': compute_ignored_images}
+
+    def process_image(self, img_id=None, diff=None):
+        """
+        Processing image file: copy from source to destination, create glance image
+        :param img_id: image ID from source
+        :param diff: diff file of root disk for instance
+        :return: new image ID if image is created
+        """
+        with files.RemoteTempDir(self.src_runner) as src_tmp_dir,\
+                files.RemoteTempDir(self.dst_runner) as dst_tmp_dir:
+            diff_name = 'diff'
+            base_name = 'base'
+            diff_file = os.path.join(src_tmp_dir, diff_name)
+            self.src_runner.run('cp {} {}'.format(diff, diff_file))
+            base_file = os.path.join(src_tmp_dir, base_name)
+            dst_base_file = os.path.join(dst_tmp_dir, base_name)
+            qemu_img_src = self.src_cloud.qemu_img
+            base = qemu_img_src.detect_backing_file(diff, self.src_host)
+            if base is not None:
+                self.src_runner.run('cp {} {}'.format(base, base_file))
+                qemu_img_src.diff_rebase(base_file, diff_file, self.src_host)
+                qemu_img_src.diff_commit(src_tmp_dir, diff_name, self.src_host)
+                verified_file_copy(self.src_runner, self.dst_runner, self.dst_user,
+                                   base_file, dst_base_file, self.dst_host, 1)
+            else:
+                verified_file_copy(self.src_runner, self.dst_runner, self.dst_user,
+                                   diff_file, dst_base_file, self.dst_host, 1)
+            image_resource = self.dst_cloud.resources[utils.IMAGE_RESOURCE]
+            id = image_resource.glance_img_create(self.dst_runner, img_id, 'qcow2',
+                                                  dst_base_file)
+            checksum = remote_md5_sum(self.dst_runner, dst_base_file)
+            return {'id': id, 'checksum': checksum}

--- a/cloudferrylib/utils/qemu_img.py
+++ b/cloudferrylib/utils/qemu_img.py
@@ -17,6 +17,10 @@ __author__ = 'mirrorcoder'
 import cmd_cfg
 import ssh_util
 
+from cloudferrylib.utils import utils
+
+LOG = utils.get_log(__name__)
+
 
 class QemuImg(ssh_util.SshUtil):
     commit_cmd = cmd_cfg.qemu_img_cmd("commit %s")
@@ -28,7 +32,7 @@ class QemuImg(ssh_util.SshUtil):
     convert_cmd = convert_cmd("-O %s %s %s")
 
     def diff_commit(self, dest_path, filename="disk", host_compute=None):
-        cmd = self.commit_cmd(dest_path, filename)
+        cmd = self.commit_cd_cmd(dest_path, filename)
         return self.execute(cmd, host_compute)
 
     def convert_image(self,
@@ -51,12 +55,12 @@ class QemuImg(ssh_util.SshUtil):
 
     def detect_backing_file(self, dest_disk_ephemeral, host_instance):
         cmd = self.backing_file_cmd(dest_disk_ephemeral)
-        return self.parsing_output_backing(self.execute(cmd, host_instance))
+        return self.parsing_output_backing(self.execute(cmd=cmd, host_exec=host_instance, ignore_errors=True))
 
     @staticmethod
     def parsing_output_backing(output):
         out = output.split('\n')
-        backing_file = ""
+        backing_file = None
         for i in out:
             line_out = i.split(":")
             if line_out[0] == "backing file":

--- a/devlab/tests/scenarios/cold_migrate.yaml
+++ b/devlab/tests/scenarios/cold_migrate.yaml
@@ -61,6 +61,8 @@ process:
           - transport_resource_inst:
               - transport_images:
                   - act_conv_comp_img: True
+                  - act_is_boot_image_deleted: ['act_copy_inst_images']
+                  - act_recreate_boot_image: True
                   - act_copy_inst_images: True
                   - act_conv_image_comp: True
               - set_volume_id_for_attaching: True

--- a/scenario/tasks.yaml
+++ b/scenario/tasks.yaml
@@ -17,6 +17,8 @@ tasks:
    act_net_prep: ['PrepareNetworks', 'dst_cloud']
    act_deploy_instances: ['TransportInstance']
    act_conv_comp_img: ['ConvertComputeToImage', 'src_cloud']
+   act_recreate_boot_image: ['ReCreateBootImage', 'src_cloud']
+   act_is_boot_image_deleted: ['IsBootImageDeleted']
    act_conv_image_comp: ['ConvertImageToCompute']
    act_copy_inst_images: ['CopyFromGlanceToGlance']
    act_identity_trans: ['IdentityTransporter']


### PR DESCRIPTION
Example output when no backing file:

INFO     [/home/segorov/projects/CloudFerry/cloudferrylib/scheduler/scheduler.py : lineno 47]  08-26 17:30:10  -------- Start task: BaseTask|ConvertComputeToImage
ERROR    [/home/segorov/projects/CloudFerry/cloudferrylib/os/image/glance_image.py : lineno 310]  08-26 17:30:11  Image has not been found
WARNING  [/home/segorov/projects/CloudFerry/cloudferrylib/os/actions/convert_compute_to_image.py : lineno 74]  08-26 17:30:11  No boot image for instance, need to re-create it
INFO     [/home/segorov/projects/CloudFerry/cloudferrylib/scheduler/scheduler.py : lineno 51]  08-26 17:30:11  -------- End task: BaseTask|ConvertComputeToImage
INFO     [/home/segorov/projects/CloudFerry/cloudferrylib/scheduler/scheduler.py : lineno 47]  08-26 17:30:11  -------- Start task: BaseTask|IsBootImageDeleted
INFO     [/home/segorov/projects/CloudFerry/cloudferrylib/scheduler/scheduler.py : lineno 51]  08-26 17:30:11  -------- End task: BaseTask|IsBootImageDeleted
INFO     [/home/segorov/projects/CloudFerry/cloudferrylib/scheduler/scheduler.py : lineno 47]  08-26 17:30:11  -------- Start task: BaseTask|ReCreateBootImage
[192.168.1.2] run: qemu-img info /var/lib/nova/instances/9696e30d-d58a-4893-b9d9-a3f210ec3acf/disk | grep "backing file"

Warning: run() received nonzero return code 1 while executing 'qemu-img info /var/lib/nova/instances/9696e30d-d58a-4893-b9d9-a3f210ec3acf/disk | grep "backing file"'!

[192.168.1.2] run: mktemp -d
[192.168.1.2] out: /tmp/tmp.lubVL8nZrJ
[192.168.1.2] out:

[192.168.1.3] run: mktemp -d
[192.168.1.3] out: /tmp/tmp.wmpU8NdPr9
[192.168.1.3] out:

[192.168.1.2] run: cp /var/lib/nova/instances/9696e30d-d58a-4893-b9d9-a3f210ec3acf/disk /tmp/tmp.lubVL8nZrJ/diff
INFO     [/home/segorov/projects/CloudFerry/cloudferrylib/utils/drivers/ssh_chunks.py : lineno 91]  08-26 17:30:11  Copying file '/tmp/tmp.lubVL8nZrJ/diff' to '192.168.1.3', attempt '1'
[192.168.1.2] run: md5sum /tmp/tmp.lubVL8nZrJ/diff
[192.168.1.2] out: 4cda2a267e2d4466bba04d1916eb5867  /tmp/tmp.lubVL8nZrJ/diff
[192.168.1.2] out:

[192.168.1.2] run: scp -o StrictHostKeyChecking=no /tmp/tmp.lubVL8nZrJ/diff root@192.168.1.3:/tmp/tmp.wmpU8NdPr9/base
[192.168.1.2] out:
[192.168.1.2] out: diff                                                                                                                                                                                                                                           0%    0     0.0KB/s   --:-- ETA
[192.168.1.2] out: diff                                                                                                                                                                                                                                         100%   18MB  18.4MB/s   00:01
[192.168.1.2] out:

[192.168.1.3] run: md5sum /tmp/tmp.wmpU8NdPr9/base
[192.168.1.3] out: 4cda2a267e2d4466bba04d1916eb5867  /tmp/tmp.wmpU8NdPr9/base
[192.168.1.3] out:

[192.168.1.3] run: glance --os-username=admin --os-password=admin --os-tenant-name=admin --os-auth-url=http://192.168.1.3:35357/v2.0 image-create --name 3bc00065-befe-40da-9e06-0789867b8811 --disk-format=qcow2 --container-format=bare --file /tmp/tmp.wmpU8NdPr9/base | grep id
[192.168.1.3] out: | id               | 4ef85159-8894-4b91-8479-6ef93ebb89b3 |
[192.168.1.3] out:

[192.168.1.3] run: md5sum /tmp/tmp.wmpU8NdPr9/base
[192.168.1.3] out: 4cda2a267e2d4466bba04d1916eb5867  /tmp/tmp.wmpU8NdPr9/base
[192.168.1.3] out:

[192.168.1.3] run: rm -rf /tmp/tmp.wmpU8NdPr9
[192.168.1.2] run: rm -rf /tmp/tmp.lubVL8nZrJ
INFO     [/home/segorov/projects/CloudFerry/cloudferrylib/scheduler/scheduler.py : lineno 51]  08-26 17:30:13  -------- End task: BaseTask|ReCreateBootImage