### PR TITLE
[SAIC-184] Vagrant commands outside of devlab folder.

### DIFF
--- a/devlab/Vagrantfile
+++ b/devlab/Vagrantfile
@@ -1,7 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby ts=2 sw=2 et sua= inex= :
 
-config_file = "config.ini"
+config_file = File.join(File.dirname(__FILE__), "/config.ini")
 options = {}
 File.foreach(config_file) { |line|
   option, value = line.split("=")


### PR DESCRIPTION
By default, Vagrant uses the current directory you're in.
So before execution commands, don't forget to change the
working directory of Vagrant.

i.e.:
export VAGRANT_CWD=/path/to/CloudFerry/devlab