### PR TITLE
Fix propsed for SAIC-480 & SAIC-488

### DIFF
--- a/devlab/tests/config.py
+++ b/devlab/tests/config.py
@@ -40,8 +40,8 @@ tenants = [
          {'name': 'server6', 'image': 'image1', 'flavor': 'del_flvr'}],
      'networks': [{'name': 'tenantnet1', 'admin_state_up': True},
                   {'name': 'tenant1_net2', 'admin_state_up': True}],
-     'subnets': [{'cidr': '10.5.2.0/24', 'ip_version': 4},
-                 {'cidr': '10.6.2.0/24', 'ip_version': 4}],
+     'subnets': [{'cidr': '10.5.2.0/24', 'ip_version': 4, 'name': 't1_s1'},
+                 {'cidr': '10.6.2.0/24', 'ip_version': 4, 'name': 't1_s2'}],
      'security_groups': [
          {'name': 'sg11', 'description': 'Blah blah group', 'rules': [
              {'ip_protocol': 'icmp',
@@ -72,7 +72,7 @@ tenants = [
           'flavor': 'flavorname2', 'key_name': 'key2', 'nics': [
               {'net-id': 'tenantnet2'}]}],
      'networks': [{'name': 'tenantnet2', 'admin_state_up': True}],
-     'subnets': [{'cidr': '22.2.2.0/24', 'ip_version': 4}],
+     'subnets': [{'cidr': '22.2.2.0/24', 'ip_version': 4, 'name': 't2_s1'}],
      'cinder_volumes': [
          {'name': 'tn_volume1', 'size': 1, 'server_to_attach': 'tn2server1',
           'device': '/dev/vdb'}

--- a/devlab/tests/functional_test.py
+++ b/devlab/tests/functional_test.py
@@ -39,15 +39,22 @@ class FunctionalTest(unittest.TestCase):
         self.filtering_utils = FilteringUtils()
 
     def filter_networks(self):
-        cfg = [i['name'] for i in config.networks]
-        networks = [cfg.extend(i['networks'])
-                    for i in config.tenants if 'networks' in i]
+        networks = [i['name'] for i in config.networks]
+        for i in config.tenants:
+            if 'networks' in i:
+                for j in i['networks']:
+                    networks.append(j['name'])
         return self._get_neutron_resources('networks', networks)
 
+    # TODO(raies): Currently we support filtering of those subnets which has
+    # 'name' parameter in it's detail.
+    # Implimentation of Subnet filtering for no name subnets is still needed.
     def filter_subnets(self):
-        cfg = [i['name'] for i in config.networks]
-        subnets = [cfg.extend(i['subnets'])
-                   for i in config.tenants if 'subnets' in i]
+        subnets = [i['name'] for i in config.subnets]
+        for i in config.tenants:
+            if 'subnets' in i:
+                for subnet in i['subnets']:
+                    subnets.append(subnet['name'])
         return self._get_neutron_resources('subnets', subnets)
 
     def filter_routers(self):


### PR DESCRIPTION
During CF functional Testing, wrong behaviour with test "test_migrate_neutron_networks under resource migration"
I have generated the load on source but migration is not initiated.
In this case when I check available networks on source and destination side then they are different (As migration is not initiated). In this case this test should fail.
But test is showing success. Please check below -

(.venv)root@cloudferry:/home/vagrant/CloudFerry# nosetests -sv devlab/tests/test_resource_migration.py:ResourceMigrationTests.test_migrate_neutron_networks


test_migrate_neutron_networks (tests.test_resource_migration.ResourceMigrationTests) ... src_nets {'networks': []}
dst_nets {'networks': [{u'status': u'ACTIVE', u'subnets': [u'8dcc195b-56af-4f19-b3f2-211403e92784'], u'name': u'public', u'provider:physical_network': None, u'admin_state_up': True, u'tenant_id': u'5d4a7644e11149a68c7afd2d40e726fe', u'provider:network_type': u'local', u'router:external': True, u'shared': False, u'id': u'5b806cff-dc87-415a-9ff6-0cb904df4916', u'provider:segmentation_id': None}, {u'status': u'ACTIVE', u'subnets': [u'0d217c94-9977-48a1-9f88-c8e2c9f7598a'], u'name': u'private', u'provider:physical_network': None, u'admin_state_up': True, u'tenant_id': u'403ebded978c42c590755b9b72e24360', u'provider:network_type': u'local', u'router:external': False, u'shared': False, u'id': u'aee2abe5-dcc7-40fd-ab06-d8c73ec2603d', u'provider:segmentation_id': None}]}
ok

----------------------------------------------------------------------
Ran 1 test in 0.174s

OK
(.venv)root@cloudferry:/home/vagrant/CloudFerry#


Actually this test should Fail but it is successful. This gives wrong behaviour.


