### PR TITLE
Fixed floating ip network in grizzly and icehouse

### DIFF
--- a/devlab/Vagrantfile
+++ b/devlab/Vagrantfile
@@ -113,8 +113,10 @@ Vagrant.configure(2) do |config|
           end
           thisnode.vm.provision "shell", path: "./provision/libvirt.sh"
           if nodename == "grizzly" then
+            thisnode.vm.provision "shell", path: "./provision/fix_interfaces.sh"
             thisnode.vm.provision "shell", path: "./provision/qemu.sh"
           elsif nodename == "icehouse" then
+            thisnode.vm.provision "shell", path: "./provision/fix_interfaces.sh"
             thisnode.vm.provision "shell", path: "./provision/cleanup_nova_instances.sh"
           end
         when "dev"

--- a/devlab/provision/fix_interfaces.sh
+++ b/devlab/provision/fix_interfaces.sh
@@ -1,0 +1,11 @@
+# Add physical eth1 interface to the floating bridge
+# This allows access to the vm's inside of openstack directly
+# from the host-server
+floating_interface='eth1'
+sudo ovs-vsctl add-port br-ex $floating_interface
+int_addr=`ip addr sh $floating_interface   | grep "inet " | awk '{print $2}'`
+sudo ip addr del $int_addr dev $floating_interface
+sudo ip addr add $int_addr dev br-ex
+sudo ip link set $floating_interface promisc on
+sudo ip link set br-ex promisc on
+sudo ip link set dev br-ex up


### PR DESCRIPTION
Added physical eth1 interface to the floating bridge. This allows access
to the vm's inside of OpenStack directly from the host-server.