### PR TITLE
Fixed blocker issue for devlab

### DIFF
--- a/devlab/config.ini
+++ b/devlab/config.ini
@@ -3,8 +3,8 @@
 scenario_file = devlab/tests/scenarios/cold_migrate.yaml
 tasks_file = scenario/tasks.yaml
 public_key_path = .ssh/id_rsa.pub
-grizzly_ip = 192.168.1.2
-icehouse_ip = 192.168.1.3
+src_ip = 192.168.1.2
+dst_ip = 192.168.1.3
 cloudferry_ip = 192.168.1.4
 nfs_ip = 192.168.1.10
 grizzly_compute_ip = 192.168.1.5


### PR DESCRIPTION
src_ip and dst_ip are used for devlab instead of grizzly_ip and icehouse_ip