### PR TITLE
Remove SSL warning message for test-requirements

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,3 +2,4 @@ flake8
 nose
 oslotest
 rednose
+requests==2.2.1


### PR DESCRIPTION
Removes SSL warning message when test-requirements.txt are installed
into venv.