### PR TITLE
SAIC-727 [FT] Verify invalid cinder volumes skipping

### DIFF
--- a/devlab/tests/config.py
+++ b/devlab/tests/config.py
@@ -1,3 +1,5 @@
+INVALID_STATUSES = ['creating', 'error', 'deleting', 'error_deleting']
+
 img_url = 'http://download.cirros-cloud.net/0.3.3/cirros-0.3.3-x86_64-disk.img'
 # username and password for ssh access for cirros image
 username_for_ssh = 'cirros'

--- a/devlab/tests/generate_load.py
+++ b/devlab/tests/generate_load.py
@@ -855,6 +855,27 @@ class Prerequisites(BasePrerequisites):
                 self.migration_utils.execute_command_on_vm(vm_ip, cmd.format(
                     path=path, _file=filename))
 
+    def create_invalid_cinder_objects(self):
+        invalid_volume_tmlt = 'cinder_volume_%s'
+        volumes = [
+            {
+                'display_name': invalid_volume_tmlt % st,
+                'size': 1,
+            }
+            for st in self.config.INVALID_STATUSES
+        ]
+        existing = [vol.display_name
+                    for vol in self.cinderclient.volumes.list(
+                        search_opts={'all_tenants': 1})]
+        volumes = [vol
+                   for vol in volumes if vol['display_name'] not in existing]
+        if volumes:
+            self.create_cinder_volumes(volumes)
+        for st in self.config.INVALID_STATUSES:
+            vol = self.cinderclient.volumes.find(
+                display_name=invalid_volume_tmlt % st)
+            self.cinderclient.volumes.reset_state(vol, state=st)
+
     def emulate_vm_states(self):
         for vm_state in self.config.vm_states:
             # emulate error state:
@@ -1070,6 +1091,8 @@ class Prerequisites(BasePrerequisites):
         self.create_cinder_objects()
         print('>>> Writing data into the volumes:')
         self.write_data_to_volumes()
+        print('>>> Creating invalid cinder objects:')
+        self.create_invalid_cinder_objects()
         print('>>> Emulating vm states:')
         self.emulate_vm_states()
         print('>>> Generating vm states list:')

--- a/devlab/tests/utils.py
+++ b/devlab/tests/utils.py
@@ -47,6 +47,8 @@ class FilteringUtils(object):
         file_path = os.path.join(self.main_folder, file_name.lstrip('/'))
         with open(file_path, "r") as f:
             filter_dict = yaml.load(f)
+            if filter_dict is None:
+                filter_dict = {}
         return [filter_dict, file_path]
 
     def filter_vms(self, src_data_list):
@@ -77,6 +79,19 @@ class FilteringUtils(object):
                     src_data_list.pop(index)
         return [src_data_list, popped_img_list]
 
+    def filter_volumes(self, src_data_list):
+        loaded_data = self.load_file('configs/filter.yaml')
+        filter_dict = loaded_data[0]
+        popped_vol_list = []
+        if 'volumes' not in filter_dict:
+            return [src_data_list, []]
+        for vol in src_data_list[:]:
+            if vol.id not in filter_dict['volumes']['volumes_list']:
+                popped_vol_list.append(vol)
+                index = src_data_list.index(vol)
+                src_data_list.pop(index)
+        return [src_data_list, popped_vol_list]
+
     def filter_tenants(self, src_data_list):
         loaded_data = self.load_file(self.filter_file_path)
         filter_dict = loaded_data[0]
@@ -93,8 +108,8 @@ class FilteringUtils(object):
 
 class MigrationUtils(object):
 
-    def __init__(self, config):
-        self.config = config
+    def __init__(self, conf):
+        self.config = conf
 
     def execute_command_on_vm(self, ip_addr, cmd, username=None,
                               warn_only=False, password=None, key=None,


### PR DESCRIPTION
Regression of SAIC-725.
Extend functional tests to make sure that cinder volumes in "invalid"
statuses ("creating", "error", "deleting", "error_deleting") are skipped
with no errors.