### PR TITLE
[CF-123] Use PyMySQL library instead of mysql-connector-python

### DIFF
--- a/cfglib.py
+++ b/cfglib.py
@@ -217,7 +217,7 @@ src_mysql_opts = [
                help='host of mysql'),
     cfg.IntOpt('db_port', default='3306',
                help='port for mysql connection'),
-    cfg.StrOpt('db_connection', default='mysql+mysqlconnector',
+    cfg.StrOpt('db_connection', default='mysql+pymysql',
                help='driver for connection'),
 ]
 
@@ -248,7 +248,7 @@ src_compute_opts = [
                 help='live-migration without shared_storage'),
     cfg.StrOpt('host_eph_drv', default='-',
                help='host ephemeral drive'),
-    cfg.StrOpt('db_connection', default='mysql+mysqlconnector',
+    cfg.StrOpt('db_connection', default='mysql+pymysql',
                help='driver for db connection'),
     cfg.StrOpt('db_host', default=None,
                help='compute mysql node ip address'),
@@ -392,7 +392,7 @@ dst_mysql_opts = [
                help='host of mysql'),
     cfg.IntOpt('db_port', default='3306',
                help='port for mysql connection'),
-    cfg.StrOpt('db_connection', default='mysql+mysqlconnector',
+    cfg.StrOpt('db_connection', default='mysql+pymysql',
                help='driver for connection'),
 ]
 

--- a/cloudferrylib/os/actions/server_group_transporter.py
+++ b/cloudferrylib/os/actions/server_group_transporter.py
@@ -49,7 +49,7 @@ class ServerGroupTransporter(transporter.Transporter):
 
         [src_compute]
         service = nova
-        db_connection = mysql+mysqlconnector
+        db_connection = mysql+pymysql
         db_host = <db_host>
         db_port = <db_port>
         db_name = nova
@@ -58,7 +58,7 @@ class ServerGroupTransporter(transporter.Transporter):
 
         [dst_compute]
         service = nova
-        db_connection = mysql+mysqlconnector
+        db_connection = mysql+pymysql
         db_host = <db_host>
         db_port = <db_port>
         db_name = nova

--- a/cloudferrylib/os/storage/cinder_storage.py
+++ b/cloudferrylib/os/storage/cinder_storage.py
@@ -17,6 +17,7 @@ from itertools import ifilter
 
 from cinderclient.v1 import client as cinder_client
 from cinderclient import exceptions as cinder_exc
+from pymysql import cursors
 
 from cloudferrylib.base import storage
 from cloudferrylib.os.storage import filters as cinder_filters
@@ -629,7 +630,7 @@ class CinderTable(object):
     def deploy(self, data):
         sql_engine = self.mysql_connector.get_engine()
         connection = sql_engine.raw_connection()
-        cursor = connection.cursor(dictionary=True)
+        cursor = connection.cursor(cursors.DictCursor)
 
         primary_key = self.get_primary_key(cursor)
         auto_increment = self.get_auto_increment(cursor)

--- a/configs/config.ini
+++ b/configs/config.ini
@@ -303,7 +303,7 @@ db_host = <src_mysql_host>
 db_port = 3306
 
 # Driver for connection
-db_connection = mysql+mysqlconnector
+db_connection = mysql+pymysql
 
 
 #==============================================================================
@@ -352,7 +352,7 @@ block_migration = True
 disk_overcommit = False
 
 # Driver for DB connection
-db_connection = mysql+mysqlconnector
+db_connection = mysql+pymysql
 
 # Compute mysql node ip address. Usually controller node.
 # `cat /etc/nova/nova.conf | grep mysql`
@@ -397,7 +397,7 @@ db_host = <src_ceph_storage_host>
 db_port = 3306
 
 # Driver for DB connection
-db_connection = mysql+mysqlconnector
+db_connection = mysql+pymysql
 
 # Database user for the Cinder service.
 # `cat /etc/cinder/cinder.conf | grep mysql`
@@ -443,7 +443,7 @@ backend = swift
 # Glance DB configuration
 db_host = <glance_db_host>
 db_port = 3306
-db_connection = mysql+mysqlconnector
+db_connection = mysql+pymysql
 
 # Database user for Glance service.
 # `cat /etc/glance/glance-api.conf | grep mysql`
@@ -472,7 +472,7 @@ db_user = <keystone_db_user>
 db_password = <keystone_db_password>
 db_host = <keystone_db_host>
 db_port = 3306
-db_connection = mysql+mysqlconnector
+db_connection = mysql+pymysql
 
 
 #==============================================================================
@@ -484,7 +484,7 @@ service = auto
 
 # neutron DB configuration options. If not set uses `[src_mysql]` values
 # Driver for DB connection
-db_connection = mysql+mysqlconnector
+db_connection = mysql+pymysql
 
 # IP address of Network service's DB node. # cat /etc/neutron/neutron.conf | grep mysql
 db_host = <neutron_db_host>
@@ -546,7 +546,7 @@ db_user = root
 db_password =
 db_host = <dst_mysql_host>
 db_port = 3306
-db_connection = mysql+mysqlconnector
+db_connection = mysql+pymysql
 
 
 [dst_rabbit]
@@ -564,7 +564,7 @@ ram_allocation_ratio = 1
 disk_allocation_ratio = 0.9
 block_migration = True
 disk_overcommit = False
-db_connection = mysql+mysqlconnector
+db_connection = mysql+pymysql
 db_host = <nova_db_host>
 db_port = 3306
 db_name = nova
@@ -577,7 +577,7 @@ service = cinder
 backend = ceph
 db_host = <dst_ceph_storage_host>
 db_port = 3306
-db_connection = mysql+mysqlconnector
+db_connection = mysql+pymysql
 db_user = <cinder_database_username>
 db_password = <cinder_database_password>
 db_name = <cinder_database_name>
@@ -592,7 +592,7 @@ convert_to_raw = False
 backend = swift
 db_host = <glance_db_host>
 db_port = 3306
-db_connection = mysql+mysqlconnector
+db_connection = mysql+pymysql
 db_user = <glance_db_user>
 db_password = <glance_db_password>
 db_name = glance
@@ -604,7 +604,7 @@ service = keystone
 
 [dst_network]
 service = auto
-db_connection = mysql+mysqlconnector
+db_connection = mysql+pymysql
 db_host = <neutron_db_host>
 db_port = 3306
 db_name = neutron

--- a/devlab/config.template
+++ b/devlab/config.template
@@ -48,7 +48,7 @@ db_user = <src_mysql_user>
 db_password = <src_mysql_password>
 db_host = <src_ip>
 db_port = 3306
-db_connection = mysql+mysqlconnector
+db_connection = mysql+pymysql
 
 [src_rabbit]
 password = <src_rabbit_password>
@@ -58,7 +58,7 @@ hosts = <src_ip>:5672
 service = nova
 backend = iscsi
 host_eph_drv = <src_ip>
-db_connection = mysql+mysqlconnector
+db_connection = mysql+pymysql
 db_host = <src_ip>
 db_port = 3306
 db_name = nova
@@ -70,7 +70,7 @@ service = cinder
 backend = <src_storage_backend>
 db_host = <src_ip>
 db_port = 3306
-db_connection = mysql+mysqlconnector
+db_connection = mysql+pymysql
 db_user = <src_mysql_user>
 db_password = <src_mysql_password>
 db_name = cinder
@@ -85,7 +85,7 @@ db_user = <src_mysql_user>
 db_password = <src_mysql_password>
 db_host = <src_ip>
 db_port = 3306
-db_connection = mysql+mysqlconnector
+db_connection = mysql+pymysql
 db_name = glance
 
 [src_identity]
@@ -96,7 +96,7 @@ service = auto
 db_user = <src_mysql_user>
 db_password = <src_mysql_password>
 db_host = <src_ip>
-db_connection = mysql+mysqlconnector
+db_connection = mysql+pymysql
 db_name = quantum
 get_all_quota = False
 
@@ -121,13 +121,13 @@ db_user = <dst_mysql_user>
 db_password = <dst_mysql_password>
 db_host = <dst_ip>
 db_port = 3306
-db_connection = mysql+mysqlconnector
+db_connection = mysql+pymysql
 
 [dst_compute]
 service = nova
 backend = iscsi
 host_eph_drv = <dst_ip>
-db_connection = mysql+mysqlconnector
+db_connection = mysql+pymysql
 db_host = <dst_ip>
 db_port = 3306
 db_name = nova
@@ -144,7 +144,7 @@ backend = <dst_storage_backend>
 db_host = <dst_ip>
 db_port = 3306
 protocol_transfer = <dst_storage_protocol_transfer>
-db_connection = mysql+mysqlconnector
+db_connection = mysql+pymysql
 db_user = <dst_mysql_user>
 db_password = <dst_mysql_password>
 db_name = cinder
@@ -157,7 +157,7 @@ db_user = <dst_mysql_user>
 db_password = <dst_mysql_password>
 db_host = <dst_ip>
 db_port = 3306
-db_connection = mysql+mysqlconnector
+db_connection = mysql+pymysql
 db_name = glance
 
 [dst_identity]
@@ -168,7 +168,7 @@ service=auto
 db_user = <dst_mysql_user>
 db_password = <dst_mysql_password>
 db_host = <dst_ip>
-db_connection = mysql+mysqlconnector
+db_connection = mysql+pymysql
 db_name = neutron
 get_all_quota = False
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ fabric>=1.8.2
 ipaddr
 jinja2
 jsondate
-mysql-connector-python
+PyMySQL==0.6.7
 oslo.config==1.15.0
 oslo.utils==1.9.0
 pika==0.9.14


### PR DESCRIPTION
Pip cannot find and install mysql-connector-python library.
The page https://pypi.python.org/simple/mysql-connector-python/ is empty.