### PR TITLE
CF-119 Fixed tearDown in functional tests

### DIFF
--- a/devlab/tests/generate_load.py
+++ b/devlab/tests/generate_load.py
@@ -1239,12 +1239,12 @@ class CleanEnv(BasePrerequisites):
             vms_ids.append(vm.id)
             self.novaclient.servers.delete(vm.id)
             print('VM "%s" has been deleted' % vm.name)
-        self.wait_vms_deleted(all_tenants=True)
+        self.wait_vms_deleted()
 
-    def wait_vms_deleted(self, all_tenants=False):
-        search_opts = {}
-        if all_tenants:
-            search_opts.update({'all_tenants': 1})
+    def wait_vms_deleted(self, tenant_id=None):
+        search_opts = {'all_tenants': 1}
+        if tenant_id is not None:
+            search_opts['tenant_id'] = tenant_id
         timeout = 120
         for _ in range(timeout):
             servers = self.novaclient.servers.list(

--- a/devlab/tests/test_verify_dst_functionality.py
+++ b/devlab/tests/test_verify_dst_functionality.py
@@ -99,10 +99,6 @@ class VerifyDstCloudFunctionality(functional_test.FunctionalTest):
             {"floatingip": {"floating_network_id":
                             self.external_networks_ids_list[0]}})
 
-        fip = self.dst_cloud.neutronclient.create_floatingip(
-            {"floatingip": {"floating_network_id":
-                            self.external_networks_ids_list[0]}})
-
         self.float_ip_address = fip['floatingip']['floating_ip_address']
         self.float_ip_id = fip['floatingip']['id']
 
@@ -147,7 +143,7 @@ class VerifyDstCloudFunctionality(functional_test.FunctionalTest):
         for key_p in self.dst_cloud.novaclient.keypairs.list():
             key_p.delete()
 
-        self.dst_cloud.clean_tools.wait_vms_deleted()
+        self.dst_cloud.clean_tools.wait_vms_deleted(self.dst_tenant_id)
         self.release_fips_tenant()
 
         self.update_floatip_neutron_quota(self.fip_quota_neutron,


### PR DESCRIPTION
devlab/tests/test_verify_dst_functionality.py#L102-L105 - deleted duplicated code
Fixed filtering by tenant in the  "wait_vms_deleted" method.