### PR TITLE
[CF-82] Compare subnets allocation pools

### DIFF
--- a/tests/cloudferrylib/os/actions/test_check_networks.py
+++ b/tests/cloudferrylib/os/actions/test_check_networks.py
@@ -69,7 +69,8 @@ class CheckNetworksTestCase(test.TestCase):
                                       'res_hash': 1,
                                       "provider:physical_network": None,
                                       'provider:network_type': 'local',
-                                      'provider:segmentation_id': None}],
+                                      'provider:segmentation_id': None,
+                                      'router:external': False}],
                         'subnets': [{'cidr': '10.0.0.0/24',
                                      'res_hash': 2,
                                      'network_id': 'id1',
@@ -86,7 +87,8 @@ class CheckNetworksTestCase(test.TestCase):
                                       'res_hash': 1,
                                       "provider:physical_network": None,
                                       'provider:network_type': 'local',
-                                      'provider:segmentation_id': None}],
+                                      'provider:segmentation_id': None,
+                                      'router:external': False}],
                         'subnets': [{'cidr': '10.0.0.0/24',
                                      'res_hash': 2,
                                      'network_id': 'id1',
@@ -97,11 +99,13 @@ class CheckNetworksTestCase(test.TestCase):
                                       'res_hash': 1,
                                       "provider:physical_network": None,
                                       'provider:network_type': 'local',
-                                      'provider:segmentation_id': None}],
+                                      'provider:segmentation_id': None,
+                                      'router:external': False}],
                         'subnets': [{'cidr': '10.0.0.0/24',
                                      'res_hash': 2,
                                      'network_id': 'id2',
-                                     'id': 'sub2'}],
+                                     'id': 'sub2',
+                                     'external': False}],
                         'floating_ips': []}
         self.get_action(src_net_info, dst_net_info).run()
 
@@ -110,7 +114,8 @@ class CheckNetworksTestCase(test.TestCase):
                                       'res_hash': 1,
                                       "provider:physical_network": None,
                                       'provider:network_type': 'local',
-                                      'provider:segmentation_id': None}],
+                                      'provider:segmentation_id': None,
+                                      'router:external': False}],
                         'subnets': [{'cidr': '10.0.0.0/24',
                                      'res_hash': 2,
                                      'network_id': 'id1',
@@ -126,11 +131,13 @@ class CheckNetworksTestCase(test.TestCase):
                                       'res_hash': 1,
                                       "provider:physical_network": None,
                                       'provider:network_type': 'local',
-                                      'provider:segmentation_id': None}],
+                                      'provider:segmentation_id': None,
+                                      'router:external': False}],
                         'subnets': [{'cidr': '10.0.0.0/24',
                                      'res_hash': 2,
                                      'network_id': 'id2',
-                                     'id': 'sub2'}],
+                                     'id': 'sub2',
+                                     'external': False}],
                         'floating_ips': []}
         self.get_action(src_net_info, dst_net_info).run()
 
@@ -139,7 +146,8 @@ class CheckNetworksTestCase(test.TestCase):
                                       'res_hash': 1,
                                       "provider:physical_network": None,
                                       'provider:network_type': 'local',
-                                      'provider:segmentation_id': None}],
+                                      'provider:segmentation_id': None,
+                                      'router:external': False}],
                         'subnets': [{'cidr': '10.0.0.0/24',
                                      'res_hash': 2,
                                      'network_id': 'id1',
@@ -151,11 +159,13 @@ class CheckNetworksTestCase(test.TestCase):
                                       'res_hash': 1,
                                       "provider:physical_network": None,
                                       'provider:network_type': 'local',
-                                      'provider:segmentation_id': None}],
+                                      'provider:segmentation_id': None,
+                                      'router:external': False}],
                         'subnets': [{'cidr': '10.0.0.0/24',
                                      'res_hash': 3,
                                      'network_id': 'id2',
-                                     'id': 'sub2'}],
+                                     'id': 'sub2',
+                                     'external': False}],
                         'floating_ips': []}
         action = self.get_action(src_net_info, dst_net_info)
         self.assertRaises(exception.AbortMigrationError, action.run)
@@ -165,7 +175,8 @@ class CheckNetworksTestCase(test.TestCase):
                                       'res_hash': 1,
                                       "provider:physical_network": None,
                                       'provider:network_type': 'local',
-                                      'provider:segmentation_id': None}],
+                                      'provider:segmentation_id': None,
+                                      'router:external': False}],
                         'subnets': [{'cidr': '10.0.0.0/28',
                                      'res_hash': 2,
                                      'network_id': 'id1',
@@ -176,11 +187,13 @@ class CheckNetworksTestCase(test.TestCase):
                                       'res_hash': 1,
                                       "provider:physical_network": None,
                                       'provider:network_type': 'local',
-                                      'provider:segmentation_id': None}],
+                                      'provider:segmentation_id': None,
+                                      'router:external': False}],
                         'subnets': [{'cidr': '10.0.0.0/24',
                                      'res_hash': 3,
                                      'network_id': 'id2',
-                                     'id': 'sub2'}],
+                                     'id': 'sub2',
+                                     'external': False}],
                         'floating_ips': []}
         action = self.get_action(src_net_info, dst_net_info)
         self.assertRaises(exception.AbortMigrationError, action.run)
@@ -190,7 +203,8 @@ class CheckNetworksTestCase(test.TestCase):
                                       'res_hash': 1,
                                       "provider:physical_network": None,
                                       'provider:network_type': 'gre',
-                                      'provider:segmentation_id': 200}],
+                                      'provider:segmentation_id': 200,
+                                      'router:external': False}],
                         'subnets': [],
                         'floating_ips': []}
 
@@ -205,7 +219,8 @@ class CheckNetworksTestCase(test.TestCase):
                                       'res_hash': 1,
                                       "provider:physical_network": None,
                                       'provider:network_type': 'gre',
-                                      'provider:segmentation_id': 200}],
+                                      'provider:segmentation_id': 200,
+                                      'router:external': False}],
                         'subnets': [],
                         'floating_ips': []}
 
@@ -213,7 +228,8 @@ class CheckNetworksTestCase(test.TestCase):
                                       'res_hash': 1,
                                       "provider:physical_network": None,
                                       'provider:network_type': 'gre',
-                                      'provider:segmentation_id': 200}],
+                                      'provider:segmentation_id': 200,
+                                      'router:external': False}],
                         'subnets': [],
                         'floating_ips': []}
 
@@ -331,7 +347,8 @@ class CheckNetworksTestCase(test.TestCase):
                                       'res_hash': 1,
                                       "provider:physical_network": None,
                                       'provider:network_type': 'local',
-                                      'provider:segmentation_id': None}],
+                                      'provider:segmentation_id': None,
+                                      'router:external': True}],
                         'subnets': [{'cidr': '10.0.0.0/24',
                                      'res_hash': 2,
                                      'network_id': 'fake_network_id',
@@ -348,7 +365,8 @@ class CheckNetworksTestCase(test.TestCase):
                                       'res_hash': 1,
                                       "provider:physical_network": None,
                                       'provider:network_type': 'local',
-                                      'provider:segmentation_id': None}],
+                                      'provider:segmentation_id': None,
+                                      'router:external': False}],
                         'subnets': [{'cidr': '10.0.0.0/24',
                                      'res_hash': 2,
                                      'network_id': 'fake_network_id',
@@ -360,3 +378,123 @@ class CheckNetworksTestCase(test.TestCase):
 
         action = self.get_action(src_net_info, src_compute_info=src_cmp_info)
         self.assertRaises(exception.AbortMigrationError, action.run)
+
+    def test_allocation_pools_overlap(self):
+        src_net_info = {'networks': [{'id': 'id1',
+                                      'res_hash': 1,
+                                      "provider:physical_network": None,
+                                      'provider:network_type': 'local',
+                                      'provider:segmentation_id': None,
+                                      'router:external': True}],
+                        'subnets': [{'cidr': '1.1.1.1/24',
+                                     'res_hash': 2,
+                                     'network_id': 'id1',
+                                     'id': 'sub1',
+                                     'external': True,
+                                     'allocation_pools': [
+                                         {'start': '1.1.1.2',
+                                          'end': '1.1.1.10'},
+                                         {'start': '1.1.1.20',
+                                          'end': '1.1.1.30'}]
+                                     }],
+                        'floating_ips': []}
+
+        dst_net_info = {'networks': [{'id': 'id2',
+                                      'res_hash': 1,
+                                      "provider:physical_network": None,
+                                      'provider:network_type': 'local',
+                                      'provider:segmentation_id': None,
+                                      'router:external': True}],
+                        'subnets': [{'cidr': '1.1.1.1/25',
+                                     'res_hash': 3,
+                                     'network_id': 'id2',
+                                     'id': 'sub2',
+                                     'external': True,
+                                     'allocation_pools': [
+                                         {'start': '1.1.1.5',
+                                          'end': '1.1.1.15'}]
+                                     }],
+                        'floating_ips': []}
+
+        action = self.get_action(src_net_info, dst_net_info)
+        self.assertRaises(exception.AbortMigrationError, action.run)
+
+    def test_allocation_pools_no_overlap(self):
+        src_net_info = {'networks': [{'id': 'id1',
+                                      'res_hash': 1,
+                                      "provider:physical_network": None,
+                                      'provider:network_type': 'local',
+                                      'provider:segmentation_id': None,
+                                      'router:external': True}],
+                        'subnets': [{'cidr': '1.1.1.1/24',
+                                     'res_hash': 2,
+                                     'network_id': 'id1',
+                                     'id': 'sub1',
+                                     'external': True,
+                                     'allocation_pools': [
+                                         {'start': '1.1.1.100',
+                                          'end': '1.1.1.200'}]
+                                     }],
+                        'floating_ips': []}
+
+        dst_net_info = {'networks': [{'id': 'id2',
+                                      'res_hash': 1,
+                                      "provider:physical_network": None,
+                                      'provider:network_type': 'local',
+                                      'provider:segmentation_id': None,
+                                      'router:external': True}],
+                        'subnets': [{'cidr': '1.1.1.1/25',
+                                     'res_hash': 3,
+                                     'network_id': 'id2',
+                                     'id': 'sub2',
+                                     'external': True,
+                                     'allocation_pools': [
+                                         {'start': '1.1.1.2',
+                                          'end': '1.1.1.10'},
+                                         {'start': '1.1.1.20',
+                                          'end': '1.1.1.30'}]
+                                     }],
+                        'floating_ips': []}
+
+        self.get_action(src_net_info, dst_net_info).run()
+
+    def test_allocation_pools_same_network_and_subnet(self):
+        src_net_info = {'networks': [{'id': 'id1',
+                                      'res_hash': 1,
+                                      "provider:physical_network": None,
+                                      'provider:network_type': 'local',
+                                      'provider:segmentation_id': None,
+                                      'router:external': True}],
+                        'subnets': [{'cidr': '1.1.1.1/25',
+                                     'res_hash': 3,
+                                     'network_id': 'id1',
+                                     'id': 'sub1',
+                                     'external': True,
+                                     'allocation_pools': [
+                                         {'start': '1.1.1.2',
+                                          'end': '1.1.1.10'},
+                                         {'start': '1.1.1.20',
+                                          'end': '1.1.1.30'}]
+                                     }],
+                        'floating_ips': []}
+
+        dst_net_info = {'networks': [{'id': 'id2',
+                                      'res_hash': 1,
+                                      "provider:physical_network": None,
+                                      'provider:network_type': 'local',
+                                      'provider:segmentation_id': None,
+                                      'router:external': True}],
+                        'subnets': [{'cidr': '1.1.1.1/25',
+                                     'res_hash': 3,
+                                     'network_id': 'id2',
+                                     'id': 'sub2',
+                                     'external': True,
+                                     'allocation_pools': [
+                                         {'start': '1.1.1.2',
+                                          'end': '1.1.1.10'},
+                                         {'start': '1.1.1.20',
+                                          'end': '1.1.1.30'}]
+                                     }],
+                        'floating_ips': []}
+
+        self.get_action(src_net_info, dst_net_info).run()

--- a/tests/cloudferrylib/os/network/test_neutron.py
+++ b/tests/cloudferrylib/os/network/test_neutron.py
@@ -95,7 +95,6 @@ class NeutronTestCase(test.TestCase):
                            'provider:network_type': 'gre',
                            'provider:segmentation_id': 5,
                            'res_hash': 'fake_net_hash_1',
-                           'subnets_hash': ['fake_subnet_hash_1'],
                            'meta': {}}
 
         self.net_2_info = {'name': 'fake_network_name_2',
@@ -110,7 +109,6 @@ class NeutronTestCase(test.TestCase):
                            'provider:network_type': 'vlan',
                            'provider:segmentation_id': 10,
                            'res_hash': 'fake_net_hash_2',
-                           'subnets_hash': ['fake_subnet_hash_2'],
                            'meta': {}}
 
         self.subnet_1_info = {'name': 'fake_subnet_name_1',
@@ -120,7 +118,7 @@ class NeutronTestCase(test.TestCase):
                                                     'end': 'fake_end_ip_1'}],
                               'gateway_ip': 'fake_gateway_ip_1',
                               'ip_version': 4,
-                              'cidr': 'fake_cidr_1',
+                              'cidr': '1.1.1.0/24',
                               'network_name': 'fake_network_name_1',
                               'external': False,
                               'network_id': 'fake_network_id_1',
@@ -135,7 +133,7 @@ class NeutronTestCase(test.TestCase):
                                                     'end': 'fake_end_ip_2'}],
                               'gateway_ip': 'fake_gateway_ip_2',
                               'ip_version': 4,
-                              'cidr': 'fake_cidr_2',
+                              'cidr': '2.2.2.0/25',
                               'network_name': 'fake_network_name_2',
                               'external': False,
                               'network_id': 'fake_network_id_2',
@@ -431,7 +429,7 @@ class NeutronTestCase(test.TestCase):
                                          'host_routes': [],
                                          'ip_version': 4,
                                          'gateway_ip': 'fake_gateway_ip_1',
-                                         'cidr': 'fake_cidr_1',
+                                         'cidr': '1.1.1.0/24',
                                          'id': 'fake_subnet_id_1'}]}
 
         self.neutron_mock_client().list_networks.return_value = fake_net_list
@@ -470,7 +468,7 @@ class NeutronTestCase(test.TestCase):
                                          'host_routes': [],
                                          'ip_version': 4,
                                          'gateway_ip': 'fake_gateway_ip_1',
-                                         'cidr': 'fake_cidr_1',
+                                         'cidr': '1.1.1.0/24',
                                          'id': 'fake_subnet_id_1'}]}
 
         self.neutron_mock_client().list_subnets.return_value = fake_subnet_list
@@ -864,13 +862,6 @@ class NeutronTestCase(test.TestCase):
         self.neutron_mock_client().add_interface_router.\
             assert_called_once_with('fake_router_id_2',
                                     {'subnet_id': 'fake_subnet_id_2'})
-
-    def test_hash_is_equal_for_nets_with_different_cidrs(self):
-        net1 = {'cidr': "192.168.1.11/22"}
-        net2 = {'cidr': "192.168.1.0/22"}
-        net1_hash = neutron.NeutronNetwork.get_resource_hash(net1, 'cidr')
-        net2_hash = neutron.NeutronNetwork.get_resource_hash(net2, 'cidr')
-        self.assertEqual(net1_hash, net2_hash)
 
     def test_get_network_from_list_by_id(self):
         networks_list = [self.net_1_info, self.net_2_info]


### PR DESCRIPTION
Add allocation pools to subnets hash. From now all networks comparisons
during migration include allocation pools as well as CIDRs.

Add allocation pools verification for external networks to the
`check_networks` action. If allocation pools overlap on source and
destination, migration does not start.

Remove `subnets_hash` from networks hash due to it's irrelevance.

Move CIDR conversion from `get_resource_hash` to the `convert_subnets`
method of `NeutronNetwork` resource.