### PR TITLE
SAIC-540 Floating IP allocated in different external networks

### DIFF
--- a/cloudferrylib/base/resource.py
+++ b/cloudferrylib/base/resource.py
@@ -41,6 +41,11 @@ class Resource(object):
     def restore(self):
         pass
 
+    def required_tenants(self):
+        """Returns list of tenants required by resource. Important for the
+        filtering feature."""
+        return []
+
     def wait_for_status(self, res_id, get_status, wait_status, timeout=60):
         delay = 1
         while delay < timeout:

--- a/cloudferrylib/os/image/glance_image.py
+++ b/cloudferrylib/os/image/glance_image.py
@@ -95,6 +95,14 @@ class GlanceImage(image.Image):
             endpoint=endpoint_glance,
             token=self.identity_client.get_auth_token_from_user())
 
+    def required_tenants(self):
+        image_owners = set()
+
+        for i in self.get_image_list():
+            image_owners.add(i.owner)
+
+        return list(image_owners)
+
     def get_image_list(self):
         images = self.glance_client.images.list(filters={"is_public": None})
 

--- a/cloudferrylib/utils/cache.py
+++ b/cloudferrylib/utils/cache.py
@@ -1,0 +1,83 @@
+# Copyright 2015 Mirantis Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import collections
+import functools
+
+
+class Memoized(object):
+    """Decorator. Caches a function's return value each time it is called.
+   If called later with the same arguments, the cached value is returned
+   (not reevaluated).
+
+   Does not support key-value arguments.
+
+   Taken from https://wiki.python.org/moin/PythonDecoratorLibrary#Memoize
+   """
+
+    def __init__(self, func):
+        self.func = func
+        self.cache = {}
+
+    def __call__(self, *args):
+        if not isinstance(args, collections.Hashable):
+            # uncacheable. a list, for instance.
+            # better to not cache than blow up.
+            return self.func(*args)
+        if args in self.cache:
+            return self.cache[args]
+        else:
+            value = self.func(*args)
+            self.cache[args] = value
+            return value
+
+    def reset(self):
+        self.cache = {}
+
+    def __repr__(self):
+        """Return the function's docstring."""
+        return self.func.__doc__
+
+    def __get__(self, obj, objtype):
+        """Support instance methods."""
+        return functools.partial(self.__call__, obj)
+
+
+class Cached(object):
+    """Property. Modifies class methods at runtime by caching results.
+
+    `getter` - cached method;
+    `modifier` - method which modifies cached values. Calling this method
+    resets cache.
+    """
+
+    def __init__(self, getter, modifier):
+        self.getter = getter
+        self.modifier = modifier
+        self.cacher = None
+
+    def __call__(self, cls):
+        getter = getattr(cls, self.getter)
+        cached_getter = Memoized(getter)
+        setattr(cls, self.getter, cached_getter)
+
+        modifier = getattr(cls, self.modifier)
+
+        def mod(*args, **kwargs):
+            cached_getter.reset()
+            return modifier(*args, **kwargs)
+
+        setattr(cls, self.modifier, mod)
+
+        return cls

--- a/tests/cloudferrylib/os/identity/test_keystone.py
+++ b/tests/cloudferrylib/os/identity/test_keystone.py
@@ -132,13 +132,6 @@ class KeystoneIdentityTestCase(test.TestCase):
 
         self.assertIsNone(tenant)
 
-    def test_get_tenant_by_id(self):
-        self.mock_client().tenants.get.return_value = self.fake_tenant_0
-
-        tenant = self.keystone_client.get_tenant_by_id('tenant_id_0')
-
-        self.assertEqual(self.fake_tenant_0, tenant)
-
     def test_get_users_list(self):
         fake_users_list = [self.fake_user_0, self.fake_user_1]
         self.mock_client().users.list.return_value = fake_users_list

--- a/tests/cloudferrylib/os/network/test_neutron.py
+++ b/tests/cloudferrylib/os/network/test_neutron.py
@@ -76,7 +76,7 @@ class NeutronTestCase(test.TestCase):
                            'shared': False,
                            'tenant_id': 'fake_tenant_id_1',
                            'tenant_name': 'fake_tenant_name_1',
-                           'subnet_names': ['fake_subnet_name_1'],
+                           'subnets': [mock.MagicMock()],
                            'router:external': False,
                            'provider:physical_network': None,
                            'provider:network_type': 'gre',
@@ -201,9 +201,8 @@ class NeutronTestCase(test.TestCase):
         self.assertDictEqual(res5, {})
 
     def test_get_networks(self):
-
         fake_networks_list = {'networks': [{'status': 'ACTIVE',
-                                            'subnets': ['fake_subnet_id_1'],
+                                            'subnets': [mock.ANY],
                                             'name': 'fake_network_name_1',
                                             'provider:physical_network': None,
                                             'admin_state_up': True,
@@ -223,6 +222,7 @@ class NeutronTestCase(test.TestCase):
 
         networks_info = [self.net_1_info]
         networks_info_result = self.neutron_network_client.get_networks()
+        networks_info_result[0]['subnets'] = [mock.ANY]
         self.assertEquals(networks_info, networks_info_result)
 
     def test_get_subnets(self):
@@ -529,42 +529,6 @@ class NeutronTestCase(test.TestCase):
         if network_info['network']['provider:physical_network']:
             self.neutron_mock_client().create_network.\
                 assert_called_once_with(network_info)
-
-    def test_upload_subnets(self):
-
-        src_net_info = copy.deepcopy(self.net_1_info)
-        src_net_info['subnet_names'].append('fake_subnet_name_2')
-
-        dst_net_info = self.net_1_info
-
-        subnet1_info = self.subnet_1_info
-
-        subnet2_info = copy.deepcopy(self.subnet_2_info)
-        subnet2_info['network_name'] = 'fake_network_name_1'
-        subnet2_info['network_id'] = 'fake_network_id_1'
-        subnet2_info['tenant_name'] = 'fake_tenant_name_1'
-
-        self.neutron_network_client.get_networks = \
-            mock.Mock(return_value=[dst_net_info])
-        self.neutron_network_client.get_subnets = \
-            mock.Mock(return_value=[{'res_hash': 'fake_subnet_hash_1'}])
-
-        subnet_info = {
-            'subnet': {'name': 'fake_subnet_name_2',
-                       'enable_dhcp': True,
-                       'network_id': 'fake_network_id_1',
-                       'cidr': 'fake_cidr_2',
-                       'allocation_pools': [{'start': 'fake_start_ip_2',
-                                             'end': 'fake_end_ip_2'}],
-                       'gateway_ip': 'fake_gateway_ip_2',
-                       'ip_version': 4,
-                       'tenant_id': 'fake_tenant_id_1'}}
-
-        self.neutron_network_client.upload_subnets([src_net_info],
-                                                   [subnet1_info,
-                                                    subnet2_info])
-        self.neutron_mock_client().create_subnet.\
-            assert_called_once_with(subnet_info)
 
     def test_upload_routers(self):
 

--- a/tests/cloudferrylib/utils/test_cache.py
+++ b/tests/cloudferrylib/utils/test_cache.py
@@ -1,0 +1,72 @@
+# Copyright 2015 Mirantis Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from cloudferrylib.utils.cache import Memoized, Cached
+
+from tests import test
+
+
+class MemoizationTestCase(test.TestCase):
+    def test_treats_self_as_separate_objects(self):
+        class C(object):
+            def __init__(self, i):
+                self.i = i
+
+            @Memoized
+            def get_i(self):
+                return self.i
+
+        o1 = C(1)
+        o2 = C(2)
+
+        self.assertNotEqual(o1.get_i(), o2.get_i())
+        self.assertEqual(o1.get_i(), 1)
+        self.assertEqual(o2.get_i(), 2)
+
+    def test_takes_value_from_cache(self):
+        class C(object):
+            def __init__(self, i):
+                self.i = i
+
+            @Memoized
+            def get_i(self):
+                return self.i
+
+            def set_i(self, i):
+                self.i = i
+
+        original = 1
+        o = C(original)
+        self.assertEqual(o.get_i(), original)
+        o.set_i(10)
+        self.assertEqual(o.get_i(), original)
+
+
+class CacheTestCase(test.TestCase):
+    def test_resets_cache_when_modifier_called(self):
+        @Cached(getter='get_i', modifier='set_i')
+        class C(object):
+            def __init__(self, i):
+                self.i = i
+
+            def get_i(self):
+                return self.i
+
+            def set_i(self, i):
+                self.i = i
+
+        o = C(1)
+        self.assertEqual(o.get_i(), 1)
+
+        o.set_i(100)
+        self.assertEqual(o.get_i(), 100)


### PR DESCRIPTION
Previously network migration logic assumed external networks only belong to admin tenant,
which is not the case for the most production environments. This patch adds support for
floating IPs allocated in external networks which belong to different tenants.