### PR TITLE
SAIC-534 Detach volume from compute

### DIFF
--- a/cloudferrylib/os/actions/detach_used_volumes_via_compute.py
+++ b/cloudferrylib/os/actions/detach_used_volumes_via_compute.py
@@ -40,6 +40,6 @@ class DetachVolumesCompute(action.Action):
                     compute_resource.detach_volume(instance['instance']['id'],
                                                    vol['id'])
                     LOG.debug("Detach volume %s" % vol['id'])
-                    storage_resource.wait_for_status(vol['id'],
-                                                     'available')
+                    storage_resource.wait_for_status(
+                        vol['id'], storage_resource.get_status, 'available')
         return {}


### PR DESCRIPTION
Resolves issue caused by refactoring done for the `wait_for_status`
method. Invalid number of arguments were passed to the method.