### PR TITLE
[SAIC-442] FloatingIP migration creates another IPs on dst

### DIFF
--- a/cloudferrylib/utils/mysql_connector.py
+++ b/cloudferrylib/utils/mysql_connector.py
@@ -37,3 +37,9 @@ class MysqlConnector():
         with sqlalchemy.create_engine(
                 self.connection_url).begin() as connection:
             return connection.execute(sqlalchemy.text(command), **kwargs)
+
+    def batch_execute(self, commands, **kwargs):
+        with sqlalchemy.create_engine(
+                self.connection_url).begin() as connection:
+            for command in commands:
+                connection.execute(sqlalchemy.text(command), **kwargs)


### PR DESCRIPTION
Steps for FloatingIP migration:
- Allocate FloatingIP on dst
- Change FloatingIP in database:
 - Change IP in `floatingips` table
 - Change IP in `ipallocations` table *(added in this patch)*
- Delete related rows from `ipavailabilityranges` table for avoid FloatingIP duplication *(added in this patch)*