### PR TITLE
[SAIC-565] Network info retreiving optimization

### DIFF
--- a/cloudferrylib/base/network.py
+++ b/cloudferrylib/base/network.py
@@ -24,9 +24,6 @@ class Network(resource.Resource):
     def get_func_mac_address(self, instance):
         raise NotImplemented("it's base class")
 
-    def get_list_ports(self, **kwargs):
-        raise NotImplemented("it's base class")
-
     def create_port(self, net_id, mac, ip, tenant_id, keep_ip, sg_ids=None):
         raise NotImplemented("it's base class")
 

--- a/cloudferrylib/utils/cache.py
+++ b/cloudferrylib/utils/cache.py
@@ -30,7 +30,9 @@ class Memoized(object):
         self.func = func
         self.cache = {}
 
-    def __call__(self, *args):
+    def __call__(self, *args, **kwargs):
+        if kwargs:
+            return self.func(*args, **kwargs)
         if not isinstance(args, collections.Hashable):
             # uncacheable. a list, for instance.
             # better to not cache than blow up.

--- a/configs/config.ini
+++ b/configs/config.ini
@@ -460,6 +460,13 @@ db_user = <neutron_db_user>
 # Database user's password for the Network service. # cat /etc/neutron/neutron.conf | grep mysql
 db_password = <neutron_db_password>
 
+# Get all Neutron network quotas.
+# Default value is False.
+# Values:
+#   False - Get only custom Neutron quotas;
+#   True - Get all Neutron quotas (default and custom)
+get_all_quota = False
+
 
 #==============================================================================
 # Source cloud object storage service (swift) configuration
@@ -561,6 +568,7 @@ db_port = 3306
 db_name = neutron
 db_user = <neutron_db_user>
 db_password = <neutron_db_password>
+get_all_quota = False
 
 
 [dst_objstorage]

--- a/devlab/config.template
+++ b/devlab/config.template
@@ -97,6 +97,7 @@ db_password = <src_mysql_password>
 db_host = <src_ip>
 db_connection = mysql+mysqlconnector
 db_name = quantum
+get_all_quota = False
 
 [src_objstorage]
 service =
@@ -168,6 +169,7 @@ db_password = <dst_mysql_password>
 db_host = <dst_ip>
 db_connection = mysql+mysqlconnector
 db_name = neutron
+get_all_quota = False
 
 [import_rules]
 key = {name:dest-key-1}

--- a/tests/cloudferrylib/os/network/test_neutron.py
+++ b/tests/cloudferrylib/os/network/test_neutron.py
@@ -201,24 +201,38 @@ class NeutronTestCase(test.TestCase):
         self.assertDictEqual(res5, {})
 
     def test_get_networks(self):
-        fake_networks_list = {'networks': [{'status': 'ACTIVE',
-                                            'subnets': [mock.ANY],
-                                            'name': 'fake_network_name_1',
-                                            'provider:physical_network': None,
-                                            'admin_state_up': True,
-                                            'tenant_id': 'fake_tenant_id_1',
-                                            'provider:network_type': 'gre',
-                                            'router:external': False,
-                                            'shared': False,
-                                            'id': 'fake_network_id_1',
-                                            'provider:segmentation_id': 5}]}
+        fake_net_list = {'networks': [{'status': 'ACTIVE',
+                                       'subnets': [mock.ANY],
+                                       'name': 'fake_network_name_1',
+                                       'provider:physical_network': None,
+                                       'admin_state_up': True,
+                                       'tenant_id': 'fake_tenant_id_1',
+                                       'provider:network_type': 'gre',
+                                       'router:external': False,
+                                       'shared': False,
+                                       'id': 'fake_network_id_1',
+                                       'provider:segmentation_id': 5}]}
 
-        self.neutron_mock_client().list_networks.return_value = \
-            fake_networks_list
-        self.neutron_mock_client.show_subnet.return_value = \
-            {'subnet': {'name': 'fake_subnet_name_1'}}
-        self.network_mock.get_resource_hash = \
-            mock.Mock(return_value='fake_net_hash_1')
+        fake_subnet_list = {'subnets': [{'name': 'fake_subnet_name_1',
+                                         'enable_dhcp': True,
+                                         'network_id': 'fake_network_id_1',
+                                         'tenant_id': 'fake_tenant_id_1',
+                                         'allocation_pools': [
+                                             {'start': 'fake_start_ip_1',
+                                              'end': 'fake_end_ip_1'}
+                                         ],
+                                         'host_routes': [],
+                                         'ip_version': 4,
+                                         'gateway_ip': 'fake_gateway_ip_1',
+                                         'cidr': 'fake_cidr_1',
+                                         'id': 'fake_subnet_id_1'}]}
+
+        self.neutron_mock_client().list_networks.return_value = fake_net_list
+        self.neutron_mock_client().list_subnets.return_value = fake_subnet_list
+        self.network_mock.get_networks_list = mock.Mock(
+            return_value=fake_net_list['networks'])
+        self.network_mock.get_resource_hash = mock.Mock(
+            return_value='fake_net_hash_1')
 
         networks_info = [self.net_1_info]
         networks_info_result = self.neutron_network_client.get_networks()
@@ -226,62 +240,76 @@ class NeutronTestCase(test.TestCase):
         self.assertEquals(networks_info, networks_info_result)
 
     def test_get_subnets(self):
+        fake_net_list = {'networks': [{'status': 'ACTIVE',
+                                       'subnets': [mock.ANY],
+                                       'name': 'fake_network_name_1',
+                                       'provider:physical_network': None,
+                                       'admin_state_up': True,
+                                       'tenant_id': 'fake_tenant_id_1',
+                                       'provider:network_type': 'gre',
+                                       'router:external': False,
+                                       'shared': False,
+                                       'id': 'fake_network_id_1',
+                                       'provider:segmentation_id': 5}]}
 
-        fake_subnets_list = {
-            'subnets': [{'name': 'fake_subnet_name_1',
-                         'enable_dhcp': True,
-                         'network_id': 'fake_network_id_1',
-                         'tenant_id': 'fake_tenant_id_1',
-                         'allocation_pools': [
-                             {'start': 'fake_start_ip_1',
-                              'end': 'fake_end_ip_1'}
-                         ],
-                         'host_routes': [],
-                         'ip_version': 4,
-                         'gateway_ip': 'fake_gateway_ip_1',
-                         'cidr': 'fake_cidr_1',
-                         'id': 'fake_subnet_id_1'}]}
+        fake_subnet_list = {'subnets': [{'name': 'fake_subnet_name_1',
+                                         'enable_dhcp': True,
+                                         'network_id': 'fake_network_id_1',
+                                         'tenant_id': 'fake_tenant_id_1',
+                                         'allocation_pools': [
+                                             {'start': 'fake_start_ip_1',
+                                              'end': 'fake_end_ip_1'}
+                                         ],
+                                         'host_routes': [],
+                                         'ip_version': 4,
+                                         'gateway_ip': 'fake_gateway_ip_1',
+                                         'cidr': 'fake_cidr_1',
+                                         'id': 'fake_subnet_id_1'}]}
 
-        self.neutron_mock_client().list_subnets.return_value = \
-            fake_subnets_list
-        self.neutron_mock_client.show_network.return_value = \
-            {'network': {'name': 'fake_network_name_1',
-                         'router:external': False}}
-        self.network_mock.get_resource_hash = \
-            mock.Mock(return_value='fake_subnet_hash_1')
+        self.neutron_mock_client().list_subnets.return_value = fake_subnet_list
+        self.network_mock.get_networks_list = mock.Mock(
+            return_value=fake_net_list['networks'])
+        self.network_mock.get_resource_hash = mock.Mock(
+            return_value='fake_subnet_hash_1')
 
         subnets_info = [self.subnet_1_info]
         subnets_info_result = self.neutron_network_client.get_subnets()
         self.assertEquals(subnets_info, subnets_info_result)
 
     def test_get_routers(self):
+        fake_net_list = {'networks': [{'status': 'ACTIVE',
+                                       'subnets': [mock.ANY],
+                                       'name': 'fake_network_name_1',
+                                       'provider:physical_network': None,
+                                       'admin_state_up': True,
+                                       'tenant_id': 'fake_tenant_id_1',
+                                       'provider:network_type': 'gre',
+                                       'router:external': False,
+                                       'shared': False,
+                                       'id': 'fake_network_id_1',
+                                       'provider:segmentation_id': 5}]}
 
-        fake_routers_list = {
-            'routers': [{'status': 'ACTIVE',
-                         'external_gateway_info': {
-                             'network_id': 'fake_network_id_1',
-                             'enable_snat': True
-                         },
-                         'name': 'fake_router_name_1',
-                         'admin_state_up': True,
-                         'tenant_id': 'fake_tenant_id_1',
-                         'routes': [],
-                         'id': 'fake_router_id_1'}]}
+        fake_router_list = {'routers': [{'status': 'ACTIVE',
+                                         'external_gateway_info': {
+                                             'network_id': 'fake_network_id_1',
+                                             'enable_snat': True
+                                         },
+                                         'name': 'fake_router_name_1',
+                                         'admin_state_up': True,
+                                         'tenant_id': 'fake_tenant_id_1',
+                                         'routes': [],
+                                         'id': 'fake_router_id_1'}]}
 
-        self.neutron_mock_client().list_routers.return_value = \
-            fake_routers_list
-        self.neutron_mock_client.show_network.return_value = \
-            {'network': {'name': 'fake_network_name_1',
-                         'tenant_id': 'fake_tenant_id_1'}}
+        fake_ports_list = [{'fixed_ips': [{'subnet_id': 'fake_subnet_id_1',
+                                           'ip_address': 'fake_ipaddr_1'}],
+                            'device_id': 'fake_router_id_1'}]
 
-        fake_ports_list = {
-            'ports': [{'fixed_ips': [{'subnet_id': 'fake_subnet_id_1',
-                                      'ip_address': 'fake_ipaddr_1'}],
-                       'device_id': 'fake_router_id_1'}]}
-
-        self.neutron_mock_client.list_ports.return_value = fake_ports_list
-        self.network_mock.get_resource_hash = \
-            mock.Mock(return_value='fake_router_hash')
+        self.neutron_mock_client().list_routers.return_value = fake_router_list
+        self.network_mock.get_networks_list = mock.Mock(
+            return_value=fake_net_list['networks'])
+        self.network_mock.get_ports_list.return_value = fake_ports_list
+        self.network_mock.get_resource_hash = mock.Mock(
+            return_value='fake_router_hash')
 
         routers_info = [{'name': 'fake_router_name_1',
                          'id': 'fake_router_id_1',
@@ -304,21 +332,30 @@ class NeutronTestCase(test.TestCase):
         self.assertEquals(routers_info, routers_info_result)
 
     def test_get_floatingips(self):
+        fake_net_list = {'networks': [{'status': 'ACTIVE',
+                                       'subnets': [mock.ANY],
+                                       'name': 'fake_network_name_1',
+                                       'provider:physical_network': None,
+                                       'admin_state_up': True,
+                                       'tenant_id': 'fake_tenant_id_1',
+                                       'provider:network_type': 'gre',
+                                       'router:external': False,
+                                       'shared': False,
+                                       'id': 'fake_network_id_1',
+                                       'provider:segmentation_id': 5}]}
 
-        fake_floatingips_list = {
-            'floatingips': [{'router_id': None,
-                             'tenant_id': 'fake_tenant_id_1',
-                             'floating_network_id': 'fake_network_id_1',
-                             'fixed_ip_address': None,
-                             'floating_ip_address': 'fake_floatingip_1',
-                             'port_id': None,
-                             'id': 'fake_floating_ip_id_1'}]}
+        fake_fips = {'floatingips': [
+            {'router_id': None,
+             'tenant_id': 'fake_tenant_id_1',
+             'floating_network_id': 'fake_network_id_1',
+             'fixed_ip_address': None,
+             'floating_ip_address': 'fake_floatingip_1',
+             'port_id': None,
+             'id': 'fake_floating_ip_id_1'}]}
 
-        self.neutron_mock_client().list_floatingips.return_value = \
-            fake_floatingips_list
-        self.neutron_mock_client.show_network.return_value = \
-            {'network': {'name': 'fake_network_name_1',
-                         'tenant_id': 'fake_tenant_id_1'}}
+        self.network_mock.get_networks_list = mock.Mock(
+            return_value=fake_net_list['networks'])
+        self.neutron_mock_client().list_floatingips.return_value = fake_fips
 
         floatingips_info = [{'id': 'fake_floating_ip_id_1',
                              'tenant_id': 'fake_tenant_id_1',


### PR DESCRIPTION
Reduce OpenStack Neutron API calls in the `NeutronNetwork's`
`read_info` method. Use caching instead of multiple API calls.

Fix issue with keyword arguments in `utils/cache` module.

Add `get_all_quota` option to all configs.