### PR TITLE
 "Behind the proxy" support for devlab setup

### DIFF
--- a/devlab/Vagrantfile
+++ b/devlab/Vagrantfile
@@ -45,9 +45,32 @@ nodes = {
   }
 }
 
+options['http_proxy'] ||= ""
+options['https_proxy'] ||= ""
+options['ftp_proxy'] ||= ""
+
 Vagrant.require_version '>= 1.6.0'
 
+if not options['http_proxy'].empty?
+    unless Vagrant.has_plugin?("vagrant-proxyconf")
+        system('vagrant plugin install vagrant-proxyconf')
+    end
+end
+
 Vagrant.configure(2) do |config|
+
+  if Vagrant.has_plugin?("vagrant-proxyconf")
+    config.proxy.http     = "#{options['http_proxy']}"
+    config.proxy.https    = "#{options['https_proxy']}"
+    config.proxy.ftp      = "#{options['ftp_proxy']}"
+    config.proxy.no_proxy = "localhost,127.0.0.1,"\
+                            "#{options['grizzly_ip']},"\
+                            "#{options['icehouse_ip']},"\
+                            "#{options['juno_ip']},"\
+                            "#{options['cloudferry_ip']},"\
+                            "#{options['nfs_ip']}"
+  end
+
   config.vm.provision "shell", path: "./provision/prerequisites.sh"
   etc_hosts = nodes.map { |name, data| [data["ip"], name].join(' ') }.join("\n")
 

--- a/devlab/config.ini
+++ b/devlab/config.ini
@@ -11,6 +11,11 @@ grizzly_compute_ip = 192.168.1.5
 icehouse_compute_ip = 192.168.1.6
 juno_ip = 192.168.1.8
 
+# If required, please set Proxy as below
+#http_proxy =
+#https_proxy =
+#ftp_proxy =
+
 migrate_key_filename = ~/.ssh/id_rsa
 
 src_ext_cidr = 192.168.1.0/24


### PR DESCRIPTION
As per current design of Cloudferry, Vagrantfile does not considers
'host behind proxy' problem.

If one is trying to setup Cloudferry devlabs, booted VM will have no Internet
access, as Vagrantfile does consider proxy considerations.

Again, with no internet access it not be able to downloads required packages.

When I tried 'vagrant up juno', devstack was not able to download.
And this was basically because of lack of support of 'behind the proxy'.

This patch eliminates this problem.