### PR TITLE
Fix for SAIC-436. Add service_tenant parameter to [src] and [dst]

### DIFF
--- a/configs/config.ini
+++ b/configs/config.ini
@@ -61,6 +61,12 @@ password = admin
 tenant = admin
 temp = /root/temp
 
+#"service_tenant" is the name for Tenant used by openstack services. (Optional)
+#By default CloudFerry takes following value for service tenant name: "service".
+#In some cases (e.g Mirantis Openstack) the service tenant name can be different.
+#To verify if value is different from default run : "keystone tenant-list | grep service"
+service_tenant = service
+
 [src_mysql]
 user = root
 password =
@@ -135,6 +141,12 @@ user = admin
 password = admin
 tenant = admin
 temp = /root/merge
+
+#"service_tenant" is the name for Tenant used by openstack services. (Optional)
+#By default CloudFerry takes following value for service tenant name: "service".
+#In some cases (e.g Mirantis Openstack) the service tenant name can be different.
+#To verify if value is different from default run : "keystone tenant-list | grep service"
+service_tenant = service
 
 [dst_mysql]
 user = root

--- a/devlab/config.template
+++ b/devlab/config.template
@@ -64,6 +64,7 @@ port = 3306
 database_name = nova
 user = <src_mysql_user>
 password = <src_mysql_password>
+service_tenant = service
 
 [src_storage]
 service = cinder
@@ -113,6 +114,7 @@ ext_cidr = <dst_ext_cidr>
 user = <dst_user>
 password = <dst_password> 
 tenant = <dst_tenant>
+service_tenant = service
 
 [dst_mysql]
 user = <dst_mysql_user> 


### PR DESCRIPTION
This is Fix for SAIC-436. Add service_tenant parameter to [src] and [dst] and description what is this parameter and how to obtain the values.