### PR TITLE
[CF-110] Keep order of interfaces

### DIFF
--- a/cfglib.py
+++ b/cfglib.py
@@ -189,6 +189,8 @@ migrate_opts = [
     cfg.BoolOpt('debug', default=False,
                 help="Print debugging output (set logging level to DEBUG "
                      "instead of default INFO level)."),
+    cfg.BoolOpt('keep_network_interfaces_order', default=True,
+                help="Keep the order of network interfaces of instances."),
 ]
 
 mail = cfg.OptGroup(name='mail',

--- a/cloudferrylib/os/compute/instance_info_caches.py
+++ b/cloudferrylib/os/compute/instance_info_caches.py
@@ -1,0 +1,55 @@
+# Copyright 2016 Mirantis Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+
+
+class InstanceInfoCaches(object):
+    """
+    The data from network_info column is necessary to keep the order of
+    creation of network interfaces of instances.
+
+    """
+
+    GET_INSTANCE_INFO = ("select * from instance_info_caches "
+                         "where instance_uuid = :uuid")
+
+    def __init__(self, nova_db_connection):
+        self.conn = nova_db_connection
+
+    def get_info_caches(self, instance_id):
+        """Raw data for an instance.
+
+        :param instance_id: ID of instance
+        :return: A dictionary with raw data
+        """
+        return (self.conn.execute(self.GET_INSTANCE_INFO, uuid=instance_id).
+                fetchone())
+
+    def get_network_info(self, instance_id):
+        """Converted json data from network_info column.
+
+        :param instance_id: ID of instance
+        :return: The dictionary with network info
+        """
+        return json.loads(self.get_info_caches(instance_id)['network_info'])
+
+    def enumerate_addresses(self, instance_id):
+        """Mac addresses with positions
+
+        :param instance_id: ID of instance
+        :return: Dictionary with mac address: position
+        """
+        network_info = self.get_network_info(instance_id)
+        return {v['address']: i for i, v in enumerate(network_info)}

--- a/configs/config.ini
+++ b/configs/config.ini
@@ -17,6 +17,10 @@ scenario = scenario/migrate.yaml
 # Path to tasks mapping file. 'scenario/tasks.yaml' by default
 tasks_mapping = scenario/tasks.yaml
 
+# Keep the order of network interfaces of instances.
+# Default value is True.
+keep_network_interfaces_order = True
+
 # Enable or Disable capability to keep  user passwords value from keystone.
 # Default value is False.
 # Values:

--- a/devlab/config.template
+++ b/devlab/config.template
@@ -4,6 +4,7 @@
 scenario = <scenario_file>
 tasks_mapping = <tasks_file>
 
+keep_network_interfaces_order = True
 keep_user_passwords = False
 ssh_transfer_port = 9990-9999
 key_filename = <migrate_key_filename>

--- a/tests/cloudferrylib/os/compute/test_instance_info_caches.py
+++ b/tests/cloudferrylib/os/compute/test_instance_info_caches.py
@@ -1,0 +1,56 @@
+# Copyright 2016 Mirantis Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import mock
+
+from cloudferrylib.os.compute import instance_info_caches
+
+from tests import test
+
+
+class InstanceInfoCachesTestCase(test.TestCase):
+    def setUp(self):
+        super(InstanceInfoCachesTestCase, self).setUp()
+
+        self.conn = mock.Mock()
+        self.instance_info_caches = instance_info_caches.InstanceInfoCaches(
+            self.conn)
+
+    def test_get_info_caches(self):
+        self.conn.execute.return_value.fetchone.return_value = 'fake'
+        res = self.instance_info_caches.get_info_caches('fake_id')
+        self.assertEqual('fake', res)
+        self.conn.execute.assert_called_once_with(
+            instance_info_caches.InstanceInfoCaches.GET_INSTANCE_INFO,
+            uuid='fake_id')
+
+    @mock.patch('json.loads')
+    def test_get_network_info(self, mock_loads):
+        mock_loads.return_value = 'fake'
+        with mock.patch.object(
+            self.instance_info_caches, 'get_info_caches',
+            return_value={'network_info': 'fake_info_caches'}) as m:
+            res = self.instance_info_caches.get_network_info('fake_id')
+            self.assertEqual('fake', res)
+            m.assert_called_once_with('fake_id')
+        mock_loads.assert_called_once_with('fake_info_caches')
+
+    def test_enumerate_addresses(self):
+        with mock.patch.object(
+            self.instance_info_caches, 'get_network_info',
+            return_value=[{'address': 'fake_1'},
+                          {'address': 'fake_2'}]) as m:
+            res = self.instance_info_caches.enumerate_addresses('fake_id')
+            self.assertEqual({'fake_1': 0, 'fake_2': 1}, res)
+            m.assert_called_once_with('fake_id')

--- a/tests/cloudferrylib/os/compute/test_nova.py
+++ b/tests/cloudferrylib/os/compute/test_nova.py
@@ -37,12 +37,13 @@ FAKE_CONFIG = utils.ext_dict(
     mysql=utils.ext_dict({'host': '1.1.1.1'}),
     migrate=utils.ext_dict({'migrate_quotas': True,
                             'retry': '7',
-                            'time_wait': 5}))
+                            'time_wait': 5,
+                            'keep_network_interfaces_order': True}))
 
 
-class NovaComputeTestCase(test.TestCase):
+class BaseNovaComputeTestCase(test.TestCase):
     def setUp(self):
-        super(NovaComputeTestCase, self).setUp()
+        super(BaseNovaComputeTestCase, self).setUp()
 
         self.mock_client = mock.MagicMock()
         self.nc_patch = mockpatch.PatchObject(nova_client, 'Client',
@@ -54,6 +55,7 @@ class NovaComputeTestCase(test.TestCase):
         self.fake_cloud = mock.Mock()
         self.fake_cloud.resources = dict(identity=self.identity_mock)
         self.fake_cloud.position = 'src'
+        self.fake_cloud.config = FAKE_CONFIG
 
         with mock.patch(
                 'cloudferrylib.os.compute.nova_compute.mysql_connector'):
@@ -71,6 +73,8 @@ class NovaComputeTestCase(test.TestCase):
 
         self.fake_tenant_quota_0 = mock.Mock()
 
+
+class NovaComputeTestCase(BaseNovaComputeTestCase):
     def test_get_nova_client(self):
         # To check self.mock_client call only from this test method
         self.mock_client.reset_mock()
@@ -211,8 +215,47 @@ class NovaComputeTestCase(test.TestCase):
             user_id=None,
             instances='new_fake_value')
 
+    def _test_get_networks(self, instance_network_info,
+                           keep_network_interfaces_order):
+        instance = mock.Mock()
+        instance.id = 'fake_instance_id'
+        network_resource = mock.Mock()
+        network_resource.get_instance_network_info.\
+            return_value = instance_network_info
+        self.nova_client.cloud.resources = {
+            utils.NETWORK_RESOURCE: network_resource}
+        self.nova_client.config.migrate.\
+            keep_network_interfaces_order = keep_network_interfaces_order
+        res = self.nova_client.get_networks(instance)
+        network_resource.get_instance_network_info.assert_called_once_with(
+            'fake_instance_id')
+        return res
 
-class ComputeHostsTestCase(NovaComputeTestCase):
+    def test_get_networks_not_sorted(self):
+        res = self._test_get_networks('fake', False)
+        self.assertEqual('fake', res)
+
+    @mock.patch('cloudferrylib.os.compute.instance_info_caches.'
+                'InstanceInfoCaches.enumerate_addresses')
+    def test_get_networks_with_sorting(self, mock_enumerate_addresses):
+        unsorted_interfaces = [{'mac_address': 'fake_mac_1'},
+                               {'mac_address': 'fake_mac_3'},
+                               {'mac_address': 'fake_mac_2'}]
+        sorted_interfaces = [{'mac_address': 'fake_mac_1'},
+                             {'mac_address': 'fake_mac_2'},
+                             {'mac_address': 'fake_mac_3'}]
+        enumerated_addresses = {'fake_mac_1': 0,
+                                'fake_mac_2': 1,
+                                'fake_mac_3': 2}
+        mock_enumerate_addresses.return_value = enumerated_addresses
+        res = self._test_get_networks(unsorted_interfaces, True)
+        for i, interface in enumerate(res):
+            self.assertEqual(sorted_interfaces[i]['mac_address'],
+                             interface['mac_address'])
+        mock_enumerate_addresses.assert_called_once_with('fake_instance_id')
+
+
+class ComputeHostsTestCase(BaseNovaComputeTestCase):
     @classmethod
     def _host(cls, name, up=True, enabled=True):
         h = mock.Mock()
@@ -497,6 +540,8 @@ class NovaClientTestCase(test.TestCase):
         config.cloud.insecure = insecure
         config.cloud.cacert = cacert
 
+        cloud.position = 'src'
+
         n = nova_compute.NovaCompute(config, cloud)
         n.get_client()
 
@@ -522,6 +567,8 @@ class NovaClientTestCase(test.TestCase):
         config.cloud.password = password
         config.cloud.insecure = insecure
         config.cloud.cacert = cacert
+
+        cloud.position = 'src'
 
         n = nova_compute.NovaCompute(config, cloud)
         n.get_client()


### PR DESCRIPTION
Deploy instances and keep the order of interfaces the same as on source.
Add keep_network_interfaces_order option to use new fuctionality.
Implement unit tests.
