### PR TITLE
[SAIC-743] Add fix, check and verify for Affinity

### DIFF
--- a/cloudferrylib/os/actions/check_affinity.py
+++ b/cloudferrylib/os/actions/check_affinity.py
@@ -1,0 +1,55 @@
+# Copyright 2015 Mirantis Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from novaclient import exceptions as nova_exceptions
+
+from cloudferrylib.base import exception as cf_exceptions
+from cloudferrylib.base.action import action
+from cloudferrylib.utils import utils
+
+
+LOG = utils.get_log(__name__)
+
+
+class CheckAffinity(action.Action):
+    """Verify whether source and destination clouds support affinity and
+    anti-affinity API (Nova server groups). If affinity/anti-affinity API are
+    not supported - do not start migration and fail with error message.
+    """
+
+    def run(self, **kwargs):
+        LOG.info("Checking affinity/anti-affinity (Nova server groups) API "
+                 "support for SRC and DST clouds...")
+
+        if not self.cfg.migrate.keep_affinity_settings:
+            LOG.info("Affinity settings will not be migrated due to the config"
+                     " (keep_affinity_settings = False). Skipping this check.")
+            return
+
+        check_affinity_api(self.src_cloud)
+        check_affinity_api(self.dst_cloud)
+
+        LOG.info("SRC and DST clouds support affinity/anti-affinity (Nova "
+                 "server groups) API. Migration can proceed.")
+
+
+def check_affinity_api(cloud):
+    compute_resource = cloud.resources[utils.COMPUTE_RESOURCE]
+    try:
+        compute_resource.nova_client.server_groups.list()
+    except nova_exceptions.NotFound:
+        raise cf_exceptions.AbortMigrationError(
+            "'%s' cloud does not support affinity/anti-affinity "
+            "(Nova server groups) API." % cloud.position)

--- a/cloudferrylib/os/actions/get_info_instances.py
+++ b/cloudferrylib/os/actions/get_info_instances.py
@@ -13,20 +13,20 @@
 # limitations under the License.
 
 
+import copy
+
 from cloudferrylib.base.action import action
-from cloudferrylib.utils import utils as utl
+from cloudferrylib.utils import utils
 
 
 class GetInfoInstances(action.Action):
-    def __init__(self, init, cloud=None):
-        super(GetInfoInstances, self).__init__(init, cloud)
 
     def run(self, **kwargs):
         search_opts = {'search_opts': kwargs.get('search_opts', {})}
         search_opts.update(kwargs.get('search_opts_tenant', {}))
-        compute_resource = self.cloud.resources[utl.COMPUTE_RESOURCE]
+        compute_resource = self.cloud.resources[utils.COMPUTE_RESOURCE]
         info = compute_resource.read_info(**search_opts)
         return {
             'info': info,
-            'src_info': info
+            'src_info': copy.deepcopy(info)
         }

--- a/cloudferrylib/os/actions/verify_vms.py
+++ b/cloudferrylib/os/actions/verify_vms.py
@@ -54,6 +54,10 @@ class VerifyVms(action.Action):
                 new_dst_volumes.append(dst_vol['volume'])
             dst_cmp_info[old_id].update(
                 {'volumes': new_dst_volumes})
+
+            dst_cmp_info[old_id].update(
+                {'server_group': dst_inst_['server_group']})
+
             inst_cnt += 1
         failed_vms = []
         for src_inst_id in src_info['instances']:
@@ -84,6 +88,17 @@ class VerifyVms(action.Action):
                     LOG.warning("Wrong volumes of instance {} on DST"
                                 .format(src_inst_id))
                     failed_vms.append(src_inst_id)
+
+                # Verify that migrated VM belongs to correct server group
+                if (src_inst_info['server_group'] !=
+                        dst_cmp_inst['server_group']):
+                    LOG.warning("Wrong server group of instance '%s' on DST! "
+                                "SRC server group: '%s', "
+                                "DST server group: '%s'.",
+                                src_inst_id,
+                                src_inst_info['server_group'],
+                                dst_cmp_inst['server_group'])
+
         if failed_vms:
             LOG.warning("Instances were not migrated:")
             for vm in failed_vms:

--- a/cloudferrylib/os/compute/server_groups.py
+++ b/cloudferrylib/os/compute/server_groups.py
@@ -225,7 +225,12 @@ class ServerGroupsHandler(compute.Compute):
                 client_config.cloud.user,
                 instance_tenant):
             nclient = self.compute.get_client(client_config)
-            server_group_list = nclient.server_groups.list()
+
+            try:
+                server_group_list = nclient.server_groups.list()
+            except nova_exc.NotFound:
+                LOG.info("Cloud does not support server_groups")
+                return
 
         for server_group in server_group_list:
             if instance_id in server_group.members:

--- a/devlab/tests/scenarios/cold_migrate.yaml
+++ b/devlab/tests/scenarios/cold_migrate.yaml
@@ -6,6 +6,7 @@ preparation:
   - pre_migration_test:
       - act_get_filter: True
       - act_check_filter: True
+      - check_affinity: False
       - check_config_quota_neutron: True
       - src_test:
           - act_check_ident_api_src: True
@@ -55,7 +56,7 @@ process:
       - get_volumes_db_data: True
       - write_volumes_db_data: True
       - transport_key_pairs: True
-      - act_server_group_trans: False
+      - act_server_group_trans: True
   - transport_instances_and_dependency_resources:
       - act_get_info_inst: True
       - act_filter_similar_vms_from_dst: True

--- a/scenario/cold_migrate.yaml
+++ b/scenario/cold_migrate.yaml
@@ -6,6 +6,7 @@ preparation:
   - pre_migration_test:
       - act_get_filter: True
       - act_check_filter: True
+      - check_affinity: True
       - check_config_quota_neutron: True
       - src_test:
           - act_check_ident_api_src: True

--- a/scenario/cold_migrate_autorollback.yaml
+++ b/scenario/cold_migrate_autorollback.yaml
@@ -11,6 +11,7 @@ preparation:
   - pre_migration_test:
       - act_get_filter: True
       - act_check_filter: True
+      - check_affinity: True
       - check_config_quota_neutron: True
       - src_test:
           - act_check_ident_api_src: True

--- a/scenario/live_migrate.yaml
+++ b/scenario/live_migrate.yaml
@@ -8,6 +8,8 @@ preparation:
       - check_nova_instances_table: True
       - act_get_filter: True
       - act_check_filter: True
+      - check_affinity: True
+      - check_config_quota_neutron: True
       - src_test:
           - act_check_ident_api_src: True
           - act_check_image_api_src: True

--- a/scenario/migrate_resources.yaml
+++ b/scenario/migrate_resources.yaml
@@ -9,6 +9,7 @@ preparation:
   - pre_migration_test:
       - act_get_filter: True
       - act_check_filter: True
+      - check_affinity: True
       - check_config_quota_neutron: True
       - src_test:
           - act_check_image_api_src: True

--- a/scenario/migrate_resources_autorollback.yaml
+++ b/scenario/migrate_resources_autorollback.yaml
@@ -11,6 +11,7 @@ preparation:
   - pre_migration_test:
       - act_get_filter: True
       - act_check_filter: True
+      - check_affinity: True
       - check_config_quota_neutron: True
       - src_test:
           - act_check_image_api_src: True

--- a/scenario/migrate_vms.yaml
+++ b/scenario/migrate_vms.yaml
@@ -10,6 +10,8 @@ preparation:
   - pre_migration_test:
       - act_get_filter: True
       - act_check_filter: True
+      - check_affinity: True
+      - check_config_quota_neutron: True
       - src_test:
           - act_check_image_api_src: True
           - act_check_compute_api_src: True

--- a/scenario/stages/0_prechecks.yaml
+++ b/scenario/stages/0_prechecks.yaml
@@ -10,6 +10,7 @@ preparation:
   - pre_migration_test:
       - act_get_filter: True
       - act_check_filter: True
+      - check_affinity: True
       - check_config_quota_neutron: True
       - src_test:
           - act_check_image_api_src: True

--- a/scenario/tasks.yaml
+++ b/scenario/tasks.yaml
@@ -112,3 +112,4 @@ tasks:
    act_server_group_trans: ['ServerGroupTransporter']
    remove_failed_instances: ['RemoveFailedInstances', 'dst_cloud']
    act_check_point_vm: ['CheckPointVm']
+   check_affinity: ['CheckAffinity']

--- a/tests/cloudferrylib/os/actions/test_verify_vms.py
+++ b/tests/cloudferrylib/os/actions/test_verify_vms.py
@@ -40,7 +40,8 @@ class VerifyVmsTest(test.TestCase):
                         'key_name': 'fake_key_name_1',
                         'volumes': [{
                             'dev': 1
-                        }]
+                        }],
+                        'server_group': 'fake_server_group_1',
                     }
                 },
                 'id2': {
@@ -55,7 +56,8 @@ class VerifyVmsTest(test.TestCase):
                         'key_name': 'fake_key_name_2',
                         'volumes': [{
                             'dev': 1
-                        }]
+                        }],
+                        'server_group': 'fake_server_group_2',
                     }
                 }
             }
@@ -81,7 +83,8 @@ class VerifyVmsTest(test.TestCase):
                         'key_name': 'fake_key_name_1',
                         'interfaces': {
                             'int': 'int1'
-                        }
+                        },
+                        'server_group': 'fake_server_group_1',
                     },
                     'meta': {
                         'old_id': 'id1',
@@ -101,7 +104,8 @@ class VerifyVmsTest(test.TestCase):
                         'key_name': 'fake_key_name_2',
                         'interfaces': {
                             'int': 'int2'
-                        }
+                        },
+                        'server_group': 'fake_server_group_2',
                     },
                     'meta': {
                         'old_id': 'id2',


### PR DESCRIPTION
Add initial check, which verifies whether source and destination clouds
support affinity and anti-affinity API (Nova server groups). If
affinity/anti-affinity API is not supported - do not start migration and
fail with error message.

Add automated verification that migrated VMs belong to correct Nova
server groups.

Fix issues related to OpenStack versions, that do not support affinity
and anti-affinity API (Nova server groups).

Fix `verify_vms` action as it has not worked properly.