### PR TITLE
Resolves all flake8 issues, including F401 and F403

### DIFF
--- a/cloud/__init__.py
+++ b/cloud/__init__.py
@@ -1,3 +1,0 @@
-import cloud
-import cloud_ferry
-import os2os

--- a/cloud/cloud_ferry.py
+++ b/cloud/cloud_ferry.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and#
 # limitations under the License.
 
+import importlib
+
 
 class CloudFerry(object):
     def __new__(cls, config):
@@ -25,7 +27,8 @@ class CloudFerry(object):
             # And specify it there for first time? It can be directly names of
             # classes or any human readable mapping. And later some day
             # implement smth like auto discovering, if it will be needed
-            return __import__('cloud').os2os.OS2OSFerry(config)
+            os2os = importlib.import_module('cloud.os2os')
+            return os2os.OS2OSFerry(config)
 
         return super(CloudFerry, cls).__new__(cls)
 

--- a/cloudferrylib/os/actions/convert_file.py
+++ b/cloudferrylib/os/actions/convert_file.py
@@ -1,6 +1,6 @@
 from fabric.api import run, settings, env
 from cloudferrylib.base.action import action
-from cloudferrylib.utils import forward_agent
+from cloudferrylib.utils.utils import forward_agent
 from cloudferrylib.utils import utils as utl
 
 INSTANCES = 'instances'

--- a/cloudferrylib/os/actions/convert_image_to_file.py
+++ b/cloudferrylib/os/actions/convert_image_to_file.py
@@ -1,7 +1,7 @@
 from fabric.api import run, settings, env
 from cloudferrylib.base import image
 from cloudferrylib.base.action import action
-from cloudferrylib.utils import forward_agent
+from cloudferrylib.utils.utils import forward_agent
 
 
 class ConvertImageToFile(action.Action):

--- a/cloudferrylib/os/actions/load_compute_image_to_file.py
+++ b/cloudferrylib/os/actions/load_compute_image_to_file.py
@@ -3,7 +3,7 @@
 from fabric.api import run, settings, env
 from cloudferrylib.base import image
 from cloudferrylib.base.action import action
-from cloudferrylib.utils import forward_agent
+from cloudferrylib.utils.utils import forward_agent
 from cloudferrylib.utils import utils as utl
 
 INSTANCES = 'instances'

--- a/cloudferrylib/os/actions/pre_transport_instance.py
+++ b/cloudferrylib/os/actions/pre_transport_instance.py
@@ -23,12 +23,12 @@ from cloudferrylib.base.action import action
 from cloudferrylib.os.actions import convert_file_to_image
 from cloudferrylib.os.actions import convert_image_to_file
 from cloudferrylib.os.actions import task_transfer
-from cloudferrylib.utils import utils as utl, forward_agent
-
+from cloudferrylib.utils import utils as utl
 from cloudferrylib.utils.drivers import ssh_ceph_to_ceph
 from cloudferrylib.utils.drivers import ssh_ceph_to_file
 from cloudferrylib.utils.drivers import ssh_file_to_file
 from cloudferrylib.utils.drivers import ssh_file_to_ceph
+from cloudferrylib.utils.utils import forward_agent
 
 
 CLOUD = 'cloud'

--- a/cloudferrylib/os/actions/transport_ephemeral.py
+++ b/cloudferrylib/os/actions/transport_ephemeral.py
@@ -21,7 +21,7 @@ from fabric.api import settings
 
 from cloudferrylib.base.action import action
 from cloudferrylib.os.actions import task_transfer
-from cloudferrylib.utils import forward_agent
+from cloudferrylib.utils.utils import forward_agent
 from cloudferrylib.utils import utils as utl
 
 

--- a/cloudferrylib/os/actions/verify_vms.py
+++ b/cloudferrylib/os/actions/verify_vms.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from cloudferrylib import utils
+from cloudferrylib.utils import utils
 from cloudferrylib.base import exception
 from cloudferrylib.base.action import action
 

--- a/cloudferrylib/os/identity/keystone.py
+++ b/cloudferrylib/os/identity/keystone.py
@@ -23,9 +23,9 @@ from keystoneclient.v2_0 import client as keystone_client
 import cfglib
 from cloudferrylib.base import identity
 from cloudferrylib.utils.cache import Cached
-from cloudferrylib.utils import GeneratorPassword
-from cloudferrylib.utils import Postman
-from cloudferrylib.utils import Templater
+from cloudferrylib.utils.utils import GeneratorPassword
+from cloudferrylib.utils.utils import Postman
+from cloudferrylib.utils.utils import Templater
 from cloudferrylib.utils import utils as utl
 from sqlalchemy.exc import ProgrammingError
 

--- a/cloudferrylib/os/image/glance_image.py
+++ b/cloudferrylib/os/image/glance_image.py
@@ -83,7 +83,7 @@ class GlanceImage(image.Image):
 
         # we can figure out what version of client to use from url
         # check if we have "v1" or "v2" in the end of url
-        m = re.search("(.*)/v(\d)", endpoint_glance)
+        m = re.search(r"(.*)/v(\d)", endpoint_glance)
         if m:
             endpoint_glance = m.group(1)
             # for now we always use 1 version of client

--- a/cloudferrylib/utils/__init__.py
+++ b/cloudferrylib/utils/__init__.py
@@ -11,7 +11,3 @@
 # implied.
 # See the License for the specific language governing permissions and#
 # limitations under the License.
-
-__author__ = 'mirrorcoder'
-
-from utils import *

--- a/cloudferrylib/utils/remote_runner.py
+++ b/cloudferrylib/utils/remote_runner.py
@@ -17,7 +17,7 @@ from fabric.api import run
 from fabric.api import settings
 
 import cfglib
-from cloudferrylib.utils import forward_agent
+from cloudferrylib.utils.utils import forward_agent
 from cloudferrylib.utils import utils
 
 LOG = utils.get_log(__name__)

--- a/devlab/tests/functional_test.py
+++ b/devlab/tests/functional_test.py
@@ -17,7 +17,7 @@ import logging
 import sys
 import os
 import unittest
-from generate_load import Prerequisites, NotFound
+from generate_load import Prerequisites
 from filtering_utils import FilteringUtils
 
 

--- a/tests/cloud/test_grouping.py
+++ b/tests/cloud/test_grouping.py
@@ -22,7 +22,7 @@ from oslotest import mockpatch
 
 from cloud import cloud
 from cloud import grouping
-from cloudferrylib import utils
+from cloudferrylib.utils import utils
 from tests import test
 
 


### PR DESCRIPTION
Following flake8 errors were ignored previously:
 - F401 - module imported but unused
 - F403 - ‘from module import *’ used; unable to detect undefined names

This patch resolves all these issues.