### PR TITLE
SAIC-628 Glance image filtering for user outside of filtered tenant

### DIFF
--- a/cloudferrylib/os/image/filters.py
+++ b/cloudferrylib/os/image/filters.py
@@ -39,6 +39,7 @@ Images filtering logic:
 """
 import datetime
 
+from cloudferrylib.os.identity import keystone
 from cloudferrylib.utils import filters
 
 


### PR DESCRIPTION
When filtering by tenant is enabled and user specified in migration
config is not member of a filtered tenant, an error occurs when CF tries
to read glance image members belonging to a tenant. This patch provides
resolution to the issue by temporarily adding migration user to filtered
tenant.