### PR TITLE
[SAIC-791] Add handlers for logger 'paramiko.transport'

### DIFF
--- a/configs/logging_config.yaml
+++ b/configs/logging_config.yaml
@@ -38,6 +38,10 @@ loggers:
   CF:
     level: INFO
     handlers: [console, info, error]
+  paramiko.transport:
+    level: INFO
+    handlers: [console, info, error]
+
 root:
   level: INFO
   handlers: []


### PR DESCRIPTION
It's required to add handlers for logger 'paramiko.transport' to exclude log warning "No handlers could be found for logger 'paramiko.transport' "