### PR TITLE
change of keystone client authorization logic

### DIFF
--- a/cloudferrylib/os/identity/keystone.py
+++ b/cloudferrylib/os/identity/keystone.py
@@ -106,7 +106,7 @@ class KeystoneIdentity(identity.Identity):
 
     @property
     def keystone_client(self):
-        return self.proxy(self._get_client_by_creds(), self.config)
+        return self.proxy(self.get_client(), self.config)
 
     @staticmethod
     def convert(identity_obj, cfg):
@@ -212,7 +212,12 @@ class KeystoneIdentity(identity.Identity):
         :return: OpenStack Keystone Client instance
         """
 
-        return self.keystone_client
+        auth_ref = self._get_client_by_creds().auth_ref
+
+        return keystone_client.Client(auth_ref=auth_ref,
+                                      endpoint=self.config.cloud.auth_url,
+                                      cacert=self.config.cloud.cacert,
+                                      insecure=self.config.cloud.insecure)
 
     def _get_client_by_creds(self):
         """Authenticating with a user name and password.

--- a/tests/cloudferrylib/os/identity/test_keystone.py
+++ b/tests/cloudferrylib/os/identity/test_keystone.py
@@ -452,7 +452,7 @@ class KeystoneClientTestCase(test.TestCase):
         config.cloud.cacert = cacert
 
         ks = keystone.KeystoneIdentity(config, cloud)
-        ks.get_client()
+        ks._get_client_by_creds()
 
         ks_client.assert_called_with(
             region_name=region,
@@ -484,7 +484,7 @@ class KeystoneClientTestCase(test.TestCase):
         config.cloud.cacert = cacert
 
         ks = keystone.KeystoneIdentity(config, cloud)
-        ks.get_client()
+        ks._get_client_by_creds()
 
         ks_client.assert_called_with(
             tenant_name=tenant,


### PR DESCRIPTION
When we get keystoneclient instance using only user/pass credentials, during further operations keystone client will use internal endpoint for API requests. This way we need to have an access internal cloud network from CF host and it brake initial conceptions of CF tool 'use only public network'. This fix adds additional authorization of keystone client using token and endpoint,which allows us to use some
specific endpoint during API requests.