### PR TITLE
Removes flavor removal logic from check_needed_compute_resources

### DIFF
--- a/cloudferrylib/os/actions/check_needed_compute_resources.py
+++ b/cloudferrylib/os/actions/check_needed_compute_resources.py
@@ -29,7 +29,6 @@ class CheckNeededComputeResources(action.Action):
         cnt_map = collections.defaultdict(int)
         for instance in objs.values():
             cnt_map[instance['instance']['flavor_id']] += 1
-        self.check_in_use_flavor(objs, info)
         needed_cpu = 0
         needed_ram = 0
         needed_hdd = 0
@@ -55,33 +54,3 @@ class CheckNeededComputeResources(action.Action):
                                            "Have %s %s, needed %s %s." % (
                                                name, have, units, needed,
                                                units))
-
-    def check_in_use_flavor(self, objs, info):
-        # when a flavor is updated, the flavor id will change. If an instance
-        # is in this flavor, it will keep the old flavor id, can not be matched
-        # to existing flavors
-        src_compute = self.src_cloud.resources[utl.COMPUTE_RESOURCE]
-        src_flavor_ids = \
-            [flavor.id for flavor in src_compute.get_flavor_list()]
-        dst_compute = self.dst_cloud.resources[utl.COMPUTE_RESOURCE]
-        dst_flavors = dst_compute.get_flavor_list()
-        for instance in objs.values():
-            inst_flavor_id = instance['instance']['flavor_id']
-            _instance = instance['instance']
-            instance_id = _instance['id']
-            flav_details = \
-                info['instances'][instance_id]['instance']['flav_details']
-            re_create_dst_flavor = False
-            for flavor in dst_flavors:
-                if flavor.name == flav_details['name']:
-                    dst_compute.delete_flavor(flavor.id)
-                    re_create_dst_flavor = True
-            if inst_flavor_id not in src_flavor_ids or re_create_dst_flavor:
-                dst_compute.create_flavor(name=flav_details['name'],
-                                          flavorid=_instance['flavor_id'],
-                                          ram=flav_details['memory_mb'],
-                                          vcpus=flav_details['vcpus'],
-                                          disk=flav_details['root_gb'],
-                                          ephemeral=flav_details[
-                                              'ephemeral_gb'])
-                src_flavor_ids.append(_instance['flavor_id'])

--- a/devlab/tests/scenarios/cold_migrate.yaml
+++ b/devlab/tests/scenarios/cold_migrate.yaml
@@ -30,6 +30,7 @@ preparation:
           - check_dst_rabbit: True
           - act_get_info_objects_dst: False
       - check_networks: True
+  - check_needed_compute_resources: True
   - check_users_availability: False
   - create_snapshot: True
   - create_vm_snapshot_src: True
@@ -61,7 +62,6 @@ process:
       - init_iteration_instance:
           - init_iteration_instance_copy_var: True
           - init_iteration_instance_ref: True
-      - check_needed_compute_resources: True
       - check_instances: ['rename_info_iter']
       - get_next_instance: True
       - trans_one_inst:

--- a/devlab/tests/scenarios/live_migrate.yaml
+++ b/devlab/tests/scenarios/live_migrate.yaml
@@ -31,6 +31,7 @@ preparation:
           - check_dst_rabbit: True
           - act_get_info_objects_dst: False
       - check_networks: True
+  - check_needed_compute_resources: True
   - check_users_availability: False
   - create_snapshot: True
   - create_vm_snapshot_src: True
@@ -63,7 +64,6 @@ process:
       - init_iteration_instance:
           - init_iteration_instance_copy_var: True
           - init_iteration_instance_ref: True
-      - check_needed_compute_resources: True
       - check_instances: ['rename_info_iter']
       - get_next_instance: True
       - trans_one_inst:

--- a/scenario/cold_migrate.yaml
+++ b/scenario/cold_migrate.yaml
@@ -30,6 +30,7 @@ preparation:
           - check_dst_rabbit: True
           - act_get_info_objects_dst: False
       - check_networks: True
+  - check_needed_compute_resources: True
   - check_users_availability: False
   - create_snapshot: True
   - create_vm_snapshot_src: True
@@ -61,7 +62,6 @@ process:
       - init_iteration_instance:
           - init_iteration_instance_copy_var: True
           - init_iteration_instance_ref: True
-      - check_needed_compute_resources: True
       - check_instances: ['rename_info_iter']
       - get_next_instance: True
       - trans_one_inst:

--- a/scenario/live_migrate.yaml
+++ b/scenario/live_migrate.yaml
@@ -31,6 +31,7 @@ preparation:
           - check_dst_rabbit: True
           - act_get_info_objects_dst: False
       - check_networks: True
+  - check_needed_compute_resources: True
   - check_users_availability: False
   - create_snapshot: True
   - create_vm_snapshot_src: True
@@ -63,7 +64,6 @@ process:
       - init_iteration_instance:
           - init_iteration_instance_copy_var: True
           - init_iteration_instance_ref: True
-      - check_needed_compute_resources: True
       - check_instances: ['rename_info_iter']
       - get_next_instance: True
       - trans_one_inst:

--- a/scenario/migrate_vms.yaml
+++ b/scenario/migrate_vms.yaml
@@ -31,6 +31,7 @@ preparation:
           - check_dst_rabbit: True
           - act_get_info_objects_dst: False
       - check_networks: True
+  - check_needed_compute_resources: True
   - create_snapshot: True
   - create_vm_snapshot_src: True
   - create_vm_snapshot_dst: True

--- a/scenario/prechecks.yaml
+++ b/scenario/prechecks.yaml
@@ -28,3 +28,4 @@ preparation:
           - check_dst_sql: True
           - check_dst_rabbit: True
       - check_networks: True
+  - check_needed_compute_resources: True


### PR DESCRIPTION
Flavor operations are handled from the primary compute resource when those
deal with flavors directly. Thus leaving `check_needed_compute_resources` as
a pre-migration check only.