### PR TITLE
upgrade of python-cinderclient version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ oslo.utils==1.9.0
 pika==0.9.14
 progressbar==2.3
 pycrypto
-python-cinderclient==1.0.9
+python-cinderclient==1.1.0
 python-glanceclient==0.12.0
 python-keystoneclient==1.6.0
 python-neutronclient==2.3.4


### PR DESCRIPTION
Python-cinderclient has updated from 1.0.9 to 1.1.0
version to have an ability to change bootable flag of volume.
__patch_option_bootable_of_volume, which uses mysqlconnector
replaced by api call