### PR TITLE
[SAIC-802] Avoid extra getting an external ip from instances

### DIFF
--- a/cloudferrylib/os/actions/check_networks.py
+++ b/cloudferrylib/os/actions/check_networks.py
@@ -56,7 +56,7 @@ class CheckNetworks(action.Action):
         LOG.debug("Retrieving Network information from Destination cloud...")
         dst_net_info = NetworkInfo(dst_net.read_info())
         LOG.debug("Retrieving Compute information from Source cloud...")
-        src_compute_info = ComputeInfo(src_compute.read_info(**search_opts))
+        src_compute_info = ComputeInfo(src_compute, search_opts)
 
         # Check subnets and segmentation IDs overlap
         LOG.info("Check networks overlapping...")
@@ -93,8 +93,10 @@ class CheckNetworks(action.Action):
 
 
 class ComputeInfo(object):
-    def __init__(self, info):
-        self.instance_ids = info['instances'].keys()
+    def __init__(self, src_compute, search_opts):
+        search_opts['all_tenants'] = True
+        self.instances = {s.id for s in src_compute.get_instances_list(
+            search_opts=search_opts)}
 
     def list_vms_in_external_network(self, devices):
         """
@@ -109,8 +111,7 @@ class ComputeInfo(object):
                       'Finishing check.')
             return []
 
-        return list({instance_id for instance_id in self.instance_ids
-                     if instance_id in devices})
+        return list(self.instances & devices)
 
 
 class NetworkInfo(object):

--- a/cloudferrylib/os/compute/nova_compute.py
+++ b/cloudferrylib/os/compute/nova_compute.py
@@ -251,21 +251,15 @@ class NovaCompute(compute.Compute):
         if target != 'instances':
             raise ValueError('Only "resources" or "instances" values allowed')
 
-        search_opts = kwargs.get('search_opts')
-
-        search_opts = search_opts if search_opts else {}
+        search_opts = kwargs.get('search_opts') or {}
         search_opts.update(all_tenants=True)
 
         info = {'instances': {}}
 
         for instance in self.get_instances_list(search_opts=search_opts):
             if instance.status in ALLOWED_VM_STATUSES:
-                if (self.cloud.position == 'dst' or
-                        (self.cloud.position == 'src' and
-                            self.filter_tenant_id is not None and
-                            self.filter_tenant_id == instance.tenant_id) or
-                        (self.cloud.position == 'src' and
-                            self.filter_tenant_id is None)):
+                if (self.filter_tenant_id is None or
+                        self.filter_tenant_id == instance.tenant_id):
                     converted = self.convert(instance, self.config, self.cloud)
                     if converted is None:
                         continue

--- a/tests/cloudferrylib/os/actions/test_check_networks.py
+++ b/tests/cloudferrylib/os/actions/test_check_networks.py
@@ -29,9 +29,10 @@ class CheckNetworksTestCase(test.TestCase):
                             'subnets': [],
                             'floating_ips': []}
         if not src_compute_info:
-            src_compute_info = {'instances': {}}
+            src_compute_info = [mock.Mock(id='fake_id_1'),
+                                mock.Mock(id='fake_id_2')]
         fake_src_compute = mock.Mock()
-        fake_src_compute.read_info.return_value = src_compute_info
+        fake_src_compute.get_instances_list.return_value = src_compute_info
         fake_src_net = mock.Mock()
         fake_src_net.read_info.return_value = src_net_info
         fake_src_net.get_ports_list.return_value = [
@@ -338,10 +339,7 @@ class CheckNetworksTestCase(test.TestCase):
                                      'external': True}],
                         'floating_ips': []}
 
-        src_cmp_info = {'instances': {
-            'fake_instance_id_not_in_external': {
-                'instance': {
-                    'id': 'fake_instance_id_not_in_external'}}}}
+        src_cmp_info = [mock.Mock(id='fake_instance_id_not_in_external')]
 
         self.get_action(src_net_info, src_compute_info=src_cmp_info).run()
 
@@ -358,10 +356,7 @@ class CheckNetworksTestCase(test.TestCase):
                                      'external': True}],
                         'floating_ips': []}
 
-        src_cmp_info = {'instances': {
-            'fake_instance_id': {
-                'instance': {
-                    'id': 'fake_instance_id'}}}}
+        src_cmp_info = [mock.Mock(id='fake_instance_id')]
 
         action = self.get_action(src_net_info, src_compute_info=src_cmp_info)
         self.assertRaises(exception.AbortMigrationError, action.run)


### PR DESCRIPTION
Get only ids of instances instead of getting full information
in check_networks action.