### PR TITLE
[DO NOT MERGE] Remove unnecessary steps from stages scenarios

### DIFF
--- a/scenario/stages/1_checkcloud.yaml
+++ b/scenario/stages/1_checkcloud.yaml
@@ -3,11 +3,5 @@
 # cinder volume as well as spinning VM using API calls.
 # After successful testing all resources and VMs are deleted.
 
-preparation:
-  - create_snapshot: True
-
-rollback:
-  - restore_from_snapshot: True
-
 process:
   - act_check_dst_cloud: True

--- a/scenario/stages/3_get_and_transfer_images.yaml
+++ b/scenario/stages/3_get_and_transfer_images.yaml
@@ -12,6 +12,5 @@ rollback:
 process:
   - act_get_filter: True
   - act_check_filter: True
-  - act_identity_trans: True
   - act_get_info_images: True
   - act_deploy_images: True

--- a/scenario/stages/5_network_transporter.yaml
+++ b/scenario/stages/5_network_transporter.yaml
@@ -11,5 +11,4 @@ rollback:
 process:
   - act_get_filter: True
   - act_check_filter: True
-  - act_identity_trans: True
   - act_network_trans: True

--- a/scenario/stages/6_get_transfer_volumes.yaml
+++ b/scenario/stages/6_get_transfer_volumes.yaml
@@ -9,6 +9,5 @@ rollback:
 process:
   - act_get_filter: True
   - act_check_filter: True
-  - act_identity_trans: True
   - get_volumes_db_data: True
   - write_volumes_db_data: True

--- a/scenario/stages/7_transport_keypairs.yaml
+++ b/scenario/stages/7_transport_keypairs.yaml
@@ -9,5 +9,4 @@ rollback:
 process:
   - act_get_filter: True
   - act_check_filter: True
-  - act_identity_trans: True
   - transport_key_pairs: True


### PR DESCRIPTION
Remove `identity_transporter` task from stages scenario to reduce
migration time.

Also remove `preparation` and `rollback` steps from
`scenario/stages/1_checkcloud.yaml`, because `CheckCloud` action
guarantees removal of all objects created in destination.