### PR TITLE
CF-129 Fix for runtime warning with rednose dependance.

### DIFF
--- a/devlab/tests/test_resource_migration.py
+++ b/devlab/tests/test_resource_migration.py
@@ -204,6 +204,9 @@ class ResourceMigrationTests(functional_test.FunctionalTest):
             src_sec_gr, dst_sec_gr, resource_name='security_groups',
             parameter='description')
 
+    @unittest.skipUnless(
+        functional_test.config_ini['migrate']['keep_affinity_settings'],
+        'Keep affinity settings disabled in CloudFerry config')
     @attr(migrated_tenant=['admin', 'tenant1', 'tenant2', 'tenant4'])
     def test_migrate_nova_server_groups(self):
         def get_members_names(client, sg_groups):

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,6 @@ python-novaclient==2.20.0
 python-swiftclient==2.3.1
 pyyaml
 redis
-nose
 sqlalchemy
 # see https://github.com/paramiko/paramiko/issues/570 and https://github.com/paramiko/paramiko/pull/571
 -e git://github.com/mirrorcoder/paramiko.git#egg=paramiko-1.16.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,6 @@
+coverage
 flake8
 oslotest
-rednose
 ipdb
-nose-testconfig
+nose==1.3.7
+nose-testconfig==0.9.1


### PR DESCRIPTION
Moved nose to test-requirements.
Removed rednose requirement.