### PR TITLE
Add NFS server to quickstart documentation

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -23,7 +23,7 @@
 4. Setup development environment
     ```
     cd CloudFerry/devlab
-    vagrant up grizzly icehouse
+    vagrant up grizzly icehouse nfs
     ```
 
 5. Setup virtual environment for cloudferry


### PR DESCRIPTION
Devlab was recently updated with separate NFS server which is used as a
backend for cinder in openstack VMs. This change was not reflected in
quickstart guide, which this patch fixes.