### PR TITLE
SAIC-788 Fallback to host's IP address if `ext_cidr` doesn't match anything

### DIFF
--- a/cloudferrylib/os/compute/nova_compute.py
+++ b/cloudferrylib/os/compute/nova_compute.py
@@ -26,9 +26,9 @@ from cloudferrylib.os.compute import cold_evacuate
 from cloudferrylib.os.compute import server_groups
 from cloudferrylib.os.identity import keystone
 from cloudferrylib.utils import mysql_connector
+from cloudferrylib.utils import node_ip
 from cloudferrylib.utils import timeout_exception
 from cloudferrylib.utils import utils as utl
-
 
 LOG = utl.get_log(__name__)
 
@@ -306,10 +306,10 @@ class NovaCompute(compute.Compute):
 
         if direct_transfer:
             ext_cidr = cfg.cloud.ext_cidr
-            host = utl.get_ext_ip(ext_cidr,
-                                  cloud.getIpSsh(),
-                                  instance_node,
-                                  ssh_user)
+            host = node_ip.get_ext_ip(ext_cidr,
+                                      cloud.getIpSsh(),
+                                      instance_node,
+                                      ssh_user)
         elif is_ceph:
             host = cfg.compute.host_eph_drv
         else:

--- a/cloudferrylib/utils/node_ip.py
+++ b/cloudferrylib/utils/node_ip.py
@@ -1,0 +1,54 @@
+# Copyright 2015 Mirantis Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import socket
+from fabric.context_managers import settings
+from fabric.operations import run
+from fabric.state import env
+import ipaddr
+
+from cloudferrylib.utils import utils
+
+
+LOG = utils.get_log(__name__)
+
+
+def get_ext_ip(ext_cidr, init_host, compute_host, ssh_user):
+    list_ips = get_ips(init_host, compute_host, ssh_user)
+    for ip_str in list_ips:
+        ip_addr = ipaddr.IPAddress(ip_str)
+        for cidr in ext_cidr:
+            if ipaddr.IPNetwork(cidr.strip()).Contains(ip_addr):
+                return ip_str
+    LOG.warning("Unable to find IP address of '%s' node, please "
+                "check ext_cidr config value.", compute_host)
+    return socket.gethostbyname(compute_host)
+
+
+def get_ips(init_host, compute_host, ssh_user):
+    with settings(host_string=compute_host,
+                  user=ssh_user,
+                  gateway=init_host,
+                  connection_attempts=env.connection_attempts):
+        cmd = ("ifconfig | awk -F \"[: ]+\" \'/inet addr:/ "
+               "{ if ($4 != \"127.0.0.1\") print $4 }\'")
+        out = run(cmd)
+        list_ips = []
+        for info in out.split():
+            try:
+                ipaddr.IPAddress(info)
+            except ValueError:
+                continue
+            list_ips.append(info)
+    return list_ips

--- a/cloudferrylib/utils/utils.py
+++ b/cloudferrylib/utils/utils.py
@@ -18,22 +18,20 @@ import timeit
 import random
 import string
 import smtplib
-import os.path
-from pkg_resources import Requirement, resource_filename
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from functools import wraps
 import json
-from jinja2 import Environment, FileSystemLoader
 import os
 import inspect
 from multiprocessing import Lock
-from fabric.api import run, settings, local, env, sudo
-from fabric.context_managers import hide
-import ipaddr
-import yaml
 from logging import config
 
+from pkg_resources import Requirement, resource_filename
+from jinja2 import Environment, FileSystemLoader
+from fabric.api import run, settings, local, env, sudo
+from fabric.context_managers import hide
+import yaml
 
 ISCSI = "iscsi"
 CEPH = "ceph"
@@ -505,34 +503,6 @@ def get_disk_path(instance, blk_list, is_ceph_ephemeral=False, disk=DISK):
             if ("compute/%s%s" % (instance.id, disk)) == i:
                 disk_path = i
     return disk_path
-
-
-def get_ips(init_host, compute_host, ssh_user):
-    with settings(host_string=compute_host,
-                  user=ssh_user,
-                  gateway=init_host,
-                  connection_attempts=env.connection_attempts):
-        cmd = ("ifconfig | awk -F \"[: ]+\" \'/inet addr:/ "
-               "{ if ($4 != \"127.0.0.1\") print $4 }\'")
-        out = run(cmd)
-        list_ips = []
-        for info in out.split():
-            try:
-                ipaddr.IPAddress(info)
-            except ValueError:
-                continue
-            list_ips.append(info)
-    return list_ips
-
-
-def get_ext_ip(ext_cidr, init_host, compute_host, ssh_user):
-    list_ips = get_ips(init_host, compute_host, ssh_user)
-    for ip_str in list_ips:
-        ip_addr = ipaddr.IPAddress(ip_str)
-        for cidr in ext_cidr:
-            if ipaddr.IPNetwork(cidr.strip()).Contains(ip_addr):
-                return ip_str
-    return None
 
 
 def check_file(file_path):

--- a/tests/cloudferrylib/utils/test_node_ip.py
+++ b/tests/cloudferrylib/utils/test_node_ip.py
@@ -1,0 +1,51 @@
+# Copyright 2015 Mirantis Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from mock import patch
+
+from cloudferrylib.utils import node_ip
+
+from tests import test
+
+
+class NodeIPTestCase(test.TestCase):
+    @patch("cloudferrylib.utils.node_ip.socket")
+    @patch.object(node_ip, "get_ips")
+    def test_falls_back_to_node_ip(self, get_ips_mock, socket_mock):
+        ext_cidr = ["10.0.0.0/24"]
+        init_host = "controller"
+        compute_host = "compute"
+        user = "user"
+        expected = "192.168.1.3"
+
+        get_ips_mock.return_value = []
+        socket_mock.gethostbyname.return_value = expected
+
+        ip = node_ip.get_ext_ip(ext_cidr, init_host, compute_host, user)
+
+        self.assertEqual(expected, ip)
+
+    @patch.object(node_ip, "get_ips")
+    def test_returns_correct_ip_if_available(self, get_ips_mock):
+        ext_cidr = ["10.0.0.0/24"]
+        init_host = "controller"
+        compute_host = "compute"
+        user = "user"
+        expected = "10.0.0.100"
+
+        get_ips_mock.return_value = [expected, "1.2.3.4", "5.6.7.8"]
+
+        ip = node_ip.get_ext_ip(ext_cidr, init_host, compute_host, user)
+
+        self.assertEqual(expected, ip)


### PR DESCRIPTION
We often faced an issue when user-configured `ext_cidr` option doesn't
match any IP address on a node, which resulted in debug messages like these:

```
DEBUG remote_runner.py:62 "running 'mktemp -d' on 'None' host as user 'root'"
```

This is happening because `ext_cidr` config option doesn't match any IP
address on a node. In order to avoid this, a fallback path was implemented:
if `ext_cidr` doesn't match any IP address on a node, show warning and
return IP address which was used to reach to a particular node.