### PR TITLE
SAIC-445 Fixed generate_config.sh

### DIFF
--- a/devlab/provision/generate_config.sh
+++ b/devlab/provision/generate_config.sh
@@ -10,7 +10,7 @@ error_exit() {
         echo &>2
     fi
 
-    echo "Usage: ${SCRIPT} --cloudferry-path <path> [--destination <path>]"
+    echo "Usage: ${SCRIPT} --cloudferry-path <path> [--destination <path>] [--src-ip <src-ip>] [--dst-ip <dst-ip>]"
 
     exit 1
 }
@@ -19,6 +19,8 @@ while [[ $# -ge 2 ]]; do
     case $1 in
         --cloudferry-path) shift; CF_PATH=$1; shift;;
         --destination) shift; S_PATH=$1; shift;;
+        --src-ip) shift; SRC_IP=$1; shift;;
+        --dst-ip) shift; DST_IP=$1; shift;;
         *) error_exit "Invalid arg $1";;
     esac
 done
@@ -33,6 +35,31 @@ result_config=${S_PATH}/configuration.ini
 
 echo "Preparing configuration for CloudFerry"
 cp ${CF_PATH}/devlab/config.template ${result_config}
+
+ip_regexp="\b([0-9]{1,3}\.){3}[0-9]{1,3}\b"
+
+#Use icehouse ip if dst ip is not defined
+if [ -z $DST_IP ]; then
+   DST_IP=$(cat ${CF_PATH}/devlab/config.ini | grep icehouse_ip|\
+            grep -oE ${ip_regexp})
+fi
+#Use grizzly ip if src ip is not defined
+if [ -z $SRC_IP ]; then
+   SRC_IP=$(cat ${CF_PATH}/devlab/config.ini | grep grizzly_ip|\
+            grep -oE ${ip_regexp})
+fi
+
+config=${CF_PATH}/devlab/config.ini
+if grep -q '^src_ip' $config ; then
+    sed -i "s/^src_ip.*/src_ip = ${SRC_IP}/" $config
+else
+    echo "src_ip = ${SRC_IP}" >> $config
+fi
+if grep -q '^dst_ip' $config ; then
+    sed -i "s/^dst_ip.*/dst_ip = ${DST_IP}/" $config
+else
+    echo "dst_ip = ${DST_IP}" >> $config
+fi
 
 while read key value
 do

--- a/devlab/tests/test_group_verification.py
+++ b/devlab/tests/test_group_verification.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import re
 import yaml
 import unittest
 import functional_test
@@ -33,11 +34,15 @@ class GroupProcedureVerification(functional_test.FunctionalTest):
         #  Should be fixed by implementing proper package module for Cloud
         #  Ferry.
         self.conf_path = 'devlab/tests'
+        dst_ip = self._get_ip_from_url(self.dst_cloud.auth_url)
+        src_ip = self._get_ip_from_url(self.src_cloud.auth_url)
         cmd_no_path = './../../devlab/provision/generate_config.sh' \
-                      ' --cloudferry-path {} --destination {}'
+                      ' --cloudferry-path {} --destination {} --src-ip {}' \
+                      ' --dst-ip {}'
         cmd = cmd_no_path.format(self.main_folder,
                                  os.path.join(self.main_folder,
-                                              self.conf_path))
+                                              self.conf_path),
+                                 src_ip, dst_ip)
         os.system(cmd)
 
     def tearDown(self):
@@ -54,6 +59,10 @@ class GroupProcedureVerification(functional_test.FunctionalTest):
             except Exception as e:
                 print 'Was unable to delete testing files, error output:' \
                       '\n{}'.format(e)
+
+    def _get_ip_from_url(self, url):
+        ip_regexp = '.+(\d{3}\.\d{1,3}\.\d{1,3}\.\d{1,3}).+'
+        return re.match(ip_regexp, url).group(1)
 
     def _prepare_files(self, grouping_by):
         """


### PR DESCRIPTION
Now src and dst ips can be defined as arguments. Example:
./generate_config.sh --src-ip <src-ip> --dst-ip <dst-ip>
If src or dst ip is not defined, grizzly ip will be used
as default src_ip and icehouse ip - as defult dst_ip.