### PR TITLE
[SAIC-646] Remove excess warnings from log

### DIFF
--- a/cloudferrylib/base/resource.py
+++ b/cloudferrylib/base/resource.py
@@ -51,6 +51,8 @@ class Resource(object):
         LOG.debug("Waiting for status change")
         delay = 1
         stop_statuses = [s.lower() for s in (stop_statuses or [])]
+        if 'error' not in stop_statuses:
+            stop_statuses.append('error')
         while delay < timeout:
             actual_status = get_status(res_id).lower()
             LOG.debug("Expected status is '%s', actual - '%s', "

--- a/cloudferrylib/os/actions/check_cloud.py
+++ b/cloudferrylib/os/actions/check_cloud.py
@@ -16,6 +16,7 @@ import contextlib
 import time
 
 from cloudferrylib.base.action import action
+from cloudferrylib.utils import proxy_client
 from cloudferrylib.utils import utils as utl
 from cloudferrylib.os.identity.keystone import KeystoneIdentity
 from cloudferrylib.os.compute.nova_compute import NovaCompute
@@ -119,7 +120,8 @@ class CheckCloud(action.Action):
         try:
             delay = 1
             while timeout > delay:
-                nv_client.nova_client.servers.get(instance_id)
+                with proxy_client.expect_exception(nova_exc.NotFound):
+                    nv_client.nova_client.servers.get(instance_id)
                 LOG.info("Instance still exist, waiting %s sec", delay)
                 time.sleep(delay)
                 delay *= 2

--- a/cloudferrylib/os/actions/check_filter.py
+++ b/cloudferrylib/os/actions/check_filter.py
@@ -20,6 +20,7 @@ from keystoneclient import exceptions as keystone_exc
 from novaclient import exceptions as nova_exc
 from cloudferrylib.base.action import action
 from cloudferrylib.os.storage import filters as cinder_filters
+from cloudferrylib.utils import proxy_client
 from cloudferrylib.utils import utils as utl
 
 import datetime
@@ -50,17 +51,19 @@ class CheckFilter(action.Action):
             for instance_id in instances:
                 LOG.debug('Filtered instance id: %s', instance_id)
                 try:
-                    instance = \
-                        compute_resource.nova_client.servers.get(instance_id)
+                    with proxy_client.expect_exception(nova_exc.NotFound):
+                        instance = \
+                            compute_resource.nova_client.servers.get(
+                                instance_id)
                     if instance:
                         LOG.debug('Filter config check: Instance ID %s is OK',
                                   instance_id)
-                except nova_exc.NotFound as e:
+                except nova_exc.NotFound:
                     LOG.error('Filter config check: Instance ID %s '
                               'is not present in source cloud, '
                               'please update your filter config. Aborting.',
                               instance_id)
-                    raise e
+                    raise
 
     def _check_opts_vol(self, opts):
         if not opts:
@@ -71,16 +74,17 @@ class CheckFilter(action.Action):
             for vol_id in volumes_list:
                 LOG.debug('Filtered volume id: %s', vol_id)
                 try:
-                    vol = cinder_resource.cinder_client.volumes.get(vol_id)
+                    with proxy_client.expect_exception(cinder_exc.NotFound):
+                        vol = cinder_resource.cinder_client.volumes.get(vol_id)
                     if vol:
                         LOG.debug('Filter config check: Volume ID %s is OK',
                                   vol_id)
-                except cinder_exc.NotFound as e:
+                except cinder_exc.NotFound:
                     LOG.error('Filter config check: Volume ID %s '
                               'is not present in source cloud, '
                               'please update your filter config. Aborting.',
                               vol_id)
-                    raise e
+                    raise
 
     @staticmethod
     def _check_opts_vol_date(opts):
@@ -95,10 +99,10 @@ class CheckFilter(action.Action):
                         volumes_date, cinder_filters.DATETIME_FMT)
                     LOG.debug('Filtered str volume date: %s',
                               str(volumes_date))
-                except ValueError, e:
+                except ValueError:
                     LOG.error('Filter config check: '
                               'invalid volume date format')
-                    raise e
+                    raise
 
     def _check_opts_img(self, opts):
         image_resource = self.cloud.resources[utl.IMAGE_RESOURCE]
@@ -107,16 +111,17 @@ class CheckFilter(action.Action):
             for img_id in images_list:
                 LOG.debug('Filtered image id: %s', img_id)
                 try:
-                    img = image_resource.glance_client.images.get(img_id)
+                    with proxy_client.expect_exception(glance_exc.NotFound):
+                        img = image_resource.glance_client.images.get(img_id)
                     if img:
                         LOG.debug('Filter config check: Image ID %s is OK',
                                   img_id)
-                except glance_exc.HTTPNotFound as e:
+                except glance_exc.HTTPNotFound:
                     LOG.error('Filter config check: Image ID %s '
                               'is not present in source cloud, '
                               'please update your filter config. Aborting.',
                               img_id)
-                    raise e
+                    raise
 
     def _check_opts_tenant(self, opts):
         ident_resource = self.cloud.resources[utl.IDENTITY_RESOURCE]
@@ -125,14 +130,15 @@ class CheckFilter(action.Action):
             for tenant_id in tenants:
                 LOG.debug('Filtered tenant id: %s', tenant_id)
                 try:
-                    tenant = ident_resource.keystone_client.tenants.find(
-                        id=tenant_id)
+                    with proxy_client.expect_exception(keystone_exc.NotFound):
+                        tenant = ident_resource.keystone_client.tenants.find(
+                            id=tenant_id)
                     if tenant:
                         LOG.debug('Filter config check: Tenant ID %s is OK',
                                   tenant_id)
-                except keystone_exc.NotFound as e:
+                except keystone_exc.NotFound:
                     LOG.error('Filter config check: Tenant ID %s '
                               'is not present in source cloud, '
                               'please update your filter config. Aborting.',
                               tenant_id)
-                    raise e
+                    raise

--- a/cloudferrylib/os/compute/cold_evacuate.py
+++ b/cloudferrylib/os/compute/cold_evacuate.py
@@ -19,6 +19,7 @@ from Crypto.PublicKey import RSA
 
 from novaclient import exceptions as nova_exc
 
+from cloudferrylib.utils import proxy_client
 from cloudferrylib.utils import remote_runner
 from cloudferrylib.utils import timeout_exception
 from cloudferrylib.utils import utils
@@ -107,7 +108,8 @@ def is_vm_deleted(client, instance_id):
     Returns True when there is no VM with ID provided in first argument.
     """
     try:
-        client.servers.get(instance_id)
+        with proxy_client.expect_exception(nova_exc.NotFound):
+            client.servers.get(instance_id)
         return False
     except nova_exc.NotFound:
         return True
@@ -120,7 +122,8 @@ def is_vm_status_in(client, instance_id, statuses):
     """
     statuses = [s.lower() for s in statuses]
     try:
-        instance = client.servers.get(instance_id)
+        with proxy_client.expect_exception(nova_exc.NotFound):
+            instance = client.servers.get(instance_id)
         status = instance.status.lower()
         if status == ERROR:
             raise RuntimeError("VM in error status")

--- a/cloudferrylib/os/image/glance_image.py
+++ b/cloudferrylib/os/image/glance_image.py
@@ -34,6 +34,7 @@ from cloudferrylib.utils import filters
 from cloudferrylib.utils import sizeof_format
 from cloudferrylib.os.image import filters as glance_filters
 from cloudferrylib.utils import file_like_proxy
+from cloudferrylib.utils import proxy_client
 from cloudferrylib.utils import utils as utl
 from cloudferrylib.utils import remote_runner
 
@@ -235,7 +236,10 @@ class GlanceImage(image.Image):
 
     def get_ref_image(self, image_id):
         try:
-            return self.get_resp(self.glance_client.images.data(image_id))
+            with proxy_client.expect_exception(
+                    glance_exceptions.NotFound,
+                    glance_exceptions.HTTPInternalServerError):
+                return self.get_resp(self.glance_client.images.data(image_id))
         except (glance_exceptions.HTTPInternalServerError,
                 glance_exceptions.HTTPNotFound):
             raise exception.ImageDownloadError

--- a/cloudferrylib/os/storage/cinder_storage.py
+++ b/cloudferrylib/os/storage/cinder_storage.py
@@ -20,6 +20,7 @@ from cinderclient import exceptions as cinder_exc
 
 from cloudferrylib.base import storage
 from cloudferrylib.os.storage import filters as cinder_filters
+from cloudferrylib.utils import proxy_client
 from cloudferrylib.utils import utils as utl
 from cloudferrylib.utils import filters
 
@@ -210,10 +211,10 @@ class CinderStorage(storage.Storage):
 
     def finish(self, vol):
         try:
-            self.cinder_client.volumes.set_bootable(
-                vol[utl.VOLUME_BODY]['id'],
-                vol[utl.VOLUME_BODY]['bootable']
-            )
+            with proxy_client.expect_exception(cinder_exc.BadRequest):
+                self.cinder_client.volumes.set_bootable(
+                    vol[utl.VOLUME_BODY]['id'],
+                    vol[utl.VOLUME_BODY]['bootable'])
         except cinder_exc.BadRequest:
             LOG.info("Can't update bootable flag of volume with id = %s "
                      "using API, trying to use DB...",

--- a/cloudferrylib/utils/proxy_client.py
+++ b/cloudferrylib/utils/proxy_client.py
@@ -11,9 +11,13 @@
 # implied.
 # See the License for the specific language governing permissions and#
 # limitations under the License.
-import time
+import contextlib
 import inspect
+import threading
+import time
+
 from cloudferrylib.utils import utils
+
 LOG = utils.get_log(__name__)
 method_wrapper = type(object().__str__)
 
@@ -45,6 +49,7 @@ base_types = [inspect.types.BooleanType,
               inspect.types.TypeType,
               inspect.types.UnicodeType,
               inspect.types.XRangeType]
+tls = threading.local()
 
 
 def is_wrapping(x):
@@ -55,7 +60,7 @@ def is_wrapping(x):
     return True
 
 
-class Proxy:
+class Proxy(object):
     def __init__(self, client, retry, wait_time):
         self.client = client
         self.retry = retry
@@ -65,18 +70,22 @@ class Proxy:
         time.sleep(self.wait_time)
 
     def __call__(self, *args, **kwargs):
-        c = 0
+        count = 0
         result = None
         is_retry = True
         while is_retry:
             try:
                 result = self.client(*args, **kwargs)
                 is_retry = False
-            except Exception:  # pylint: disable=broad-except
+            except Exception as ex:  # pylint: disable=broad-except
+                expected_exceptions = getattr(tls, 'expected_exceptions', ())
+                for expected_exception in expected_exceptions:
+                    if isinstance(ex, expected_exception):
+                        raise
                 LOG.warning('Error happened while calling client',
                             exc_info=True)
-                if c < self.retry:
-                    c += 1
+                if count < self.retry:
+                    count += 1
                     self.wait()
                 else:
                     raise
@@ -89,3 +98,16 @@ class Proxy:
                 is_wrapping(attr):
             return Proxy(attr, self.retry, self.wait_time)
         return attr
+
+
+@contextlib.contextmanager
+def expect_exception(*exception_classes):
+    old_expected_exceptions = getattr(tls, 'expected_exceptions', None)
+    tls.expected_exceptions = exception_classes
+    try:
+        yield
+    finally:
+        if old_expected_exceptions is None:
+            delattr(tls, 'expected_exceptions')
+        else:
+            tls.expected_exceptions = old_expected_exceptions


### PR DESCRIPTION
Client proxy catch all exceptions and retry request after waiting for
some time. The problem is that sometimes exception is expected to
occur but proxy client don't know anything about this. So it try to
call API several times before allowing exception to be handled
elsewhere. This results in several WARNINGs shown in log. This
patch fix it by adding special method that can be used to tell
proxy client which exceptions it shouldn't handle.