### PR TITLE
Use rsync for ephemeral storage transfer

### DIFF
--- a/cfglib.py
+++ b/cfglib.py
@@ -175,6 +175,11 @@ migrate_opts = [
     cfg.IntOpt('boot_timeout', default=300,
                help="Timeout booting of instance"),
     cfg.StrOpt('ssh_cipher', default=None, help='SSH cipher to use for SCP'),
+    cfg.StrOpt('ephemeral_copy_backend', default="rsync",
+               help="Allows to choose how ephemeral storage is copied over "
+                    "from source to destination. Possible values: 'rsync' "
+                    "(default) and 'scp'. scp seem to be faster, while rsync "
+                    "is more reliable")
 ]
 
 mail = cfg.OptGroup(name='mail',

--- a/cloud/os2os.py
+++ b/cloud/os2os.py
@@ -64,7 +64,7 @@ from cloudferrylib.utils.drivers import ssh_ceph_to_ceph
 from cloudferrylib.utils.drivers import ssh_ceph_to_file
 from cloudferrylib.utils.drivers import ssh_file_to_file
 from cloudferrylib.utils.drivers import ssh_file_to_ceph
-from cloudferrylib.utils.drivers import ssh_chunks
+from cloudferrylib.utils.drivers import copy_engine
 from cloudferrylib.os.actions import get_filter
 from cloudferrylib.os.actions import deploy_snapshots
 from cloudferrylib.base.action import is_option
@@ -101,7 +101,7 @@ class OS2OSFerry(cloud_ferry.CloudFerry):
             'SSHFileToFile': ssh_file_to_file.SSHFileToFile,
             'SSHFileToCeph': ssh_file_to_ceph.SSHFileToCeph,
             'CopyFilesBetweenComputeHosts':
-                ssh_chunks.CopyFilesBetweenComputeHosts,
+                copy_engine.CopyFilesBetweenComputeHosts,
         }
 
     def migrate(self, scenario=None):

--- a/cloudferrylib/os/actions/recreate_boot_image.py
+++ b/cloudferrylib/os/actions/recreate_boot_image.py
@@ -15,7 +15,7 @@
 from cloudferrylib.base.action import action
 from cloudferrylib.utils import files
 from cloudferrylib.utils import remote_runner
-from cloudferrylib.utils.drivers.ssh_chunks import verified_file_copy,\
+from cloudferrylib.utils.drivers.copy_engine import verified_file_copy,\
     remote_md5_sum
 from cloudferrylib.utils import utils
 import copy

--- a/configs/config.ini
+++ b/configs/config.ini
@@ -185,6 +185,11 @@ boot_timeout = 300
 # Specify SSH cipher to use while copying ephemeral disks, etc...
 ssh_cipher = arcfour128
 
+# Allows to choose how ephemeral storage is copied over from source to
+# destination. Possible values: 'rsync' (default) and 'scp'. scp seem to be
+# faster, while rsync is more reliable
+ephemeral_copy_backend = rsync
+
 #==============================================================================
 # Mailing configuration
 # CF allows sending email notifications to the interested parties

--- a/tests/cloudferrylib/utils/test_copy_engine.py
+++ b/tests/cloudferrylib/utils/test_copy_engine.py
@@ -1,0 +1,64 @@
+# Copyright 2015 Mirantis Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import inspect
+import mock
+
+from cloudferrylib.utils.remote_runner import RemoteExecutionError
+from cloudferrylib.utils.drivers import copy_engine
+
+from tests import test
+
+
+class CopyFileTestCase(test.TestCase):
+    @mock.patch("cloudferrylib.utils.drivers.copy_engine.remote_runner."
+                "RemoteRunner.run")
+    def test_uses_rsync_if_its_available(self, rr):
+        host = 'host'
+        user = 'user'
+        password = 'password'
+        config = mock.Mock()
+        config.migrate.ephemeral_copy_backend = 'rsync'
+
+        rr.return_value = None
+
+        engine = copy_engine.file_transfer_engine(config, host, user, password)
+
+        self.assertTrue(inspect.isclass(engine))
+
+        src_cloud = mock.Mock()
+        dst_cloud = mock.Mock()
+        config = mock.Mock()
+        copier = engine(src_cloud, dst_cloud, config)
+        self.assertIsInstance(copier, copy_engine.RsyncCopier)
+
+    @mock.patch("cloudferrylib.utils.drivers.copy_engine.remote_runner."
+                "RemoteRunner.run")
+    def test_falls_back_to_scp_if_rsync_is_not_installed(self, rr):
+        host = 'host'
+        user = 'user'
+        password = 'password'
+        config = mock.Mock()
+        config.migrate.ephemeral_copy_backend = 'rsync'
+        rr.side_effect = RemoteExecutionError
+
+        engine = copy_engine.file_transfer_engine(config, host, user, password)
+
+        self.assertTrue(inspect.isclass(engine))
+
+        src_cloud = mock.Mock()
+        dst_cloud = mock.Mock()
+        config = mock.Mock()
+        copier = engine(src_cloud, dst_cloud, config)
+        self.assertIsInstance(copier, copy_engine.ScpCopier)

--- a/tests/cloudferrylib/utils/test_file_utils.py
+++ b/tests/cloudferrylib/utils/test_file_utils.py
@@ -14,7 +14,7 @@
 import mock
 from cloudferrylib.utils import files
 from cloudferrylib.utils import remote_runner
-from cloudferrylib.utils.drivers import ssh_chunks
+from cloudferrylib.utils.drivers import copy_engine
 from tests import test
 
 
@@ -71,9 +71,9 @@ class RemoteDirTestCase(test.TestCase):
 
 
 class VerifiedFileCopyTestCase(test.TestCase):
-    @mock.patch("tests.cloudferrylib.utils.test_file_utils.ssh_chunks."
+    @mock.patch("tests.cloudferrylib.utils.test_file_utils.copy_engine."
                 "remote_scp")
-    @mock.patch("tests.cloudferrylib.utils.test_file_utils.ssh_chunks."
+    @mock.patch("tests.cloudferrylib.utils.test_file_utils.copy_engine."
                 "remote_md5_sum")
     def test_raises_error_on_copy_failure(self, scp, _):
         src_runner = mock.Mock()
@@ -87,14 +87,14 @@ class VerifiedFileCopyTestCase(test.TestCase):
 
         scp.side_effect = remote_runner.RemoteExecutionError
 
-        self.assertRaises(ssh_chunks.FileCopyFailure,
-                          ssh_chunks.verified_file_copy, src_runner,
+        self.assertRaises(copy_engine.FileCopyFailure,
+                          copy_engine.verified_file_copy, src_runner,
                           dst_runner, user, src_path, dst_path, dest_host,
                           num_retries)
 
-    @mock.patch("tests.cloudferrylib.utils.test_file_utils.ssh_chunks."
+    @mock.patch("tests.cloudferrylib.utils.test_file_utils.copy_engine."
                 "remote_scp")
-    @mock.patch("tests.cloudferrylib.utils.test_file_utils.ssh_chunks."
+    @mock.patch("tests.cloudferrylib.utils.test_file_utils.copy_engine."
                 "remote_md5_sum")
     def test_retries_if_error_occurs(self, scp, _):
         src_runner = mock.Mock()
@@ -109,10 +109,10 @@ class VerifiedFileCopyTestCase(test.TestCase):
         scp.side_effect = remote_runner.RemoteExecutionError
 
         try:
-            ssh_chunks.verified_file_copy(src_runner, dst_runner, user,
-                                          src_path, dst_path, dest_host,
-                                          num_retries)
-        except ssh_chunks.FileCopyFailure:
+            copy_engine.verified_file_copy(src_runner, dst_runner, user,
+                                           src_path, dst_path, dest_host,
+                                           num_retries)
+        except copy_engine.FileCopyFailure:
             assert scp.call_count == num_retries + 1
 
     def test_temp_dir_exception_inside_with(self):


### PR DESCRIPTION
scp was previously used to copy ephemeral storage, which resulted in a
lot of code which does a fraction of what rsync can, while being more
complex to maintain. This patch uses rsync by default, and if rsync is
not available on a target host, falls back ot scp. Ephemeral copy backend
is now also configurable through `[migrate] ephemeral_copy_backend`
config option.