### PR TITLE
SAIC-810 Retry VM boot in correct availability zone

### DIFF
--- a/cfglib.py
+++ b/cfglib.py
@@ -176,6 +176,9 @@ migrate_opts = [
     cfg.IntOpt('boot_timeout', default=300,
                help="Timeout booting of instance"),
     cfg.StrOpt('ssh_cipher', default=None, help='SSH cipher to use for SCP'),
+    cfg.StrOpt('default_availability_zone', default="nova",
+               help="Availability zone to use for VM provisioning, in case "
+                    "source cloud zones do not match destination"),
     cfg.StrOpt('ephemeral_copy_backend', default="rsync",
                help="Allows to choose how ephemeral storage is copied over "
                     "from source to destination. Possible values: 'rsync' "

--- a/cloudferrylib/os/compute/nova_compute.py
+++ b/cloudferrylib/os/compute/nova_compute.py
@@ -90,13 +90,14 @@ class RandomSchedulerVmDeployer(object):
         try:
             return self.nc.deploy_instance(create_params, client_conf)
         except timeout_exception.TimeoutException:
-            hosts = self.nc.get_compute_hosts()
+            az = instance['availability_zone']
+            hosts = self.nc.get_compute_hosts(availability_zone=az)
             random.seed()
             random.shuffle(hosts)
 
             while hosts:
-                create_params['availability_zone'] = ':'.join([
-                    instance['availability_zone'], hosts.pop()])
+                next_host = hosts.pop()
+                create_params['availability_zone'] = ':'.join([az, next_host])
                 LOG.info("Trying to deploy instance '%s' in '%s'",
                          create_params['name'],
                          create_params.get('availability_zone', 'UNKNOWN'))
@@ -912,9 +913,22 @@ class NovaCompute(compute.Compute):
     def get_hypervisor_statistics(self):
         return self.nova_client.hypervisors.statistics()
 
-    def get_compute_hosts(self):
+    def get_compute_hosts(self, availability_zone=None):
+        if availability_zone:
+            try:
+                self.nova_client.availability_zones.find(
+                        zoneName=availability_zone)
+            except nova_exc.NotFound:
+                availability_zone = \
+                    self.config.migrate.default_availability_zone
+
+        hosts = self.nova_client.hosts.list(zone=availability_zone)
+        az_host_names = set([h.host_name for h in hosts])
+
         computes = self.nova_client.services.list(binary='nova-compute')
-        return [c.host for c in computes if host_available(c)]
+        return [c.host
+                for c in computes if host_available(c) and
+                c.host in az_host_names]
 
     def get_free_vcpus(self):
         hypervisor_statistics = self.get_hypervisor_statistics()

--- a/configs/config.ini
+++ b/configs/config.ini
@@ -195,6 +195,11 @@ ssh_cipher = arcfour128
 # faster, while rsync is more reliable
 ephemeral_copy_backend = rsync
 
+# Availability zone to use for VM provisioning, in case source cloud zones do
+# not match destination
+default_availability_zone = nova
+
+
 #==============================================================================
 # Mailing configuration
 # CF allows sending email notifications to the interested parties


### PR DESCRIPTION
When VM boot fails on a host scheduled by nova scheduler, CF tries to
boot it on all hosts in random order, but without availability zone
taken into account. This resulted in hosts picked from random
availability zone. Given patch uses hosts present in availability zone.