### PR TITLE
Fixed keypair filtering in func tests

### DIFF
--- a/cloudferrylib/os/network/neutron.py
+++ b/cloudferrylib/os/network/neutron.py
@@ -1019,8 +1019,6 @@ class NeutronNetwork(network.Network):
         LOG.info("Creating networks on destination")
 
         existing_networks = self.get_networks()
-        existing_nets_hashlist = (
-            [ex_net['res_hash'] for ex_net in existing_networks])
 
         # we need to handle duplicates in segmentation ids
         # hash is used with structure {"gre": [1, 2, ...],

--- a/devlab/tests/functional_test.py
+++ b/devlab/tests/functional_test.py
@@ -115,8 +115,8 @@ class FunctionalTest(unittest.TestCase):
         for user in config.users:
             if user.get('deleted'):
                 continue
-            if self._tenant_exists(user.get('tenant')) or\
-                    self._user_has_not_primary_tenants(user['name']):
+            if self.src_cloud.tenant_exists(user.get('tenant')) or\
+                    self.src_cloud.user_has_not_primary_tenants(user['name']):
                 users.append(user['name'])
         return self._get_keystone_resources('users', users)
 
@@ -142,8 +142,7 @@ class FunctionalTest(unittest.TestCase):
         return self._get_nova_resources('flavors', flavors)
 
     def filter_keypairs(self):
-        keypairs = [i['name'] for i in config.keypairs]
-        return self._get_nova_resources('keypairs', keypairs)
+        return self.src_cloud.get_users_keypairs()
 
     def filter_security_groups(self):
         sgs = [sg['name'] for i in config.tenants if 'security_groups' in i
@@ -182,21 +181,6 @@ class FunctionalTest(unittest.TestCase):
         client = getattr(self.src_cloud.keystoneclient, res)
         return [i for i in client.list()
                 if i.name in names]
-
-    def _tenant_exists(self, tenant_name):
-        try:
-            self.src_cloud.get_tenant_id(tenant_name)
-            return True
-        except NotFound:
-            return False
-
-    def _user_has_not_primary_tenants(self, user_name):
-        user_id = self.src_cloud.get_user_id(user_name)
-        for tenant in self.src_cloud.keystoneclient.tenants.list():
-            if self.src_cloud.keystoneclient.roles.roles_for_user(
-                    user=user_id, tenant=tenant.id):
-                return True
-        return False
 
     def get_vms_with_fip_associated(self):
         vms = config.vms

--- a/devlab/tests/test_resource_migration.py
+++ b/devlab/tests/test_resource_migration.py
@@ -111,7 +111,7 @@ class ResourceMigrationTests(functional_test.FunctionalTest):
 
     def test_migrate_nova_keypairs(self):
         src_keypairs = self.filter_keypairs()
-        dst_keypairs = self.dst_cloud.novaclient.keypairs.list()
+        dst_keypairs = self.dst_cloud.get_users_keypairs()
 
         self.validate_resource_parameter_in_dst(src_keypairs, dst_keypairs,
                                                 resource_name='keypair',


### PR DESCRIPTION
To get all keypairs, which were created via generate_load.py,
method get_users_keypairs logins under each valid user,
which were created by generate_load.py and takes keypairs.list().
For dst clould, users passords updates according to config.py
(because user passwords migrate not correctly)