### PR TITLE
SAIC-468 Config option for DB backend host

### DIFF
--- a/cfglib.py
+++ b/cfglib.py
@@ -138,7 +138,10 @@ migrate_opts = [
                      'OpenStack does not support user quotas (e.g. Grizzly)'),
     cfg.StrOpt('incloud_live_migration', default='nova',
                help='Live migration type used for in-cloud live migration. '
-                    'Possible values: "nova", "cobalt".')
+                    'Possible values: "nova", "cobalt".'),
+    cfg.StrOpt('mysqldump_host',
+               help='IP or hostname used for creating MySQL dump for rollback.'
+                    'If not set uses `[dst] db_host` config option.')
 ]
 
 mail = cfg.OptGroup(name='mail',

--- a/cloudferrylib/os/actions/snapshots.py
+++ b/cloudferrylib/os/actions/snapshots.py
@@ -14,6 +14,7 @@
 
 
 from cloudferrylib.base.action import action
+from cloudferrylib.utils import mysql_connector
 from cloudferrylib.utils import utils
 from fabric.api import local
 
@@ -22,8 +23,27 @@ LOG = utils.get_log(__name__)
 
 
 class MysqlDump(action.Action):
+    """Dumps MySQL database to a file. Primarily used for rollbacks.
+
+    Config options:
+      - `config.migrate.mysqldump_host`;
+      - `config.dst_mysql.db_host` - used if `config.migrate.mysqldump_host` is
+        not set.
+
+    Process:
+      1. SSH into DB host (see Config options);
+      2. Run `mysqldump`;
+      3. Copy MySQL dump to CloudFerry host.
+
+    Requirements:
+      - SSH access to DB host (see Config options);
+      - Read access to MySQL DB from DB host;
+      - Write access for `config.dst_mysql.db_user` on DB host.
+    """
 
     def run(self, *args, **kwargs):
+        db_host = mysql_connector.get_db_host(self.cloud.cloud_config)
+
         # dump mysql to file
         # probably, we have to choose what databases we have to dump
         # by default we dump all databases
@@ -36,11 +56,11 @@ class MysqlDump(action.Action):
             password=self.cloud.cloud_config.mysql.db_password,
             path=self.cloud.cloud_config.snapshot.snapshot_path)
         LOG.info("dumping database with command '%s'", command)
-        self.cloud.ssh_util.execute(command)
+        self.cloud.ssh_util.execute(command, host_exec=db_host)
         # copy dump file to host with cloudferry (for now just in case)
         # in future we will store snapshot for every step of migration
         context = {
-            'host_src': self.cloud.cloud_config.mysql.db_host,
+            'host_src': db_host,
             'path_src': self.cloud.cloud_config.snapshot.snapshot_path,
             'user_src': self.cloud.cloud_config.cloud.ssh_user,
             'key': self.cloud.config.migrate.key_filename,
@@ -54,8 +74,14 @@ class MysqlDump(action.Action):
 
 
 class MysqlRestore(action.Action):
+    """Restores MySQL DB from previously created dump using `MysqlDump()`
+
+    See `MysqlDump` documentation for requirements and config options used.
+    """
 
     def run(self, *args, **kwargs):
+        db_host = mysql_connector.get_db_host(self.cloud.cloud_config)
+
         # apply sqldump from file to mysql
         command = ("mysql "
                    "--user={user} "
@@ -65,5 +91,5 @@ class MysqlRestore(action.Action):
             password=self.cloud.cloud_config.mysql.db_password,
             path=self.cloud.cloud_config.snapshot.snapshot_path)
         LOG.info("restoring database with command '%s'", command)
-        self.cloud.ssh_util.execute(command)
+        self.cloud.ssh_util.execute(command, host_exec=db_host)
         return {}

--- a/cloudferrylib/utils/mysql_connector.py
+++ b/cloudferrylib/utils/mysql_connector.py
@@ -16,6 +16,26 @@
 import sqlalchemy
 
 
+def get_db_host(cloud_config):
+    """Returns DB host based on configuration.
+
+    Useful when MySQL is deployed on multiple nodes, when multiple MySQL nodes
+    are hidden behind a VIP. In this scenario providing VIP in
+    `config.dst_mysql.db_host` will break mysqldump which requires to be run
+    locally on particular DB host.
+
+    :returns: `config.migrate.mysqldump_host` if not `None`, or
+    `config.dst_mysql.db_host` otherwise
+    """
+
+    db_host = cloud_config.mysql.db_host
+
+    if cloud_config.migrate.mysqldump_host:
+        db_host = cloud_config.migrate.mysqldump_host
+
+    return db_host
+
+
 class MysqlConnector():
     def __init__(self, config, db):
         self.config = config

--- a/tests/cloudferrylib/utils/test_mysql_connector.py
+++ b/tests/cloudferrylib/utils/test_mysql_connector.py
@@ -1,0 +1,36 @@
+# Copyright 2015 Mirantis Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import mock
+
+from cloudferrylib.utils import mysql_connector
+from tests import test
+
+
+class GetDbTestCase(test.TestCase):
+    def test_returns_mysqldump_host_if_set(self):
+        config = mock.MagicMock()
+        config.mysql.db_host = "db_vip"
+        expected = "mysql_node"
+        config.migrate.mysqldump_host = expected
+
+        self.assertEqual(expected, mysql_connector.get_db_host(config))
+
+    def test_returns_vip_host_if_mysqldump_node_is_not_set(self):
+        config = mock.MagicMock()
+        expected = "db_vip"
+        config.mysql.db_host = expected
+        config.migrate.mysqldump_host = None
+
+        self.assertEqual(expected, mysql_connector.get_db_host(config))


### PR DESCRIPTION
Allows user to specify particular MySQL backend host when MySQL is deployed
on multiple nodes, and multiple MySQL nodes are hidden behind a VIP. In this
scenario providing VIP in `config.dst_mysql.db_host` will break mysqldump
which requires to be run locally on particular DB host. Patch allows to specify
`config.migrate.mysqldump_host` which workarounds this problem.