### PR TITLE
SAIC-629 Unprotect image before delete

### DIFF
--- a/cloudferrylib/os/image/glance_image.py
+++ b/cloudferrylib/os/image/glance_image.py
@@ -122,6 +122,8 @@ class GlanceImage(image.Image):
         return self.glance_client.images.create(**kwargs)
 
     def delete_image(self, image_id):
+        # Change protected property to false before delete
+        self.glance_client.images.update(image_id, protected=False)
         self.glance_client.images.delete(image_id)
 
     def get_image_by_id(self, image_id):

--- a/tests/cloudferrylib/os/image/test_glance_image.py
+++ b/tests/cloudferrylib/os/image/test_glance_image.py
@@ -158,6 +158,8 @@ class GlanceImageTestCase(test.TestCase):
         fake_image_id = 'fake_image_id_1'
         self.glance_image.delete_image(fake_image_id)
 
+        self.glance_mock_client().images.update.assert_called_once_with(
+            fake_image_id, protected=False)
         self.glance_mock_client().images.delete.assert_called_once_with(
             fake_image_id)
 


### PR DESCRIPTION
Glance have special property to protect images that are used as "gold master"
from accidental removal. This property is useful in typical OpenStack API
use case, but in case of migration it is good idea to set protected to
false every time we try to remove image.