### PR TITLE
[CF-167] Fix searching tenant by name.

### DIFF
--- a/tests/cloudferrylib/os/identity/test_keystone.py
+++ b/tests/cloudferrylib/os/identity/test_keystone.py
@@ -126,10 +126,9 @@ class KeystoneIdentityTestCase(test.TestCase):
 
     def test_get_tenant_by_name_default(self):
         self.mock_client().tenants.list.return_value = []
-
-        tenant = self.keystone_client.get_tenant_by_name('tenant_name_0')
-
-        self.assertIsNone(tenant)
+        self.assertRaises(
+            exceptions.NotFound,
+            self.keystone_client.get_tenant_by_name, 'tenant_name_0')
 
     def test_get_users_list(self):
         fake_users_list = [self.fake_user_0, self.fake_user_1]


### PR DESCRIPTION
Looks like tenant names are case-insensitive. E.g. when you try to
create tenant with name "TEST" when tenant with name "test" already
exists, you will get 409 Conflict. But when you try to search tenant
by name using keystone_client.tenants.find(name='TEST') you will
get NotFound exception because find function code don't respect
tenant name case insensitivity. This patch fix this problem by
using get_tenant_by_name method instead of tenants.find.