### PR TITLE
SAIC-435,436,503,504 Non-filtered image migration

### DIFF
--- a/cloudferrylib/os/actions/convert_compute_to_image.py
+++ b/cloudferrylib/os/actions/convert_compute_to_image.py
@@ -48,6 +48,7 @@ class ConvertComputeToImage(action.Action):
         missing_images = {}
         for instance_id, instance in info[utl.INSTANCES_TYPE].iteritems():
             _instance = instance[utl.INSTANCE_BODY]
+            image_id = None
             if _instance['boot_mode'] == utl.BOOT_FROM_VOLUME:
                 if _instance['volumes']:
                     volume = get_boot_volume(instance)
@@ -57,7 +58,7 @@ class ConvertComputeToImage(action.Action):
                 image_id = _instance['image_id']
             # TODO: Case when image is None
             if image_id:
-                img = image_resource.read_info(image_id=image_id)
+                img = image_resource.get_image_by_id_converted(image_id)
                 img = img[utl.IMAGES_TYPE]
                 if image_id in images_body:
                     images_body[image_id][utl.META_INFO][

--- a/cloudferrylib/os/actions/convert_file.py
+++ b/cloudferrylib/os/actions/convert_file.py
@@ -15,7 +15,7 @@ class ConvertFile(action.Action):
         for instance_id, instance in info[utl.INSTANCES_TYPE].iteritems():
             image_id = \
                 info[INSTANCES][instance_id][utl.INSTANCE_BODY]['image_id']
-            images = image_res.read_info(image_id=image_id)
+            images = image_res.get_image_by_id_converted(image_id=image_id)
             image = images[utl.IMAGES_TYPE][image_id]
             disk_format = image[utl.IMAGE_BODY]['disk_format']
             base_file = "%s/%s" % (cfg.temp, "temp%s_base" % instance_id)

--- a/cloudferrylib/os/actions/convert_volume_to_image.py
+++ b/cloudferrylib/os/actions/convert_volume_to_image.py
@@ -58,7 +58,7 @@ class ConvertVolumeToImage(converter.Converter):
                                            resource_image.get_status,
                                            ACTIVE)
             resource_image.patch_image(resource_image.get_backend(), image_id)
-            image_vol = resource_image.read_info(image_id=image_id)
+            image_vol = resource_image.get_image_by_id_converted(image_id)
             img_new = {
                 utl.IMAGE_BODY: (
                     image_vol[utl.IMAGES_TYPE][image_id][utl.IMAGE_BODY]),

--- a/cloudferrylib/os/actions/pre_transport_instance.py
+++ b/cloudferrylib/os/actions/pre_transport_instance.py
@@ -169,7 +169,7 @@ class PreTransportInstance(action.Action):
         self.merge_file(dst_cloud, base_file, diff_file)
 
         image_res = dst_cloud.resources[utl.IMAGE_RESOURCE]
-        images = image_res.read_info(image_id=image_id)
+        images = image_res.get_image_by_id_converted(image_id=image_id)
         image = images[utl.IMAGE_RESOURCE][utl.IMAGES_TYPE][image_id]
         disk_format = image[utl.IMAGE_BODY]['disk_format']
         if image_res.config.image.convert_to_raw:

--- a/cloudferrylib/os/actions/upload_file_to_image.py
+++ b/cloudferrylib/os/actions/upload_file_to_image.py
@@ -40,7 +40,8 @@ class UploadFileToImage(action.Action):
             image_id = inst_body['image_id']
             base_file = "/tmp/%s" % ("temp%s_base" % instance_id)
             image_name = "%s-image" % instance_id
-            images = img_res.read_info(image_id=image_id)[utl.IMAGES_TYPE]
+            internal_image = img_res.get_image_by_id_converted(image_id)
+            images = internal_image[utl.IMAGES_TYPE]
             image_format = images[image_id][utl.IMAGE_BODY]['disk_format']
             if img_res.config.image.convert_to_raw:
                 image_format = utl.RAW

--- a/cloudferrylib/os/image/filters.py
+++ b/cloudferrylib/os/image/filters.py
@@ -1,0 +1,119 @@
+# Copyright 2015 Mirantis Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Filters for Glance images.
+
+Filtering can be done by user through modifying filter config file. User can
+specify filtered tenant ID and/or filtered image ID. This module keeps logic to
+filter glance images based on user's input.
+
+User can specify the following filtering options for images:
+ - `date`:
+   Filters images not older than date specified. Other filters are ignored in
+   this case;
+ - `image_id`:
+   Filters specified image IDs;
+ - `image_name`:
+   FIXME: image names are not unique.
+   Filters specified image names.
+
+Images filtering logic:
+ - Public images:
+    - MUST migrate regardless of filters config contents;
+ - Private images:
+    - If nothing is specified in filters file all private images MUST migrate;
+    - If tenant is specified, ALL images which belong to this tenant MUST
+      migrate;
+    - If image ID is specified, only images specified MUST migrate.
+"""
+import datetime
+
+from cloudferrylib.utils import filters
+
+
+def _tenant_filtering_enabled(filtered_tenant_id):
+    return filtered_tenant_id is not None
+
+
+def _tenant_filtering_disabled(filtered_tenant_id):
+    return not _tenant_filtering_enabled(filtered_tenant_id)
+
+
+def _image_filtering_enabled(filtered_images):
+    return filtered_images is not None and len(filtered_images) > 0
+
+
+def _image_filtering_disabled(filtered_images):
+    return not _image_filtering_enabled(filtered_images)
+
+
+def tenant_filter(filtered_tenant_id):
+    """Filters images not specified in tenant_id section of filters file"""
+    return lambda i: (i.is_public or
+                      _tenant_filtering_disabled(filtered_tenant_id) or
+                      (_tenant_filtering_enabled(filtered_tenant_id) and
+                          i.owner == filtered_tenant_id))
+
+
+def image_id_filter(filtered_images):
+    """Filters images not specified in image_ids section of filters file"""
+    return lambda i: (i.is_public or
+                      _image_filtering_disabled(filtered_images) or
+                      (_image_filtering_enabled(filtered_images) and
+                          i.id in filtered_images))
+
+
+def member_filter(glance_client, filtered_tenant_id):
+    """Filters images which are shared between multiple tenants using image
+    membership feature (see `glance help member-list`)"""
+    members_present = len(glance_client.image_members.list(
+        member=filtered_tenant_id)) > 0
+    return lambda i: (
+        i.is_public or
+        _tenant_filtering_disabled(filtered_tenant_id) or
+        not members_present or
+        _tenant_filtering_enabled(filtered_tenant_id) and
+        i.owner in glance_client.image_members.list(image=i,
+                                                    member=filtered_tenant_id))
+
+
+def datetime_filter(filtered_tenant_id, date):
+    """Filters images not older than :arg date:"""
+    return lambda i: (
+        i.is_public or
+        i.is_snapshot or
+        _tenant_filtering_disabled(filtered_tenant_id) and
+        date <= datetime.datetime.strptime(i.updated_at, "%Y-%m-%dT%H:%M:%S"))
+
+
+class GlanceFilters(filters.CFFilters):
+    """Builds required filters based on filter configuration file"""
+
+    def __init__(self, glance_client, filter_yaml):
+        super(GlanceFilters, self).__init__(filter_yaml)
+        self.glance_client = glance_client
+
+    def get_filters(self):
+        if self.filter_yaml.get_image_date() is not None:
+            return [
+                datetime_filter(self.filter_yaml.get_tenant(),
+                                self.filter_yaml.get_image_date())
+            ]
+
+        return [
+            member_filter(self.glance_client,
+                          self.filter_yaml.get_tenant()),
+            tenant_filter(self.filter_yaml.get_tenant()),
+            image_id_filter(self.filter_yaml.get_image_ids())
+        ]

--- a/cloudferrylib/utils/filters.py
+++ b/cloudferrylib/utils/filters.py
@@ -1,0 +1,73 @@
+# Copyright 2015 Mirantis Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import abc
+import yaml
+
+
+class FilterYaml(object):
+    """Keeps contents of filter.yaml config file"""
+
+    def __init__(self, filter_yaml_stream):
+        self._file = filter_yaml_stream
+        self._filter_yaml = None
+
+    def read(self):
+        self._filter_yaml = yaml.load(self._file) or {}
+        return self._filter_yaml
+
+    def get_filter_yaml(self):
+        if self._filter_yaml is None:
+            self.read()
+        return self._filter_yaml
+
+    def get_tenant(self):
+        fy = self.get_filter_yaml()
+        tenants = fy.get('tenants', {})
+        return tenants.get('tenant_id', [None])[0]
+
+    def get_image_ids(self):
+        fy = self.get_filter_yaml()
+        images = fy.get('images', {})
+        return images.get('images_list', [])
+
+    def get_instance_ids(self):
+        fy = self.get_filter_yaml()
+        instances = fy.get('instances', {})
+        return instances.get('id', [])
+
+    def get_image_date(self):
+        # TODO: verify date filtering original functionality
+        fy = self.get_filter_yaml()
+        images = fy.get('images', {})
+        return images.get('date')
+
+
+class CFFilters(object):
+    """Base class for filter methods"""
+
+    __metaclass__ = abc.ABCMeta
+
+    def __init__(self, filter_yaml):
+        """
+        :arg filter_yaml: `FilterYaml` object
+        """
+        self.filter_yaml = filter_yaml
+
+    @abc.abstractmethod
+    def get_filters(self):
+        """Returns list of callable objects which can be supplied to a
+        standard filter() method."""
+
+        raise NotImplementedError()

--- a/tests/cloudferrylib/os/actions/test_converter_volume_to_image.py
+++ b/tests/cloudferrylib/os/actions/test_converter_volume_to_image.py
@@ -32,8 +32,8 @@ class ConverterVolumeToImageTest(test.TestCase):
         self.fake_storage.get_backend.return_value = 'ceph'
         self.fake_image = mock.Mock()
         self.fake_image.wait_for_status = mock.Mock()
-        self.fake_image.read_info = mock.Mock()
-        self.fake_image.read_info.return_value = {
+        self.fake_image.get_image_by_id_converted = mock.Mock()
+        self.fake_image.get_image_by_id_converted.return_value = {
             'images': {
                 'image_id': {'image': 'image_body', 'meta': {}}}}
         self.fake_image.patch_image = mock.Mock()

--- a/tests/cloudferrylib/os/image/test_image_filters.py
+++ b/tests/cloudferrylib/os/image/test_image_filters.py
@@ -1,0 +1,104 @@
+# Copyright 2015 Mirantis Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import mock
+from cloudferrylib.os.image import filters
+
+from tests import test
+
+
+DONT_CARE = mock.Mock()
+
+
+def _image(uuid=DONT_CARE, tenant=DONT_CARE, is_public=True):
+    image = mock.Mock()
+    image.is_public = is_public
+    image.id = uuid
+    image.owner = tenant
+    return image
+
+
+class GlanceImageFilterTestCase(test.TestCase):
+    def test_public_images_are_always_kept(self):
+        num_public = 10
+        num_private = 5
+
+        images = (_image(is_public=i < num_public)
+                  for i in xrange(num_public + num_private))
+
+        filter_yaml = mock.Mock()
+        filter_yaml.get_tenant.return_value = "some-other-tenant"
+        filter_yaml.get_image_ids.return_value = []
+        filter_yaml.get_image_date.return_value = None
+
+        glance_filters = filters.GlanceFilters(glance_client=mock.MagicMock(),
+                                               filter_yaml=filter_yaml)
+
+        fs = glance_filters.get_filters()
+
+        for f in fs:
+            images = filter(f, images)
+
+        self.assertEqual(len(images), num_public)
+
+    def test_keeps_private_image_if_filtered_image_ids_not_set(self):
+        num_private = 5
+        num_public = 10
+        total = num_private + num_public
+        expected_ids = (i for i in xrange(num_private))
+        images = [_image(is_public=False, uuid=i) for i in expected_ids]
+        images.extend([_image(is_public=True, uuid=i)
+                       for i in xrange(num_private, total)])
+
+        filter_yaml = mock.Mock()
+        filter_yaml.get_tenant.return_value = None
+        filter_yaml.get_image_ids.return_value = []
+        filter_yaml.get_image_date.return_value = None
+
+        glance_filters = filters.GlanceFilters(glance_client=mock.MagicMock(),
+                                               filter_yaml=filter_yaml)
+
+        fs = glance_filters.get_filters()
+
+        for f in fs:
+            images = filter(f, images)
+
+        self.assertEqual(len(images), total)
+        self.assertTrue([i.id in expected_ids for i in images])
+
+    def test_image_not_filtered_if_not_belongs_to_filtered_tenant(self):
+        t1_image_id = 't1_image_id'
+        t2_image_id = 't2_image_id'
+
+        t1_image = _image(tenant="t1", uuid=t1_image_id, is_public=False)
+        t2_image = _image(tenant="t2", uuid=t2_image_id, is_public=False)
+
+        filter_yaml = mock.Mock()
+        filter_yaml.get_tenant.return_value = "some other tenant"
+        filter_yaml.get_image_ids.return_value = []
+        filter_yaml.get_image_date.return_value = None
+
+        images = [t1_image, t2_image]
+
+        glance_filters = filters.GlanceFilters(glance_client=mock.MagicMock(),
+                                               filter_yaml=filter_yaml)
+        fs = glance_filters.get_filters()
+
+        for f in fs:
+            images = filter(f, images)
+
+        image_ids = [i.id for i in images]
+
+        self.assertNotIn(t1_image_id, image_ids)
+        self.assertNotIn(t2_image_id, image_ids)

--- a/tests/cloudferrylib/utils/test_filters.py
+++ b/tests/cloudferrylib/utils/test_filters.py
@@ -1,0 +1,118 @@
+# Copyright 2015 Mirantis Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import mock
+import datetime
+
+from cloudferrylib.utils import filters
+from tests import test
+
+
+class BaseCFFiltersTestCase(test.TestCase):
+    def test_base_class_has_get_filters_method(self):
+        self.assertTrue(callable(filters.CFFilters.get_filters))
+
+    def test_cannot_create_object_of_filters(self):
+        self.assertRaises(TypeError, filters.CFFilters)
+
+
+class FilterYamlTestCase(test.TestCase):
+    @mock.patch("cloudferrylib.utils.filters.yaml.load")
+    def test_reads_config_on_first_use(self, yaml_load):
+        fy_stream = mock.Mock()
+        fy = filters.FilterYaml(fy_stream)
+        self.assertFalse(yaml_load.called)
+
+        fy.get_filter_yaml()
+        self.assertTrue(yaml_load.called)
+
+    def test_returns_empty_dict_if_filter_conf_is_empty(self):
+        filters_file = u""
+        fy = filters.FilterYaml(filters_file)
+        self.assertEqual(dict(), fy.get_filter_yaml())
+
+    def test_returns_none_if_no_tenant_provided(self):
+        filters_file = u""
+        fy = filters.FilterYaml(filters_file)
+        self.assertIsNone(fy.get_tenant())
+
+    def test_returns_empty_list_if_nothing_in_image_ids(self):
+        filters_file = u""
+        fy = filters.FilterYaml(filters_file)
+        self.assertEqual(list(), fy.get_image_ids())
+
+    def test_returns_empty_list_if_nothing_in_instance_ids(self):
+        filters_file = u""
+        fy = filters.FilterYaml(filters_file)
+        self.assertEqual(list(), fy.get_instance_ids())
+
+    def test_returns_tenant_id_if_provided(self):
+        tenant_id = 'some-tenant'
+        filters_file = u"""
+        tenants:
+            tenant_id:
+                - {tenant_id}
+        """.format(tenant_id=tenant_id)
+        fy = filters.FilterYaml(filters_file)
+        self.assertEqual(tenant_id, fy.get_tenant())
+
+    def test_returns_instances_from_instance_ids(self):
+        instance1 = 'inst1'
+        instance2 = 'inst2'
+        filters_file = u"""
+        instances:
+            id:
+                - {instance1}
+                - {instance2}
+        """.format(instance1=instance1, instance2=instance2)
+
+        fy = filters.FilterYaml(filters_file)
+        filtered_instances = fy.get_instance_ids()
+
+        self.assertTrue(isinstance(filtered_instances, list))
+        self.assertIn(instance1, filtered_instances)
+        self.assertIn(instance2, filtered_instances)
+
+    def test_returns_images_from_image_ids(self):
+        image1 = 'image1'
+        image2 = 'image2'
+        filters_file = u"""
+        images:
+            images_list:
+                - {image1}
+                - {image2}
+        """.format(image1=image1, image2=image2)
+
+        fy = filters.FilterYaml(filters_file)
+        filtered_images = fy.get_image_ids()
+
+        self.assertTrue(isinstance(filtered_images, list))
+        self.assertIn(image1, filtered_images)
+        self.assertIn(image2, filtered_images)
+
+    def test_date_returns_none_if_not_specified(self):
+        filters_file = u""
+        fy = filters.FilterYaml(filters_file)
+        self.assertIsNone(fy.get_image_date())
+
+    def test_date_filter_returns_datetime_object(self):
+        filters_file = u"""
+        images:
+            date: 2000-01-01
+        """
+
+        fy = filters.FilterYaml(filters_file)
+
+        filtered_date = fy.get_image_date()
+        self.assertTrue(isinstance(filtered_date, datetime.date))


### PR DESCRIPTION
When migration is filtered by tenant, only filtered tenant migrated
originally.  Glance images which belong to tenants which are not
specified in filter were not migrated and this caused glance image
migration. This patch resolves this issue and refactors filter logic
separating it from migration.