### PR TITLE
Added missed insecure option to glance image resource

### DIFF
--- a/cloudferrylib/os/image/glance_image.py
+++ b/cloudferrylib/os/image/glance_image.py
@@ -165,7 +165,9 @@ class GlanceImage(image.Image):
         return glance_client.Client(
             version,
             endpoint=endpoint_glance,
-            token=self.identity_client.get_auth_token_from_user())
+            token=self.identity_client.get_auth_token_from_user(),
+            insecure=self.config.cloud.insecure
+        )
 
     def required_tenants(self):
         image_owners = set()

--- a/tests/cloudferrylib/os/image/test_glance_image.py
+++ b/tests/cloudferrylib/os/image/test_glance_image.py
@@ -128,7 +128,8 @@ class GlanceImageTestCase(test.TestCase):
             fake_auth_token)
 
         gl_client = self.glance_image.get_client()
-        mock_calls = [mock.call(endpoint=fake_endpoint, token=fake_auth_token)]
+        mock_calls = [mock.call(endpoint=fake_endpoint, token=fake_auth_token,
+                                insecure=FAKE_CONFIG.cloud.insecure)]
 
         self.glance_mock_client.assert_has_calls(mock_calls)
         self.assertEqual(self.glance_mock_client(), gl_client)


### PR DESCRIPTION
There was a missed option (insecure) in get_client of image resource.