### PR TITLE
SAIC-515 Added test for migration with two ip pools

### DIFF
--- a/devlab/tests/config.py
+++ b/devlab/tests/config.py
@@ -38,10 +38,18 @@ tenants = [
          {'name': 'tn1server2', 'image': 'image1', 'flavor': 'flavorname1',
           'fip': True},
          {'name': 'server6', 'image': 'image1', 'flavor': 'del_flvr'}],
-     'networks': [{'name': 'tenantnet1', 'admin_state_up': True},
-                  {'name': 'tenant1_net2', 'admin_state_up': True}],
-     'subnets': [{'cidr': '10.5.2.0/24', 'ip_version': 4, 'name': 't1_s1'},
-                 {'cidr': '10.6.2.0/24', 'ip_version': 4, 'name': 't1_s2'}],
+     'networks': [
+         {'name': 'tenantnet1', 'admin_state_up': True,
+          'subnets': [
+              {'cidr': '10.5.2.0/24', 'ip_version': 4, 'name': 't1_s1',
+               'routers_to_connect': ['ext_router']}]},
+         {'name': 'tenant1_net2', 'admin_state_up': True,
+          'subnets': [
+              {'cidr': '10.6.2.0/24', 'ip_version': 4, 'name': 't1_s2',
+               'routers_to_connect': ['ext_router']}]
+          }
+     ],
+
      'security_groups': [
          {'name': 'sg11', 'description': 'Blah blah group', 'rules': [
              {'ip_protocol': 'icmp',
@@ -71,8 +79,13 @@ tenants = [
          {'name': 'keypair_test_server', 'image': 'image1',
           'flavor': 'flavorname2', 'key_name': 'key2', 'nics': [
               {'net-id': 'tenantnet2'}]}],
-     'networks': [{'name': 'tenantnet2', 'admin_state_up': True}],
-     'subnets': [{'cidr': '22.2.2.0/24', 'ip_version': 4, 'name': 't2_s1'}],
+     'networks': [
+         {'name': 'tenantnet2', 'admin_state_up': True,
+          'subnets': [
+              {'cidr': '22.2.2.0/24', 'ip_version': 4, 'name': 't2_s1',
+               'routers_to_connect': ['ext_router']}]
+          }
+     ],
      'cinder_volumes': [
          {'name': 'tn_volume1', 'size': 1, 'server_to_attach': 'tn2server1',
           'device': '/dev/vdb'}
@@ -122,20 +135,30 @@ flavors = [
 ]
 
 # Networks to create/delete
-# Connected to tenants
+# Only one gateway can be assigned to router. If two networks have the same
+# router in 'routers_to_connect', gateway set for last networks (updating)
 networks = [
-    {'name': 'mynetwork1', 'admin_state_up': True},
+    {'name': 'mynetwork1', 'admin_state_up': True,
+     'subnets': [
+         {'cidr': '10.4.2.0/24', 'ip_version': 4, 'name': 'subnet_1',
+          'connect_to_ext_router': True, 'routers_to_connect': ['ext_router']}]
+     },
     {'name': 'shared_net', 'admin_state_up': True, 'shared': True,
-     'router:external': True}
-
-]
-
-# Subnets to create/delete
-subnets = [
-
-    {'cidr': '10.4.2.0/24', 'ip_version': 4, 'name': 'subnet_1'},
-    {'cidr': '192.168.1.0/24', 'ip_version': 4, 'name': 'external_subnet',
-     'allocation_pools': [{'start': '192.168.1.100', 'end': '192.168.1.254'}]}
+     'router:external': True, 'real_network': True,
+     'subnets': [
+         {'cidr': '192.168.1.0/24', 'ip_version': 4, 'name': 'external_subnet',
+          'routers_to_connect': ['ext_router'], 'allocation_pools': [
+              {'start': '192.168.1.100', 'end': '192.168.1.254'}]
+          }]
+     },
+    {'name': 'second_shared_net', 'admin_state_up': True, 'shared': True,
+     'router:external': True,
+     'subnets': [
+         {'cidr': '192.168.7.0/24', 'ip_version': 4, 'name': 'shared_subnet',
+          'routers_to_connect': [], 'allocation_pools': [
+              {'start': '192.168.7.10', 'end': '192.168.7.192'}]
+          }]
+     }
 ]
 
 # VM's to create/delete
@@ -150,12 +173,9 @@ vms = [
 ]
 
 routers = [
-    {
-        'router': {
-            'external_gateway_info': {
-                'network_id': 'shared_net'},
-            'name': 'ext_router',
-            'admin_state_up': True}}
+    {'router': {'external_gateway_info': {}, 'name': 'ext_router',
+                'admin_state_up': True}
+     }
 ]
 
 # VM's snapshots to create/delete

--- a/devlab/tests/functional_test.py
+++ b/devlab/tests/functional_test.py
@@ -50,10 +50,15 @@ class FunctionalTest(unittest.TestCase):
     # 'name' parameter in it's detail.
     # Implimentation of Subnet filtering for no name subnets is still needed.
     def filter_subnets(self):
-        subnets = [i['name'] for i in config.subnets]
-        for i in config.tenants:
-            if 'subnets' in i:
-                for subnet in i['subnets']:
+        subnets = [i['name'] for net in config.networks if net.get('subnets')
+                   for i in net['subnets']]
+        for tenant in config.tenants:
+            if 'networks' not in tenant:
+                continue
+            for network in tenant['networks']:
+                if 'subnets' not in network:
+                    continue
+                for subnet in network['subnets']:
                     subnets.append(subnet['name'])
         return self._get_neutron_resources('subnets', subnets)
 

--- a/devlab/tests/generate_load.py
+++ b/devlab/tests/generate_load.py
@@ -403,56 +403,65 @@ class Prerequisites(object):
             snp_ids.append(snp.id)
         wait_until_vm_snapshots_created(snp_ids)
 
-    def create_networks(self, network_list, subnet_list):
-        ext_router_id = self.get_router_id('ext_router')
-        for network, subnet in zip(network_list, subnet_list):
-            if network.get('router:external'):
-                continue
-            net = self.neutronclient.create_network({'network': network})
-            subnet['network_id'] = net['network']['id']
-            subnet = self.neutronclient.create_subnet({'subnet': subnet})
-            self.neutronclient.add_interface_router(
-                ext_router_id, {"subnet_id": subnet['subnet']['id']})
+    def create_networks(self, networks):
 
-    def create_router(self, router_list):
-        for router in router_list:
-            router['router']['external_gateway_info']['network_id'] = \
-                self.get_net_id(
-                    router['router']['external_gateway_info']['network_id'])
+        def get_body_for_network_creating(_net):
+            # Possible parameters for network creating
+            params = ['name', 'admin_state_up', 'shared', 'router:external',
+                      'provider:network_type', 'provider:segmentation_id',
+                      'provider:physical_network']
+            return {param: _net[param] for param in params if param in _net}
+
+        def get_body_for_subnet_creating(_subnet):
+            # Possible parameters for subnet creating
+            params = ['name', 'cidr', 'allocation_pools', 'dns_nameservers',
+                      'host_routes', 'ip_version', 'network_id']
+            return {param: _subnet[param] for param in params
+                    if param in _subnet}
+
+        for network in networks:
+            net = self.neutronclient.create_network(
+                {'network': get_body_for_network_creating(network)})
+            for subnet in network['subnets']:
+                subnet['network_id'] = net['network']['id']
+                _subnet = self.neutronclient.create_subnet(
+                    {'subnet': get_body_for_subnet_creating(subnet)})
+                if not subnet.get('routers_to_connect'):
+                    continue
+                # If network has attribute routers_to_connect, interface to
+                # this network is crated for given router, in case when network
+                # is internal and gateway set if - external.
+                for router in subnet['routers_to_connect']:
+                    router_id = self.get_router_id(router)
+                    if network.get('router:external'):
+                        self.neutronclient.add_gateway_router(
+                            router_id, {"network_id": net['network']['id']})
+                    else:
+                        self.neutronclient.add_interface_router(
+                            router_id, {"subnet_id": _subnet['subnet']['id']})
+
+    def create_routers(self):
+        for router in self.config.routers:
             self.neutronclient.create_router(router)
 
-    def create_external_network(self):
-        for network in self.config.networks:
-            if network.get('router:external'):
-                net = self.neutronclient.create_network({'network': network})
-                break
-        else:
-            raise RuntimeError('Please specify external network in config.py')
-        for subnet in self.config.subnets:
-            if subnet.get('name') == 'external_subnet':
-                subnet['network_id'] = net['network']['id']
-                self.neutronclient.create_subnet({'subnet': subnet})
-                break
-        else:
-            raise RuntimeError('Please specify subnet for external network in '
-                               'config.py (make sure subnet has field '
-                               '"name": "external_subnet").')
-        return net['network']['id']
-
     def create_all_networking(self):
-        self.ext_net_id = self.create_external_network()
-        self.create_router(self.config.routers)
-        self.create_networks(self.config.networks, self.config.subnets)
+        self.create_routers()
+        self.create_networks(self.config.networks)
+        # Getting ip address for real network. This networks will be used to
+        # allocation floating ips.
+        self.ext_net_id = self.get_net_id(
+            [n['name'] for n in self.config.networks
+             if n.get('real_network')][0])
         for tenant in self.config.tenants:
             if tenant.get('networks'):
                 self.switch_user(user=self.username, password=self.password,
                                  tenant=tenant['name'])
-                self.create_networks(tenant['networks'], tenant['subnets'])
-            if tenant.get('unassociated_fip'):
-                for i in range(tenant['unassociated_fip']):
-                    self.neutronclient.create_floatingip(
-                        {"floatingip": {"floating_network_id": self.ext_net_id}
-                         })
+                self.create_networks(tenant['networks'])
+            if not tenant.get('unassociated_fip'):
+                continue
+            for i in range(tenant['unassociated_fip']):
+                self.neutronclient.create_floatingip(
+                    {"floatingip": {"floating_network_id": self.ext_net_id}})
         self.switch_user(user=self.username, password=self.password,
                          tenant=self.tenant)
 


### PR DESCRIPTION
    Refactored 'create_networks' method in generate load. Now 'subnet'
is not separate parameter in config, it attribute of 'networks'.
This change allows create few subnets for network.
    Removed hardcode name of external network and subnet. Attribute of
network 'real_network' is used for specifying real network. This fix
allows create more than one external netoworks.