### PR TITLE
[CF-52] Extend FT to verify migration of VMs which already exist

### DIFF
--- a/devlab/generate_load.py
+++ b/devlab/generate_load.py
@@ -300,26 +300,27 @@ class Prerequisites(base.BasePrerequisites):
                 yaml.dump(filter_dict, f, default_flow_style=False)
 
     @clean_if_exists
-    def create_flavors(self):
-        for flavor in self.config.flavors:
-            if flavor.get('is_deleted'):
-                flavor.pop('is_deleted')
-                fl = self.novaclient.flavors.create(**flavor)
-                self.novaclient.flavors.delete(fl.id)
-            else:
-                fl = self.novaclient.flavors.create(**flavor)
-            if not is_flavor_public(flavor):
-                self.novaclient.flavor_access.add_tenant_access(
-                    flavor=fl.id,
-                    tenant=self.get_tenant_id(self.tenant))
+    def create_flavors(self, flavor_list=None):
+        def _create_flavors(flavors, ten_id):
+            for flavor in flavors:
+                if flavor.get('is_deleted'):
+                    flavor.pop('is_deleted')
+                    fl = self.novaclient.flavors.create(**flavor)
+                    self.novaclient.flavors.delete(fl.id)
+                else:
+                    fl = self.novaclient.flavors.create(**flavor)
+                if not is_flavor_public(flavor):
+                    self.novaclient.flavor_access.add_tenant_access(
+                        flavor=fl.id, tenant=ten_id)
+
+        if flavor_list is not None:
+            _create_flavors(flavor_list, self.get_tenant_id(self.tenant))
+            return
+        _create_flavors(self.config.flavors, self.get_tenant_id(self.tenant))
         for tenant in self.config.tenants:
             if tenant.get('flavors'):
-                for flavor in tenant['flavors']:
-                    fl = self.novaclient.flavors.create(**flavor)
-                    if not is_flavor_public(flavor):
-                        self.novaclient.flavor_access.add_tenant_access(
-                            flavor=fl.id,
-                            tenant=self.get_tenant_id(tenant['name']))
+                tenant_id = self.get_tenant_id(tenant['name'])
+                _create_flavors(tenant['flavors'], tenant_id)
 
     def _get_parameters_for_vm_creating(self, vm):
         def get_vm_nics(_vm):
@@ -356,7 +357,7 @@ class Prerequisites(base.BasePrerequisites):
             _create_groups(tenant['server_groups'])
         self.switch_user(self.username, self.password, self.tenant)
 
-    def create_vms(self):
+    def create_vms(self, vm_list):
 
         def wait_for_vm_creating():
             """ When limit for creating vms in nova is reached, we receive
@@ -378,23 +379,24 @@ class Prerequisites(base.BasePrerequisites):
                     'VMs with ids {0} were in "BUILD" state more than {1} '
                     'seconds'.format(spawning_vms, TIMEOUT))
 
-        def create_vms(vm_list):
-            vm_ids = []
-            for vm in vm_list:
-                wait_for_vm_creating()
-                _vm = self.novaclient.servers.create(
-                    **self._get_parameters_for_vm_creating(vm))
-                vm_ids.append(_vm.id)
-                if not vm.get('fip'):
-                    continue
-                self.wait_until_objects_created([_vm.id], self.check_vm_state,
-                                                TIMEOUT)
-                fip = self.neutronclient.create_floatingip(
-                    {"floatingip": {"floating_network_id": self.ext_net_id}})
-                _vm.add_floating_ip(fip['floatingip']['floating_ip_address'])
-            return vm_ids
+        vm_ids = []
+        for vm in vm_list:
+            wait_for_vm_creating()
+            _vm = self.novaclient.servers.create(
+                **self._get_parameters_for_vm_creating(vm))
+            vm_ids.append(_vm.id)
+            if not vm.get('fip'):
+                continue
+            self.wait_until_objects_created([_vm.id], self.check_vm_state,
+                                            TIMEOUT)
+            fip = self.neutronclient.create_floatingip(
+                {"floatingip": {"floating_network_id": self.ext_net_id}})
+            _vm.add_floating_ip(fip['floatingip']['floating_ip_address'])
+        return vm_ids
 
-        vms = create_vms(self.config.vms)
+    def create_all_vms(self):
+
+        vms = self.create_vms(self.config.vms)
         for tenant in self.config.tenants:
             if not tenant.get('vms'):
                 continue
@@ -420,13 +422,13 @@ class Prerequisites(base.BasePrerequisites):
                     raise RuntimeError(msg.format(keypair[0], tenant['name']))
                 self.switch_user(user=user['name'], password=user['password'],
                                  tenant=tenant['name'])
-                vms.extend(create_vms(keypairs_vms[keypair]))
+                vms.extend(self.create_vms(keypairs_vms[keypair]))
             # Create vms without keypair
             user = [u for u in self.config.users
                     if u.get('tenant') == tenant['name']][0]
             self.switch_user(user=user['name'], password=user['password'],
                              tenant=tenant['name'])
-            vms.extend(create_vms(vms_wo_keypairs))
+            vms.extend(self.create_vms(vms_wo_keypairs))
         self.switch_user(user=self.username, password=self.password,
                          tenant=self.tenant)
 
@@ -451,13 +453,13 @@ class Prerequisites(base.BasePrerequisites):
             # Possible parameters for network creating
             params = ['name', 'admin_state_up', 'shared', 'router:external',
                       'provider:network_type', 'provider:segmentation_id',
-                      'provider:physical_network']
+                      'provider:physical_network', 'tenant_id']
             return {param: _net[param] for param in params if param in _net}
 
         def get_body_for_subnet_creating(_subnet):
             # Possible parameters for subnet creating
             params = ['name', 'cidr', 'allocation_pools', 'dns_nameservers',
-                      'host_routes', 'ip_version', 'network_id']
+                      'host_routes', 'ip_version', 'network_id', 'tenant_id']
             return {param: _subnet[param] for param in params
                     if param in _subnet}
 
@@ -962,6 +964,40 @@ class Prerequisites(base.BasePrerequisites):
                 self.create_unassociated_fips(self.dst_cloud.neutronclient,
                                               self.config.dst_unassociated_fip,
                                               ext_net_id)
+        dst_tenants = [t for t in self.config.tenants
+                       if t.get('exists_on_dst')]
+        for tenant in dst_tenants:
+            tenant_id = self.dst_cloud.get_tenant_id(tenant['name'])
+            for net in tenant['networks']:
+                net['tenant_id'] = tenant_id
+                for subnet in net['subnets']:
+                    subnet['tenant_id'] = tenant_id
+            self.dst_cloud.create_networks(tenant['networks'])
+
+    def create_vms_on_dst(self):
+        def get_user_for_tenant(tenant_name):
+            for user in self.config.users:
+                if user.get('tenant') == tenant_name:
+                    return user
+            raise RuntimeError(
+                'User for tenant %s was not found' % tenant_name)
+
+        tenants = {}
+        for vm in self.config.dst_vms:
+            if vm['tenant'] in tenants:
+                tenants[vm['tenant']].append(vm)
+            else:
+                tenants[vm['tenant']] = [vm]
+
+        flv_names = {vm['flavor'] for vm in self.config.dst_vms}
+        flavors = [f for f in self.config.flavors if f['name'] in flv_names]
+        self.dst_cloud.create_flavors(flavors)
+
+        for tenant_name, vms in tenants.iteritems():
+            user = get_user_for_tenant(tenant_name)
+            self.dst_cloud.switch_user(
+                user['name'], user['password'], user['tenant'])
+            self.dst_cloud.create_vms(vms)
 
     def create_ext_net_map_yaml(self):
         src_ext_nets = [net['name'] for net in self.config.networks
@@ -1003,7 +1039,7 @@ class Prerequisites(base.BasePrerequisites):
             LOG.info('Boot vm from volume')
             self.boot_vms_from_volumes()
         LOG.info('Creating vms')
-        self.create_vms()
+        self.create_all_vms()
         LOG.info('Breaking VMs')
         self.break_vm()
         LOG.info('Breaking Images')
@@ -1048,7 +1084,8 @@ class Prerequisites(base.BasePrerequisites):
         self.create_dst_networking()
         LOG.info('Creating networks map')
         self.create_ext_net_map_yaml()
-
+        LOG.info('Creating vms on dst:')
+        self.create_vms_on_dst()
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(

--- a/devlab/tests/config.py
+++ b/devlab/tests/config.py
@@ -74,11 +74,14 @@ users = [
     {'name': 'user7', 'password': 'passwd', 'email': 'user7@example.com',
      'tenant': 'tenant4', 'enabled': True},
     {'name': 'user8', 'password': 'passwd', 'email': 'tenant3@example.com',
-     'tenant': 'tenant3', 'enabled': True}
+     'tenant': 'tenant3', 'enabled': True},
+    {'name': 'user9', 'password': 'passwd', 'email': 'user8@example.com',
+     'tenant': 'tenant5', 'enabled': True},
 ]
 """Users to create/delete"""
 
 user_tenant_roles = [
+    {'user9': [{'tenant': 'tenant5', 'role': 'SomeRole'}]},
     {'user1': [{'tenant': 'tenant1', 'role': 'SomeRole'}]}
 ]
 
@@ -116,7 +119,8 @@ tenants = [
          {'name': 'tn1server2', 'image': 'image1', 'flavor': 'flavorname1',
           'server_group': 'tn1_server_group'},
          {'name': 'server6', 'image': 'image1', 'flavor': 'del_flvr',
-          'server_group': 'tn1_server_group2'}],
+          'server_group': 'tn1_server_group2'}
+     ],
      'networks': [
          {'name': 'tenantnet1', 'admin_state_up': True,
           'subnets': [
@@ -211,7 +215,8 @@ tenants = [
           'fip': True, 'key_name': 'key2'},
          {'name': 'keypair_test_server', 'image': 'image1',
           'flavor': 'flavorname2', 'key_name': 'key2', 'nics': [
-              {'net-id': 'tenantnet2'}], 'fip': True}],
+              {'net-id': 'tenantnet2'}], 'fip': True}
+     ],
      'networks': [
          {'name': 'tenantnet2', 'admin_state_up': True,
           'subnets': [
@@ -343,14 +348,37 @@ tenants = [
          {'name': 'sg42', 'description': 'Tenant4 blah group2'}],
      'cinder_volumes': [],
      'cinder_snapshots': []
+     },
+    {'name': 'tenant5', 'description': 'Tenant5 exists on dst and src',
+     'exists_on_dst': True, 'enabled': True,
+     'networks': [
+         {'name': 'tenant5net',  'provider:segmentation_id': 100,
+          'provider:network_type': 'gre',
+          'subnets': [
+              {'cidr': '122.2.2.0/24', 'ip_version': 4, 'name': 't5_s1'}]},
+         {'name': 'tenant5net2',  'provider:segmentation_id': 101,
+          'provider:network_type': 'gre',
+          'subnets': [
+              {'cidr': '123.2.2.0/24', 'ip_version': 4, 'name': 't5_s2'}]}],
+     'vms': [
+         {'name': 'tn5server1', 'image': 'image1', 'flavor': 'flavorname2',
+          'nics': [{'net-id': 'tenant5net', 'v4-fixed-ip': '122.2.2.100'}]},
+         {'name': 'tn5server2', 'image': 'image1', 'flavor': 'flavorname2',
+          'nics': [{'net-id': 'tenant5net2', 'v4-fixed-ip': '123.2.2.100'}]},
+         {'name': 'tn5server3', 'image': 'image1', 'flavor': 'flavorname2',
+          'nics': [{'net-id': 'tenant5net2', 'v4-fixed-ip': '123.2.2.101'}]}
+         ],
+     'images': [{'name': 'cirros_image_for_tenant5', 'copy_from': img_url,
+                 'is_public': True}],
      }
 ]
 """Tenants to create/delete"""
 
 images = [
-    {'name': 'image1', 'copy_from': img_url, 'is_public': True},
+    {'name': 'image1', 'copy_from': img_url, 'is_public': True,
+     'upload_on_dst': True},
     {'name': 'image2', 'copy_from': img_url, 'container_format': 'bare',
-     'disk_format': 'qcow2', 'is_public': False},
+     'disk_format': 'qcow2', 'is_public': True},
     {'name': 'image3', 'copy_from': img_url, 'container_format': 'bare',
      'disk_format': 'qcow2', 'is_public': False},
     {'name': 'image4', 'copy_from': img_url, 'container_format': 'bare',
@@ -528,10 +556,25 @@ vms = [
      'server_group': 'admin_server_group'}
 ]
 """VM's to create/delete"""
+
+dst_vms = [
+    {'name': 'tn5server1', 'image': 'image1', 'flavor': 'flavorname2',
+     'tenant': 'tenant5', 'nics': [{'net-id': 'tenant5net',
+                                    'v4-fixed-ip': '122.2.2.100'}]},
+    {'name': 'tn5server2', 'image': 'image1', 'flavor': 'flavorname2',
+     'tenant': 'tenant5', 'nics': [{'net-id': 'tenant5net2',
+                                    'v4-fixed-ip': '123.2.2.102'}]},
+    {'name': 'tn5server3', 'image': 'image1', 'flavor': 'flavorname2',
+     'nics': [{'net-id': 'tenant5net', 'v4-fixed-ip': '122.2.2.101'}],
+     'tenant': 'tenant5'},
+]
+"""VM's to create on DST environment"""
+
 vms_from_volumes = [
     {'name': 'server_from_volume', 'flavor': 'flavorname1',
      'volume': 'volume_from_image'}
 ]
+"""VM's to create from volumes"""
 
 routers = [
     {'router': {'external_gateway_info': {}, 'name': 'ext_router',

--- a/devlab/tests/testcases/test_resource_migration.py
+++ b/devlab/tests/testcases/test_resource_migration.py
@@ -516,28 +516,50 @@ class ResourceMigrationTests(functional_test.FunctionalTest):
                                         'SRC %s' %
                                         (dst_tenant_name, src_tenant_name))
 
-    @attr(migrated_tenant='tenant2')
     def test_migrate_vms_parameters(self):
         """Validate VMs were migrated with correct parameters.
 
         :param name:
         :param config_drive:
-        :param key_name:"""
-        src_vms = self.filter_vms()
+        :param key_name:
+        :param security_groups:
+        :param metadata:"""
+
+        def set_hash_for_vms(vm_list):
+            for vm in vm_list:
+                for net in vm.addresses:
+                    nics = [(net, ip['addr']) for ip in vm.addresses[net]
+                            if ip['OS-EXT-IPS:type'] == 'fixed']
+                    setattr(vm, 'vm_hash',  (vm.name, nics))
+
+        def compare_vm_parameter(param, vm1, vm2):
+            if getattr(vm1, param, None) != getattr(vm2, param, None):
+                error_msg = ('Parameter {param} for VM with name '
+                             '{name} is different src: {vm1}, dst: {vm2}')
+                self.fail(error_msg.format(param=param, name=vm1.name,
+                                           vm1=getattr(vm1, param),
+                                           vm2=getattr(vm2, param)))
+
         dst_vms = self.dst_cloud.novaclient.servers.list(
-            search_opts={'all_tenants': 1})
-
-        filtering_data = self.filtering_utils.filter_vms(src_vms)
-        src_vms = filtering_data[0]
-
-        src_vms = [vm for vm in src_vms if vm.status != 'ERROR']
-
-        self.validate_resource_parameter_in_dst(
-            src_vms, dst_vms, resource_name='VM', parameter='name')
-        self.validate_resource_parameter_in_dst(
-            src_vms, dst_vms, resource_name='VM', parameter='config_drive')
-        self.validate_resource_parameter_in_dst(
-            src_vms, dst_vms, resource_name='VM', parameter='key_name')
+            search_opts={'all_tenants': True})
+        filtering_data = self.filtering_utils.filter_vms(self.filter_vms())
+        src_vms = [vm for vm in filtering_data[0] if vm.status != 'ERROR']
+        set_hash_for_vms(src_vms)
+        set_hash_for_vms(dst_vms)
+        if not src_vms:
+            self.skipTest('Nothing to check - source resources list is empty')
+        parameters = ('config_drive', 'key_name', 'security_groups',
+                      'metadata')
+        for src_vm in src_vms:
+            for dst_vm in dst_vms:
+                if src_vm.vm_hash != dst_vm.vm_hash:
+                    continue
+                for param in parameters:
+                    compare_vm_parameter(param, src_vm, dst_vm)
+                break
+            else:
+                msg = 'VM with hash %s was not found on dst'
+                self.fail(msg % str(src_vm.vm_hash))
 
     @attr(migrated_tenant=['admin', 'tenant1', 'tenant2'])
     def test_migrate_vms_with_floating(self):

--- a/devlab/tests/testcases/test_vm_migration.py
+++ b/devlab/tests/testcases/test_vm_migration.py
@@ -121,3 +121,15 @@ class VmMigration(FunctionalTest):
         for src_vm, vm_index in zip(src_vms, self.dst_vm_indexes):
             self.assertTrue(src_vm.image.id ==
                             self.dst_vms[vm_index].image.id)
+
+    def test_vms_with_same_ip_did_not_migrate(self):
+        vm_addrs = []
+        for vm in self.dst_vms:
+            for net in vm.addresses:
+                vm_addrs.extend([(net, ip['addr']) for ip in vm.addresses[net]
+                                 if ip['OS-EXT-IPS:type'] == 'fixed'])
+        duplicates = {vm for vm in vm_addrs if vm_addrs.count(vm) > 1}
+        if duplicates:
+            msg = ('2 or more vms exist on dst in the same net with same ip'
+                   ' address: %s')
+            self.fail(msg % duplicates)


### PR DESCRIPTION
Added in generate_load creating similar VMs on dst ans src clouds.
1. Totally same VM. VM must be treated as migrated/existing
2. VM with different flavor and image. VM must be treated as
   migrated/existing.
3. VM in the different networks. VM must be treated as unrelated,
   meaning that migration tool should bring up another instance
   in correct network.

Next parameters added to check:
- security_groups
- metadata