### PR TITLE
Removes unnecessary output from rsync

### DIFF
--- a/cloudferrylib/utils/drivers/copy_engine.py
+++ b/cloudferrylib/utils/drivers/copy_engine.py
@@ -131,7 +131,7 @@ def file_transfer_engine(config, host, user, password):
                                                     password=password,
                                                     sudo=True)
             LOG.debug("Checking if rsync is installed")
-            src_runner.run("rsync --help")
+            src_runner.run("rsync --help &>/dev/null")
             LOG.debug("Using rsync copy")
         except remote_runner.RemoteExecutionError:
             LOG.debug("rsync is not available, using scp copy")


### PR DESCRIPTION
Before copying ephemeral storage using `rsync` CF verifies if `rsync` is
installed by calling `rsync --help` which produces a lot of unnecessary
output. This patch reduces amount of output produced by redirecting it
to `/dev/null`.