### PR TITLE
SAIC-658 Random VM scheduling update

### DIFF
--- a/cloudferrylib/base/resource.py
+++ b/cloudferrylib/base/resource.py
@@ -47,16 +47,25 @@ class Resource(object):
         return []
 
     def wait_for_status(self, res_id, get_status, wait_status, timeout=60):
+        LOG.debug("Waiting for status change")
         delay = 1
         while delay < timeout:
-            if get_status(res_id).lower() == wait_status.lower():
+            actual_status = get_status(res_id).lower()
+            LOG.debug("Expected status is '%s', actual - '%s'",
+                      wait_status, actual_status)
+            if actual_status == wait_status.lower():
+                LOG.debug("Expected status reached, exit")
                 break
+
+            LOG.debug("Expected status NOT reached, waiting")
+
             time.sleep(delay)
             delay *= 2
         else:
+            LOG.debug("Timed out waiting for state change")
             raise timeout_exception.TimeoutException(
                 get_status(res_id).lower(),
-                wait_status, "Timeout exp")
+                wait_status, "Timed out waiting for state change")
 
     def try_wait_for_status(self, res_id, get_status, wait_status, timeout=60):
         try:

--- a/tests/cloudferrylib/os/compute/test_nova.py
+++ b/tests/cloudferrylib/os/compute/test_nova.py
@@ -303,11 +303,11 @@ class DeployInstanceWithManualScheduling(test.TestCase):
         self.assertRaises(
             nova_compute.DestinationCloudNotOperational,
             deployer.deploy, instance, create_params, client_conf)
-        self.assertEqual(nc.deploy_instance.call_count, num_computes)
+        self.assertEqual(nc.deploy_instance.call_count, num_computes + 1)
 
     def test_runs_only_one_boot_if_node_is_good(self):
         compute_hosts = ['host1', 'host2', 'host3']
-        instance = {'availability_zone': 'somezone'}
+        instance = {'availability_zone': 'somezone', 'name': 'vm1'}
         create_params = {'name': 'vm1'}
         client_conf = mock.Mock()
 


### PR DESCRIPTION
 - Increased VM boot timeout to 5 minutes to better handle
    possible service outages and longer VM boot times;
 - VM scheduler logic improved to use all the possible compute
    nodes during VM provisioning: first spawn command simply
    tries to create an instance based on nova scheduler, while
    all the subsequent boot requests use specific compute nodes.
 - Improved logging for `wait_for_status()` and nova boot process.