### PR TITLE
[SAIC-707] Implemented checking conflict ports

### DIFF
--- a/cloudferrylib/os/actions/filter_similar_vms_with_tenants.py
+++ b/cloudferrylib/os/actions/filter_similar_vms_with_tenants.py
@@ -1,0 +1,89 @@
+# Copyright 2015: Mirantis Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+
+import collections
+from cloudferrylib.base.action import action
+from cloudferrylib.utils import utils
+
+LOG = utils.get_log(__name__)
+
+
+class FilterSimilarVMs(action.Action):
+    """
+    Exclude src instances from migration workflow if they exists on dst or if
+    they ip's overlaps with dst instances ip's. Also looking
+    for similar tenants.
+    """
+    def run(self, **kwargs):
+        filter_instances = kwargs.get('search_opts', {})
+        sim_inst = self.get_similar_instances(filter_instances)
+        return {
+            'similar_instances': sim_inst
+        }
+
+    def get_similar_tenants(self):
+        src_identity = self.src_cloud.resources[utils.IDENTITY_RESOURCE]
+        dst_identity = self.dst_cloud.resources[utils.IDENTITY_RESOURCE]
+        src_tenants = src_identity.read_info()['tenants']
+        dst_tenants = {t['tenant']['name']: t['tenant']['id']
+                       for t in dst_identity.read_info()['tenants']}
+        similar_tenants = {}
+        for ts in src_tenants:
+            index = ts['tenant']['name']
+            if index in dst_tenants:
+                similar_tenants[ts['tenant']['id']] = dst_tenants[index]
+            else:
+                similar_tenants[ts['tenant']['id']] = ''
+        return similar_tenants
+
+    def get_instances(self, cloud, search_opts={}):
+        compute = cloud.resources[utils.COMPUTE_RESOURCE]
+        instances = compute.read_info('instances',
+                                      search_opts=
+                                      search_opts)['instances']
+        return instances
+
+    def get_similar_instances(self, instances):
+        src_instances = self.get_instances(self.src_cloud, instances)
+        dst_instances = self.get_instances(self.dst_cloud)
+        dst_instances_restruct = {
+            utils.Instance(
+                di): di
+            for index, di in dst_instances.iteritems()}
+        similar_tenants = self.get_similar_tenants()
+        similar_instances = []
+        for v, k in dst_instances_restruct.iteritems():
+            LOG.debug("Instance DST: %s ", k)
+        for index, si in src_instances.iteritems():
+            src_signs = utils.Instance(si)
+            LOG.debug("Check source instance: %s", si['instance'])
+            if src_signs in dst_instances_restruct.keys():
+                LOG.debug("Check tenants instances....")
+                sign = [k for k in dst_instances_restruct.keys()
+                        if src_signs == k]
+                if len(sign) > 1:
+                    LOG.warning("!!Two or more similar instances!!")
+                di = dst_instances_restruct[sign[0]]
+                src_ten = si['instance']['tenant_id']
+                dst_ten = di['instance']['tenant_id']
+                LOG.debug("Tenant instance on src %s ", src_ten)
+                LOG.debug("Tenant instance on dst %s ", dst_ten)
+                if src_ten in similar_tenants:
+                    if similar_tenants[src_ten] != dst_ten:
+                        continue
+                LOG.debug("Detect similar instance")
+                similar_instances.append(di)
+        return similar_instances

--- a/cloudferrylib/utils/utils.py
+++ b/cloudferrylib/utils/utils.py
@@ -114,6 +114,21 @@ class ext_dict(dict):
         raise AttributeError("Exporter has no attribute %s" % name)
 
 
+class Instance(object):
+    COMPARISON_FIELDS = ['name', 'flav_details', 'key_name', 'interfaces',
+                         'volumes']
+
+    def __init__(self, instance):
+        self.instance = instance
+
+    def __eq__(self, other):
+        for field in self.COMPARISON_FIELDS:
+            if (self.instance['instance'][field] !=
+                    other.instance['instance'][field]):
+                return False
+        return True
+
+
 def get_snapshots_list_repository(path=PATH_TO_SNAPSHOTS):
     path_source = path + '/source'
     path_dest = path + '/dest'

--- a/scenario/cold_migrate.yaml
+++ b/scenario/cold_migrate.yaml
@@ -29,6 +29,7 @@ preparation:
           - check_dst_sql: True
           - check_dst_rabbit: True
           - act_get_info_objects_dst: False
+      - act_filter_similar_vms: True
       - check_networks: True
   - check_users_availability: True
   - create_snapshot: True

--- a/scenario/migrate_vms.yaml
+++ b/scenario/migrate_vms.yaml
@@ -30,6 +30,7 @@ preparation:
           - check_dst_sql: True
           - check_dst_rabbit: True
           - act_get_info_objects_dst: False
+      - act_filter_similar_vms: True
       - check_networks: True
   - create_snapshot: True
   - create_vm_snapshot_src: True

--- a/scenario/tasks.yaml
+++ b/scenario/tasks.yaml
@@ -110,4 +110,5 @@ tasks:
    verify_vms: ['VerifyVms', 'src_cloud']
    act_filter_similar_vms_from_dst: ['FilterSimilarVMsFromDST', 'dst_cloud']
    act_server_group_trans: ['ServerGroupTransporter']
+   act_filter_similar_vms: ['FilterSimilarVMs']
    remove_failed_instances: ['RemoveFailedInstances', 'dst_cloud']

--- a/tests/cloudferrylib/os/actions/test_check_networks.py
+++ b/tests/cloudferrylib/os/actions/test_check_networks.py
@@ -23,30 +23,50 @@ from tests import test
 
 class CheckNetworksTestCase(test.TestCase):
     @staticmethod
-    def get_action(src_net_info, dst_net_info=None, src_compute_info=None):
+    def get_action(src_net_info, dst_net_info=None, src_compute_info=None,
+                   dst_compute_info=None, src_identity_info=None,
+                   dst_identity_info=None):
         if not dst_net_info:
             dst_net_info = {'networks': [],
                             'subnets': [],
                             'floating_ips': []}
         if not src_compute_info:
             src_compute_info = {'instances': {}}
+        if not dst_compute_info:
+            dst_compute_info = {'instances': {}}
+        if not src_identity_info:
+            src_identity_info = {'tenants': {}}
+        if not dst_identity_info:
+            dst_identity_info = {'tenants': {}}
+        fake_src_identity = mock.Mock()
+        fake_src_identity.read_info.return_value = src_identity_info
+        fake_dst_identity = mock.Mock()
+        fake_dst_identity.read_info.return_value = dst_identity_info
+
         fake_src_compute = mock.Mock()
         fake_src_compute.read_info.return_value = src_compute_info
+        fake_dst_compute = mock.Mock()
+        fake_dst_compute.read_info.return_value = dst_compute_info
         fake_src_net = mock.Mock()
         fake_src_net.read_info.return_value = src_net_info
         fake_src_net.get_ports_list.return_value = [
             {'id': 'fake_port_id',
              'network_id': 'fake_network_id',
-             'device_id': 'fake_instance_id'}]
+             'device_id': 'fake_instance_id',
+             'device_owner': 'fake_device_owner'}]
 
         fake_dst_net = mock.Mock()
         fake_dst_net.read_info.return_value = dst_net_info
+        fake_dst_net.get_ports_list.return_value = []
         fake_src_cloud = mock.Mock()
         fake_dst_cloud = mock.Mock()
         fake_config = {}
         fake_src_cloud.resources = {'network': fake_src_net,
-                                    'compute': fake_src_compute}
-        fake_dst_cloud.resources = {'network': fake_dst_net}
+                                    'compute': fake_src_compute,
+                                    'identity': fake_src_identity}
+        fake_dst_cloud.resources = {'network': fake_dst_net,
+                                    'compute': fake_dst_compute,
+                                    'identity': fake_dst_identity}
         fake_init = {
             'src_cloud': fake_src_cloud,
             'dst_cloud': fake_dst_cloud,
@@ -341,7 +361,8 @@ class CheckNetworksTestCase(test.TestCase):
         src_cmp_info = {'instances': {
             'fake_instance_id_not_in_external': {
                 'instance': {
-                    'id': 'fake_instance_id_not_in_external'}}}}
+                    'id': 'fake_instance_id_not_in_external',
+                    'interfaces': []}}}}
 
         self.get_action(src_net_info, src_compute_info=src_cmp_info).run()
 


### PR DESCRIPTION
CheckNetworks extended for checking conflict fixed
ip and mac-address on SRC and DST clouds.
Added "waiting" for delete ports.
Ports of similar instances are ignored.