### PR TITLE
[CF-102] Add physical networks check

### DIFF
--- a/cloudferrylib/os/network/neutron.py
+++ b/cloudferrylib/os/network/neutron.py
@@ -1644,8 +1644,8 @@ def generate_new_segmentation_id(src_seg_ids, dst_seg_ids, network_type):
     :result int: New generated free segmentation ID
     """
 
-    src_seg_ids = set(src_seg_ids[network_type])
-    dst_seg_ids = set(dst_seg_ids[network_type])
+    src_seg_ids = set(src_seg_ids.get(network_type, []))
+    dst_seg_ids = set(dst_seg_ids.get(network_type, []))
     busy_seg_ids = src_seg_ids | dst_seg_ids
 
     free_seg_id = None


### PR DESCRIPTION
Add 2 types of physnets checks:

1. Check busy physical networks on DST of FLAT network type.
We need this check because FLAT network can be created with one physnet
only once in Neutron. Every next attempt to use the same physnet for
network of such type will be failed.

2. Check physical networks existence on DST for VLAN network type.
We need this check because VLAN network can not be created with physnet,
that does not exist on the terget environment. Every such network
creation attempt will be failed in Neutron.

So we need to prevent these cases and inform about them in the
`CheckNetworks` step at the preparation part of CloudFerry scenario.