### PR TITLE
[CF-43] Move base exceptions to cloudferrylib.base.exception

### DIFF
--- a/cloudferrylib/base/exception.py
+++ b/cloudferrylib/base/exception.py
@@ -25,3 +25,11 @@ class AbortMigrationError(RuntimeError):
     """Non-recoverable exception which must be used in cases where migration
     process MUST be aborted"""
     pass
+
+
+class TimeoutException(Exception):
+    def __init__(self, status_obj, exp_status, msg):
+        self.status_obj = status_obj
+        self.exp_status = exp_status
+        self.msg = msg
+        super(TimeoutException, self).__init__()

--- a/cloudferrylib/base/resource.py
+++ b/cloudferrylib/base/resource.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 
 import time
+
+from cloudferrylib.base import exception
 from cloudferrylib.utils import log
 from cloudferrylib.utils import proxy_client
-from cloudferrylib.utils import timeout_exception
 
 LOG = log.getLogger(__name__)
 
@@ -60,7 +61,7 @@ class Resource(object):
                       wait_status, actual_status, stop_statuses)
             if actual_status in stop_statuses:
                 LOG.debug("Stop status reached, exit")
-                raise timeout_exception.TimeoutException(
+                raise exception.TimeoutException(
                     get_status(res_id).lower(),
                     wait_status, "Timed out waiting for state change")
             elif actual_status == wait_status.lower():
@@ -73,14 +74,14 @@ class Resource(object):
             delay *= 2
         else:
             LOG.debug("Timed out waiting for state change")
-            raise timeout_exception.TimeoutException(
+            raise exception.TimeoutException(
                 get_status(res_id).lower(),
                 wait_status, "Timed out waiting for state change")
 
     def try_wait_for_status(self, res_id, get_status, wait_status, timeout=60):
         try:
             self.wait_for_status(res_id, get_status, wait_status, timeout)
-        except timeout_exception.TimeoutException as e:
+        except exception.TimeoutException as e:
             LOG.warning("Resource '%s' has not changed status to '%s'(%s)",
                         res_id, wait_status, e)
 

--- a/cloudferrylib/os/compute/cold_evacuate.py
+++ b/cloudferrylib/os/compute/cold_evacuate.py
@@ -19,9 +19,9 @@ from Crypto.PublicKey import RSA
 
 from novaclient import exceptions as nova_exc
 
+from cloudferrylib.base import exception
 from cloudferrylib.utils import proxy_client
 from cloudferrylib.utils import remote_runner
-from cloudferrylib.utils import timeout_exception
 from cloudferrylib.utils import log
 
 LOG = log.getLogger(__name__)
@@ -154,7 +154,7 @@ def wait_for_condition(condition_fn, *args, **kwargs):
         time.sleep(delay)
         delay *= 2
     else:
-        raise timeout_exception.TimeoutException(None, None, "Timeout exp")
+        raise exception.TimeoutException(None, None, "Timeout exp")
 
 
 # TODO: move following function to utils and reuse in other parts of CloudFerry
@@ -338,7 +338,7 @@ def change_to_pre_migration_state(compute_api, instance_id):
                 wait_for_condition(is_vm_status_in, compute_api, instance_id,
                                    SUPPORTED_FINAL_STATES,
                                    timeout=state_change_timeout)
-            except timeout_exception.TimeoutException:
+            except exception.TimeoutException:
                 return False
         if state in (ACTIVE, SHUTOFF):
             return True

--- a/cloudferrylib/os/compute/nova_compute.py
+++ b/cloudferrylib/os/compute/nova_compute.py
@@ -23,6 +23,7 @@ from novaclient.v1_1 import client as nova_client
 from novaclient import exceptions as nova_exc
 
 from cloudferrylib.base import compute
+from cloudferrylib.base import exception
 from cloudferrylib.os.compute import instances
 from cloudferrylib.os.compute import cold_evacuate
 from cloudferrylib.os.compute import server_groups
@@ -31,7 +32,6 @@ from cloudferrylib.utils import log
 from cloudferrylib.utils import mysql_connector
 from cloudferrylib.utils import node_ip
 from cloudferrylib.utils import proxy_client
-from cloudferrylib.utils import timeout_exception
 from cloudferrylib.utils import utils as utl
 
 LOG = log.getLogger(__name__)
@@ -93,7 +93,7 @@ class RandomSchedulerVmDeployer(object):
 
         try:
             return self.nc.deploy_instance(create_params, client_conf)
-        except timeout_exception.TimeoutException:
+        except exception.TimeoutException:
             az = instance['availability_zone']
             hosts = self.nc.get_compute_hosts(availability_zone=az)
             random.seed()
@@ -107,7 +107,7 @@ class RandomSchedulerVmDeployer(object):
                          create_params.get('availability_zone', 'UNKNOWN'))
                 try:
                     return self.nc.deploy_instance(create_params, client_conf)
-                except timeout_exception.TimeoutException:
+                except exception.TimeoutException:
                     pass
 
         message = ("Unable to schedule VM '{vm}' on any of available compute "
@@ -646,7 +646,7 @@ class NovaCompute(compute.Compute):
                 self.wait_for_status(new_id, self.get_status, 'active',
                                      timeout=conf.migrate.boot_timeout,
                                      stop_statuses=[ERROR])
-            except timeout_exception.TimeoutException:
+            except exception.TimeoutException:
                 LOG.warning("Failed to create instance '%s'", new_id)
                 self._failed_instances.append(new_id)
                 raise
@@ -863,7 +863,7 @@ class NovaCompute(compute.Compute):
             try:
                 reduce(lambda res, f: f(instance), map_status[curr][will],
                        None)
-            except timeout_exception.TimeoutException:
+            except exception.TimeoutException:
                 LOG.warning("Failed to change state from '%s' to '%s' for VM "
                             "'%s'", curr, will, instance.name)
 

--- a/cloudferrylib/utils/timeout_exception.py
+++ b/cloudferrylib/utils/timeout_exception.py
@@ -1,8 +1,0 @@
-__author__ = 'toha'
-
-
-class TimeoutException(Exception):
-    def __init__(self, status_obj, exp_status, msg):
-        self.status_obj = status_obj
-        self.exp_status = exp_status
-        self.msg = msg

--- a/cloudferrylib/utils/utils.py
+++ b/cloudferrylib/utils/utils.py
@@ -417,17 +417,6 @@ class UpSshTunnelClass:
         self.remove_port(self.port)
 
 
-class ChecksumImageInvalid(Exception):
-    def __init__(self, checksum_source, checksum_dest):
-        self.checksum_source = checksum_source
-        self.checksum_dest = checksum_dest
-
-    def __str__(self):
-        return repr("Checksum of image source = %s" +
-                    "Checksum of image dest = %s" %
-                    (self.checksum_source, self.checksum_dest))
-
-
 def render_info(info_values, template_path="templates",
                 template_file="info.html"):
     info_env = Environment(loader=FileSystemLoader(template_path))

--- a/tests/cloudferrylib/base/test_resource.py
+++ b/tests/cloudferrylib/base/test_resource.py
@@ -16,12 +16,12 @@
 
 import mock
 
+from cloudferrylib.base import exception
 from cloudferrylib.base import resource
-from cloudferrylib.utils import timeout_exception
 
 from tests import test
 
-t_exc = timeout_exception.TimeoutException
+t_exc = exception.TimeoutException
 
 
 class ResourceTestCase(test.TestCase):

--- a/tests/cloudferrylib/os/compute/test_nova.py
+++ b/tests/cloudferrylib/os/compute/test_nova.py
@@ -19,8 +19,8 @@ import mock
 from novaclient.v1_1 import client as nova_client
 from oslotest import mockpatch
 
+from cloudferrylib.base import exception
 from cloudferrylib.os.compute import nova_compute
-from cloudferrylib.utils import timeout_exception
 from cloudferrylib.utils import utils
 
 from tests import test
@@ -340,7 +340,7 @@ class DeployInstanceWithManualScheduling(test.TestCase):
 
         nc = mock.Mock()
         nc.get_compute_hosts.return_value = compute_hosts
-        nc.deploy_instance.side_effect = timeout_exception.TimeoutException(
+        nc.deploy_instance.side_effect = exception.TimeoutException(
             None, None, None)
 
         deployer = nova_compute.RandomSchedulerVmDeployer(nc)


### PR DESCRIPTION
Move TimeoutException from cloudferrylib.utils.timeout_exception to
cloudferrylib.base.exception.
Remove unused ChecksumImageInvalid from cloudferrylib.utils.utils.