### PR TITLE
[DO NOT MERGE] Revert "SAIC-418 Migration of users with primary tenant deleted"

### DIFF
--- a/devlab/tests/test_resource_migration.py
+++ b/devlab/tests/test_resource_migration.py
@@ -5,8 +5,6 @@ import unittest
 import subprocess
 import functional_test
 
-from keystoneclient.exceptions import NotFound
-
 from time import sleep
 
 
@@ -53,14 +51,7 @@ class ResourceMigrationTests(functional_test.FunctionalTest):
                 self.fail(msg.format(res=resource_name, r_name=i['name']))
 
     def test_migrate_keystone_users(self):
-        src_users = []
-        for u in self.filter_users():
-            try:
-                self.src_cloud.keystoneclient.tenants.find(id=u.tenantId)
-                src_users.append(u)
-            except NotFound:
-                pass
-        src_users = self.filter_users()
+        src_users = self.filter_resources('users')
         dst_users = self.dst_cloud.keystoneclient.users.list()
 
         self.validate_resource_parameter_in_dst(src_users, dst_users,


### PR DESCRIPTION
This reverts commit a301b9b47409e1e8c31d004640d2159497859227 and applies
correct fix. The issue with existing fix is that it modifies existing
users while doing migration, which is not acceptable.