### PR TITLE
Skips down or disabled hosts

### DIFF
--- a/cfglib.py
+++ b/cfglib.py
@@ -141,10 +141,6 @@ migrate_opts = [
                help='Size of one chunk to transfer via SSH'),
     cfg.StrOpt('group_file_path', default="vm_groups.yaml",
                help='Path to file with the groups of VMs'),
-    cfg.BoolOpt('skip_down_hosts', default=True,
-                help="If set to True, removes unreachable compute hosts from "
-                     "nova hypervisor list. Otherwise migration process fails "
-                     "with unrecoverable error if host is down."),
     cfg.StrOpt('scenario', default='scenario/migrate.yaml',
                help='Path to a scenario file, which holds the whole migration '
                     'procedure. Must be YAML format'),
@@ -668,8 +664,8 @@ def merge_fields(index_pair, fields):
             cfg_for_reg[index_pair][1].append(field)
 
 
-def merge_cfg(cfg):
-    for pair in cfg:
+def merge_cfg(conf):
+    for pair in conf:
         index_pair = find_group(pair[0])
         if index_pair == -1:
             cfg_for_reg.append(pair)

--- a/configs/config.ini
+++ b/configs/config.ini
@@ -129,10 +129,6 @@ group_file_path = configs/grouping_result.yaml
 # Use this in case when OpenStack does not support user quotas (e.g. Grizzly)
 migrate_user_quotas = False
 
-# If set to True removes unreachable compute hosts from `nova hypervisor-list`.
-# Set to False only if you're 100% sure there are no hosts down in the cloud.
-skip_down_hosts = True
-
 # Backend used for doing live migration inside a cloud. Used by evacuation chain.
 # "nova" by default. Other possible option - "cobalt". Raises error in case
 # set to any other value.

--- a/devlab/config.template
+++ b/devlab/config.template
@@ -26,7 +26,6 @@ retry = 5
 migrate_extnets = True
 time_wait = 5
 cinder_migration_strategy = cloudferrylib.os.storage.cinder_database.CinderStorage
-skip_down_hosts = True
 migrate_user_quotas = False
 incloud_live_migration = nova
 ssh_connection_attempts = 3


### PR DESCRIPTION
- Previoulsy only hosts known to nova as 'down' were skipped, with this
  patch hosts which are 'disabled' are also treated as not available for
  migration;
- Removed config option to skip down or disabled hosts, now these hosts
  are always skipped;
- Resolved pylint warnings and errors in files modified.