### PR TITLE
[SAIC-458] Add networks segmentation id check

### DIFF
--- a/cloudferrylib/os/actions/check_networks.py
+++ b/cloudferrylib/os/actions/check_networks.py
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and#
 # limitations under the License.
 
-import ipaddr
+
 import collections
-import exceptions
+
+import ipaddr
+
+from cloudferrylib.base import exception
 from cloudferrylib.base.action import action
 from cloudferrylib.utils import utils
 
@@ -24,9 +27,12 @@ LOG = utils.get_log(__name__)
 
 class CheckNetworks(action.Action):
     """
-    Check subnets overlapping and raise EnvironmentError if needed.
-    It must be done before actual migration in check section.
-    The action use filter search opts and must run after act_get_filter action
+    Check networks segmentation ID and subnets overlapping.
+
+    Raise exception (AbortMigrationError) if overlapping has been found.
+    It must be done before actual migration in the 'preparation' section.
+    The action uses filtered search opts and must be run after 'act_get_filter'
+    action.
     """
 
     def run(self, **kwargs):
@@ -36,12 +42,22 @@ class CheckNetworks(action.Action):
         search_opts = kwargs.get('search_opts_tenant', {})
         src_info = NetworkInfo(src_net.read_info(**search_opts))
         dst_info = NetworkInfo(dst_net.read_info(**search_opts))
+        dst_seg_ids = dst_info.get_segmentation_ids()
+
         for network in src_info.get_networks():
             dst_net = dst_info.by_hash.get(network.hash)
             if dst_net:
-                LOG.debug("src network %s, dst network %s" %
+                # Current network matches with network on DST
+                # Have the same networks on SRC and DST
+                LOG.debug("SRC network: '%s', DST network: '%s'" %
                           (network.id, dst_net.id))
                 network.check_network_overlapping(dst_net)
+            else:
+                # Current network does not match with any network on DST
+                # Check Segmentation ID overlapping with DST
+                LOG.debug("Check segmentation ID for SRC network: '%s'",
+                          network.id)
+                network.check_segmentation_id_overlapping(dst_seg_ids)
 
 
 class NetworkInfo(object):
@@ -59,6 +75,40 @@ class NetworkInfo(object):
     def get_networks(self):
         return self.by_hash.values()
 
+    def get_segmentation_ids(self):
+        """Get busy segmentation IDs.
+
+        We need to handle duplicates in segmentation ids.
+        Neutron has different validation rules for different network types.
+
+        For 'gre' and 'vxlan' network types there is no strong requirement
+        for 'physical_network' attribute, if we want to have
+        'segmentation_id', because traffic is encapsulated in L3 packets.
+
+        For 'vlan' and 'flat' network types there is a strong requirement for
+        'physical_network' attribute, if we want to have 'segmentation_id'.
+
+        :result: Dictionary with busy segmentation IDs.
+                 Hash is used with structure {"gre": [1, 2, ...],
+                                              "vlan": [1, 2, ...]}
+        """
+
+        used_seg_ids = {}
+        networks = self.by_id.values()
+
+        for net in networks:
+            network_has_segmentation_id = (
+                net.info["provider:physical_network"] or
+                (net.network_type in ['gre', 'vxlan']))
+
+            if network_has_segmentation_id:
+                if net.network_type not in used_seg_ids:
+                    used_seg_ids[net.network_type] = []
+                if net.seg_id:
+                    used_seg_ids[net.network_type].append(net.seg_id)
+
+        return used_seg_ids
+
 
 class Network(object):
     def __init__(self, info):
@@ -68,24 +118,27 @@ class Network(object):
         self.id = info['id']
         self.hash = info['res_hash']
 
+        self.network_type = self.info['provider:network_type']
+        self.seg_id = self.info["provider:segmentation_id"]
+
     def add_subnet(self, info):
         self.subnets.append(info)
         self.subnets_hash.add(info['res_hash'])
 
     def check_network_overlapping(self, network):
         for subnet in network.subnets:
-            LOG.debug("work on src subnet %s" % subnet['id'])
+            LOG.debug("Work with SRC subnet: '%s'" % subnet['id'])
             if self.is_subnet_eq(subnet):
-                LOG.debug("We have the same on dst by hash")
+                LOG.debug("We have the same subnet on DST by hash")
                 continue
             overlapping_subnet = self.get_overlapping_subnet(subnet)
             if overlapping_subnet:
-                message = ("Subnet %s in network %s on src overlap "
-                           "subnet %s in network %s on dst" % (
+                message = ("Subnet '%s' in network '%s' on SRC overlaps with "
+                           "subnet '%s' in network '%s' on DST" % (
                                overlapping_subnet, self.id,
                                subnet['id'], network.id))
                 LOG.error(message)
-                raise exceptions.EnvironmentError(message)
+                raise exception.AbortMigrationError(message)
 
     def is_subnet_eq(self, subnet):
         return subnet['res_hash'] in self.subnets_hash
@@ -94,5 +147,22 @@ class Network(object):
         cidr = ipaddr.IPNetwork(subnet['cidr'])
         for self_subnet in self.subnets:
             self_cidr = ipaddr.IPNetwork(self_subnet['cidr'])
-            if (cidr.Contains(self_cidr) or self_cidr.Contains(cidr)):
+            if cidr.Contains(self_cidr) or self_cidr.Contains(cidr):
                 return self_subnet['id']
+
+    def check_segmentation_id_overlapping(self, dst_seg_ids):
+        """
+        Check if segmentation ID of current network overlaps with destination.
+
+        :param dst_seg_ids: Dictionary with busy segmentation IDs on DST
+        """
+
+        if self.network_type not in dst_seg_ids:
+            return
+
+        if self.seg_id in dst_seg_ids[self.network_type]:
+            message = ("Segmentation ID '%s' (network type = '%s', "
+                       "network ID = '%s') is already busy on the destination "
+                       "cloud.") % (self.seg_id, self.network_type, self.id)
+            LOG.error(message)
+            raise exception.AbortMigrationError(message)


### PR DESCRIPTION
Add networks segmentation id checking to the `check_networks` action.
Patch provides handling duplicates in segmentation ids. If busy
segmentation id is found on the destination, raise exception.