### PR TITLE
SAIC-462 MySQL host config description

### DIFF
--- a/configs/config.ini
+++ b/configs/config.ini
@@ -139,6 +139,13 @@ path_tasks = scenario/tasks.yaml
 #     resources were migrated using `scenario/migrate_resources.yaml` scenario
 path_scenario = scenario/migrate.yaml
 
+# Allows to specify host for creating MySQL dump used in rollback procedure.
+# Useful when MySQL uses multinode configuration with load balancer in front.
+# In this case one would set VIP hostname in `[dst] db_host` and specific
+# SSH-accessible MySQL node behind VIP for creating MySQL dump used in
+# rollback.
+mysqldump_host = <specific MySQL DB hostname or IP address, not VIP>
+
 
 #==============================================================================
 # Mailing configuration


### PR DESCRIPTION
Adds description of `mysqldump_host` config option to config.ini. New
config option Allows to specify host for creating MySQL dump used in rollback
procedure. Useful when MySQL uses multinode configuration with load balancer in front.
In this case one would set VIP hostname in `[dst] db_host` and specific
SSH-accessible MySQL node behind VIP for creating MySQL dump used in
rollback.