### PR TITLE
Removes unnecessary paramiko debug logs from tests

### DIFF
--- a/devlab/tests/functional_test.py
+++ b/devlab/tests/functional_test.py
@@ -34,7 +34,8 @@ def suppress_dependency_logging():
                        'keystoneclient.session',
                        'neutronclient.client',
                        'requests.packages.urllib3.connectionpool',
-                       'glanceclient.common.http']
+                       'glanceclient.common.http',
+                       'paramiko.transport']
 
     for l in suppressed_logs:
         logging.getLogger(l).setLevel(logging.WARNING)


### PR DESCRIPTION
Drops `paramiko.transport` debug logs when functional tests are run.
These have no value to the user and only complicate funtional test
failures.