### PR TITLE
[CF-23] Add verify step into migrate_vms.yaml

### DIFF
--- a/scenario/migrate_vms.yaml
+++ b/scenario/migrate_vms.yaml
@@ -97,3 +97,5 @@ process:
       - act_check_point_vm: True
       - is_instances: ['get_next_instance']
       - rename_info_iter: True
+  - verify:
+      - remove_failed_instances: True


### PR DESCRIPTION
CF doesn't remove broken VMs from destination
because migrate_vms scenarion didn't contain verify step.
Add remove_failed_instances step into verify section.