### PR TITLE
[CF-16] Add timeout and abort_on_prompts options to the RemoteRunner

### DIFF
--- a/cloudferrylib/os/actions/check_ssh.py
+++ b/cloudferrylib/os/actions/check_ssh.py
@@ -11,12 +11,10 @@
 # implied.
 # See the License for the specific language governing permissions and#
 # limitations under the License.
-from operator import itemgetter
 
-from fabric.api import settings
+from fabric import api
 
 from cloudferrylib.base.action import action
-from cloudferrylib.base import exception
 from cloudferrylib.utils import remote_runner
 from cloudferrylib.utils import log
 from cloudferrylib.utils import utils
@@ -27,39 +25,24 @@ LOG = log.getLogger(__name__)
 
 class CheckSSH(action.Action):
     def run(self, info=None, **kwargs):
-        check_results = []
-        check_failed = False
 
         for node in self.get_compute_nodes():
-            node_ssh_failed = self.check_access(node)
-            check_failed = check_failed or node_ssh_failed
-            check_results.append((node, node_ssh_failed))
-
-        if check_failed:
-            message = "SSH check failed for following nodes: '{nodes}'".format(
-                nodes=map(itemgetter(0),
-                          filter(lambda (n, status): status, check_results)))
-            LOG.error(message)
-            raise exception.AbortMigrationError(message)
+            self.check_access(node)
 
     def get_compute_nodes(self):
         return self.cloud.resources[utils.COMPUTE_RESOURCE].get_compute_hosts()
 
     def check_access(self, node):
-        ssh_access_failed = False
-
         cfg = self.cloud.cloud_config.cloud
-        runner = remote_runner.RemoteRunner(node, cfg.ssh_user,
-                                            password=cfg.ssh_sudo_password)
         gateway = self.cloud.getIpSsh()
-        ssh_attempts = self.cloud.cloud_config.migrate.ssh_connection_attempts
-
+        runner = remote_runner.RemoteRunner(node, cfg.ssh_user,
+                                            password=cfg.ssh_sudo_password,
+                                            timeout=60)
         try:
-            with settings(gateway=gateway, connection_attempts=ssh_attempts):
+            with api.settings(gateway=gateway,
+                              abort_on_prompts=True):
                 runner.run('echo')
-        except Exception as error:
-            LOG.error("SSH connection from '%s' to '%s' failed with error: "
-                      "'%s'", gateway, node, error.message)
-            ssh_access_failed = True
-
-        return ssh_access_failed
+        except remote_runner.RemoteExecutionError as e:
+            LOG.debug('Check access error: %s', e, exc_info=True)
+            LOG.warning("SSH connection from '%s' to '%s' failed with error: "
+                        "'%s'", gateway, node, e.message)

--- a/tests/cloudferrylib/utils/test_runner.py
+++ b/tests/cloudferrylib/utils/test_runner.py
@@ -26,9 +26,9 @@ class RemoteRunnerTestCase(test.TestCase):
         self.assertRaises(remote_runner.RemoteExecutionError, rr.run,
                           "non existing failing command")
 
-    @mock.patch('cloudferrylib.utils.remote_runner.forward_agent')
-    @mock.patch('cloudferrylib.utils.remote_runner.fab_sudo')
-    @mock.patch('cloudferrylib.utils.remote_runner.settings')
+    @mock.patch('cloudferrylib.utils.utils.forward_agent')
+    @mock.patch('fabric.api.sudo')
+    @mock.patch('fabric.api.settings')
     def test_errors_are_suppressed_for_run_ignoring_errors(
             self, *_):
         rr = remote_runner.RemoteRunner('host', 'user', 'password', sudo=True,
@@ -41,9 +41,9 @@ class RemoteRunnerTestCase(test.TestCase):
         except Exception as e:
             self.fail("run_ignoring_errors must not raise exceptions: %s" % e)
 
-    @mock.patch('cloudferrylib.utils.remote_runner.forward_agent')
-    @mock.patch('cloudferrylib.utils.remote_runner.fab_sudo')
-    @mock.patch('cloudferrylib.utils.remote_runner.run')
+    @mock.patch('cloudferrylib.utils.utils.forward_agent')
+    @mock.patch('fabric.api.sudo')
+    @mock.patch('fabric.api.run')
     def test_root_user_does_not_sudo(self, _, sudo, run):
         rr = remote_runner.RemoteRunner('host', 'root',
                                         key='key', sudo=True,


### PR DESCRIPTION
Sometime remote runner cannot raise an exception because
remote host waits an additional information.
Example: ssh server waits login and password when we are
connecting by using wrong key pair.
To solve this problem the timeout option has been added
to the RemoteRunner and abort_on_prompts option has been
set as True.
Remove raising AbortMigration error in case of any hosts
are unreacheable.