### PR TITLE
SAIC-395 Remove SSL warning

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ python-novaclient==2.16.0
 python-swiftclient==2.3.1
 pyyaml
 redis
+requests==2.2.1
 sqlalchemy
 oslo.config==1.15.0
 # see https://github.com/paramiko/paramiko/issues/570 and https://github.com/paramiko/paramiko/pull/571


### PR DESCRIPTION
Removes SSL warning generated by urllib when trying to access insecure
HTTPS endpoints. See https://urllib3.readthedocs.org/en/latest/security.html#insecurerequestwarning