### PR TITLE
[SAIC-481] Fix Floating IPs filtering

### DIFF
--- a/cloudferrylib/os/network/neutron.py
+++ b/cloudferrylib/os/network/neutron.py
@@ -1236,12 +1236,6 @@ class NeutronNetwork(network.Network):
                 tenant = self.identity_client.keystone_client.tenants.find(
                     name=fip['tenant_name'])
 
-                if self.filter_tenant_id and \
-                        (self.filter_tenant_id != tenant.id):
-                    LOG.info("Skipping floating IP '%s' based on filter rules",
-                             fip['floating_ip_address'])
-                    continue
-
                 new_fip = {
                     'floatingip': {
                         'floating_network_id': ext_net_id,


### PR DESCRIPTION
Remove redudant and bugs-forming check in the `upload_floatingips`
method of `NeutronNetwork` resource. There are two reasons for it:
 1. We have wrong tenant id to compare (we try to compare tenant_id
    from source with tenant_id on dest and of course they are different,
    because we do not migrate original tenants IDs);
 2. We already performed this filtering, when obtained information about
    migrated Neutron items (filtering has been already done in the
    `read_info` method, so we do not need to do this twice).