### PR TITLE
[CF-120] Fix attempting to boot VM second time fails with "Port is still in use"

### DIFF
--- a/cloudferrylib/os/actions/instance_floatingip_actions.py
+++ b/cloudferrylib/os/actions/instance_floatingip_actions.py
@@ -16,6 +16,7 @@
 import copy
 
 from cloudferrylib.base.action import action
+from cloudferrylib.os.network import network_utils
 from cloudferrylib.utils import utils as utl
 
 
@@ -30,16 +31,9 @@ class AssociateFloatingip(action.Action):
 
     def run(self, info=None, **kwargs):
         if self.cfg.migrate.keep_floatingip:
-            info_compute = copy.deepcopy(info)
             network_resource = self.cloud.resources[utl.NETWORK_RESOURCE]
+            network_utils.associate_floatingip(info, network_resource)
 
-            instance = info_compute[utl.INSTANCES_TYPE].values()[0]
-            networks_info = instance[utl.INSTANCE_BODY].get('nics', [])
-            for net in networks_info:
-                fip = net.get('floatingip')
-                if fip is not None:
-                    network_resource.update_floatingip(
-                        fip['dst_floatingip_id'], fip['dst_port_id'])
         return {}
 
 

--- a/cloudferrylib/os/actions/prepare_networks.py
+++ b/cloudferrylib/os/actions/prepare_networks.py
@@ -13,11 +13,10 @@
 # limitations under the License.
 
 
-import copy
-
 from cloudferrylib.base.action import action
+from cloudferrylib.os.network import network_utils
 from cloudferrylib.utils import log
-from cloudferrylib.utils import utils as utl
+from cloudferrylib.utils import utils
 
 LOG = log.getLogger(__name__)
 
@@ -35,79 +34,15 @@ class PrepareNetworks(action.Action):
 
     def run(self, info=None, **kwargs):
 
-        info_compute = copy.deepcopy(info)
+        network_resource = self.cloud.resources[utils.NETWORK_RESOURCE]
+        identity_resource = self.cloud.resources[utils.IDENTITY_RESOURCE]
 
-        network_resource = self.cloud.resources[utl.NETWORK_RESOURCE]
-        identity_resource = self.cloud.resources[utl.IDENTITY_RESOURCE]
-
-        keep_ip = self.cfg.migrate.keep_ip
-
-        instances = info_compute[utl.INSTANCES_TYPE]
-
-        # Get all tenants, participated in migration process
-        tenants = set()
-        for instance in instances.values():
-            tenants.add(instance[utl.INSTANCE_BODY]['tenant_name'])
-
-        # disable DHCP in all subnets
-        subnets = network_resource.get_subnets()
-        for snet in subnets:
-            if snet['tenant_name'] in tenants:
-                network_resource.reset_subnet_dhcp(snet['id'], False)
-
-        for (id_inst, inst) in instances.iteritems():
-            params = []
-            networks_info = inst[utl.INSTANCE_BODY][utl.INTERFACES]
-            security_groups = inst[utl.INSTANCE_BODY]['security_groups']
-            tenant_name = inst[utl.INSTANCE_BODY]['tenant_name']
-            tenant_id = identity_resource.get_tenant_id_by_name(tenant_name)
-            for src_net in networks_info:
-                dst_net = network_resource.get_network(src_net, tenant_id,
-                                                       keep_ip)
-                mac_address = src_net['mac_address']
-                ip_addresses = src_net['ip_addresses']
-                for ip_address in ip_addresses:
-                    port_dict = network_resource.check_existing_port(
-                        dst_net['id'], mac_address, ip_address)
-                    if port_dict:
-                        network_resource.delete_port(port_dict['id'])
-                sg_ids = []
-                for sg in network_resource.get_security_groups():
-                    if sg['tenant_id'] == tenant_id:
-                        if sg['name'] in security_groups:
-                            sg_ids.append(sg['id'])
-
-                port = network_resource.create_port(
-                    dst_net['id'], mac_address, ip_addresses, tenant_id,
-                    keep_ip, sg_ids, src_net['allowed_address_pairs'])
-                fip = None
-                src_fip = src_net['floatingip']
-                if src_fip:
-                    dst_flotingips = network_resource.get_floatingips()
-                    dst_flotingips_map = {
-                        fl_ip['floating_ip_address']: fl_ip['id']
-                        for fl_ip in dst_flotingips
-                    }
-                    # floating IP may be filtered and not exist on dest
-                    dst_floatingip_id = dst_flotingips_map.get(src_fip)
-                    if dst_floatingip_id is None:
-                        LOG.warning("Floating IP '%s' is not available on "
-                                    "destination, make sure floating IPs "
-                                    "migrated correctly", src_fip)
-                    else:
-                        fip = {'dst_floatingip_id': dst_floatingip_id,
-                               'dst_port_id': port['id']}
-                params.append({'net-id': dst_net['id'],
-                               'port-id': port['id'],
-                               'floatingip': fip})
-            instances[id_inst][utl.INSTANCE_BODY]['nics'] = params
-        info_compute[utl.INSTANCES_TYPE] = instances
-
-        # Reset DHCP to the original settings
-        for snet in subnets:
-            if snet['tenant_name'] in tenants:
-                network_resource.reset_subnet_dhcp(snet['id'],
-                                                   snet['enable_dhcp'])
+        info_compute = network_utils.prepare_networks(
+            info,
+            self.cfg.migrate.keep_ip,
+            network_resource,
+            identity_resource
+        )
 
         return {
             'info': info_compute

--- a/cloudferrylib/os/actions/transport_instance.py
+++ b/cloudferrylib/os/actions/transport_instance.py
@@ -14,10 +14,13 @@
 
 import logging
 import copy
+import random
 
 from cloudferrylib.base.action import action
+from cloudferrylib.base import exception
 from cloudferrylib.os.identity import keystone
-from cloudferrylib.utils import utils as utl
+from cloudferrylib.os.network import network_utils
+from cloudferrylib.utils import utils
 
 
 LOG = logging.getLogger(__name__)
@@ -27,7 +30,6 @@ CLOUD = 'cloud'
 BACKEND = 'backend'
 CEPH = 'ceph'
 ISCSI = 'iscsi'
-COMPUTE = 'compute'
 INSTANCES = 'instances'
 INSTANCE_BODY = 'instance'
 INSTANCE = 'instance'
@@ -51,17 +53,22 @@ TRANSPORTER_MAP = {CEPH: {CEPH: 'ssh_ceph_to_ceph',
                            ISCSI: 'ssh_file_to_file'}}
 
 
+class DestinationCloudNotOperational(RuntimeError):
+    pass
+
+
 class TransportInstance(action.Action):
     # TODO constants
 
     def run(self, info=None, **kwargs):
         info = copy.deepcopy(info)
         new_info = {
-            utl.INSTANCES_TYPE: {
+            utils.INSTANCES_TYPE: {
             }
         }
 
-        for instance_id, instance in info[utl.INSTANCES_TYPE].iteritems():
+        # Get next one instance
+        for instance_id, instance in info[utils.INSTANCES_TYPE].iteritems():
             instance = self._replace_user_ids(instance)
             src_instance = instance['instance']
             src_image_id = src_instance['image_id']
@@ -81,15 +88,15 @@ class TransportInstance(action.Action):
                 src_instance['image_id'] = dst_image.id
 
             one_instance = {
-                utl.INSTANCES_TYPE: {
+                utils.INSTANCES_TYPE: {
                     instance_id: instance
                 }
             }
 
             one_instance = self.deploy_instance(one_instance)
 
-            new_info[utl.INSTANCES_TYPE].update(
-                one_instance[utl.INSTANCES_TYPE])
+            new_info[utils.INSTANCES_TYPE].update(
+                one_instance[utils.INSTANCES_TYPE])
 
         return {
             'info': new_info
@@ -98,11 +105,11 @@ class TransportInstance(action.Action):
     def get_dst_image(self, src_image_id):
         """Returns active image for VM. If not found, tries to match image
         based on image name, tenant, checksum and size"""
-        dst_glance = self.dst_cloud.resources[utl.IMAGE_RESOURCE]
+        dst_glance = self.dst_cloud.resources[utils.IMAGE_RESOURCE]
         image = dst_glance.get_active_image_by_id(src_image_id)
 
         if image is None:
-            src_glance = self.src_cloud.resources[utl.IMAGE_RESOURCE]
+            src_glance = self.src_cloud.resources[utils.IMAGE_RESOURCE]
             src_image = src_glance.get_image_by_id(src_image_id)
 
             if src_image is None:
@@ -111,8 +118,8 @@ class TransportInstance(action.Action):
                 return
 
             dst_tenant = keystone.get_dst_tenant_from_src_tenant_id(
-                self.src_cloud.resources[utl.IDENTITY_RESOURCE],
-                self.dst_cloud.resources[utl.IDENTITY_RESOURCE],
+                self.src_cloud.resources[utils.IDENTITY_RESOURCE],
+                self.dst_cloud.resources[utils.IDENTITY_RESOURCE],
                 src_image.owner)
 
             LOG.info("Image with ID '%s' was not found in destination cloud, "
@@ -127,26 +134,91 @@ class TransportInstance(action.Action):
 
         return image
 
-    def deploy_instance(self, info):
-        info = copy.deepcopy(info)
-        dst_compute = self.dst_cloud.resources[COMPUTE]
+    def deploy_instance(self, one_instance):
+        one_instance = copy.deepcopy(one_instance)
+        dst_compute = self.dst_cloud.resources[utils.COMPUTE_RESOURCE]
 
-        new_ids = dst_compute.deploy(info)
+        _instance = one_instance[utils.INSTANCES_TYPE].values()[0]
+        instance = _instance[utils.INSTANCE_BODY]
+        new_ids = {}
+        try:
+            new_id = dst_compute.deploy(instance)
+        except exception.TimeoutException:
+            one_instance, new_id = self._deploy_instance_on_random_host(
+                one_instance
+            )
+
+        new_ids[new_id] = instance['id']
+
         new_info = dst_compute.read_info(search_opts={'id': new_ids.keys()})
         for i in new_ids.iterkeys():
             dst_compute.change_status('shutoff', instance_id=i)
         for new_id, old_id in new_ids.iteritems():
             new_instance = new_info['instances'][new_id]
-            old_instance = info['instances'][old_id]
+            old_instance = one_instance['instances'][old_id]
 
             new_instance['old_id'] = old_id
             new_instance['meta'] = old_instance['meta']
             new_instance['meta']['source_status'] = \
                 old_instance['instance']['status']
-            new_instance[utl.INSTANCE_BODY]['key_name'] = \
-                old_instance[utl.INSTANCE_BODY]['key_name']
-        info = self.prepare_ephemeral_drv(info, new_info, new_ids)
-        return info
+            new_instance[utils.INSTANCE_BODY]['key_name'] = \
+                old_instance[utils.INSTANCE_BODY]['key_name']
+        one_instance = self.prepare_ephemeral_drv(
+            one_instance,
+            new_info,
+            new_ids
+        )
+        return one_instance
+
+    def _deploy_instance_on_random_host(self, one_instance):
+        one_instance = copy.deepcopy(one_instance)
+        dst_compute = self.dst_cloud.resources[utils.COMPUTE_RESOURCE]
+
+        _instance = one_instance[utils.INSTANCES_TYPE].values()[0]
+        instance_body = _instance[utils.INSTANCE_BODY]
+        az = instance_body['availability_zone']
+        hosts = dst_compute.get_compute_hosts(availability_zone=az)
+        if not hosts:
+            message = ("No hosts in availability zone '{az}' "
+                       "found on destination.").format(az=az)
+            raise DestinationCloudNotOperational(message)
+
+        random.seed()
+        random.shuffle(hosts)
+
+        while hosts:
+            # Recreate ports and check floating ips
+            one_instance = network_utils.prepare_networks(
+                one_instance,
+                self.cfg.migrate.keep_ip,
+                self.dst_cloud.resources[utils.NETWORK_RESOURCE],
+                self.dst_cloud.resources[utils.IDENTITY_RESOURCE]
+            )
+
+            # Reassociate floating ips with ports
+            if self.cfg.migrate.keep_floatingip:
+                network_utils.associate_floatingip(
+                    one_instance,
+                    self.dst_cloud.resources[utils.NETWORK_RESOURCE]
+                )
+
+            next_host = hosts.pop()
+            availability_zone = ':'.join([az, next_host])
+            kwargs = {'availability_zone': availability_zone}
+
+            _updated_instance = one_instance[utils.INSTANCES_TYPE].values()[0]
+            updated_instance_body = _updated_instance[utils.INSTANCE_BODY]
+
+            try:
+                new_id = dst_compute.deploy(updated_instance_body, **kwargs)
+                return one_instance, new_id
+            except exception.TimeoutException:
+                pass
+
+        message = ("Unable to schedule VM '{vm}' on any of available compute "
+                   "nodes.").format(vm=instance_body['name'])
+        LOG.error(message)
+        raise DestinationCloudNotOperational(message)
 
     def prepare_ephemeral_drv(self, info, new_info, map_new_to_old_ids):
         info = copy.deepcopy(info)
@@ -183,8 +255,8 @@ class TransportInstance(action.Action):
 
         src_user_id = instance['instance']['user_id']
         dst_user = keystone.get_dst_user_from_src_user_id(
-            self.src_cloud.resources[utl.IDENTITY_RESOURCE],
-            self.dst_cloud.resources[utl.IDENTITY_RESOURCE],
+            self.src_cloud.resources[utils.IDENTITY_RESOURCE],
+            self.dst_cloud.resources[utils.IDENTITY_RESOURCE],
             src_user_id
         )
         instance['instance']['user_id'] = dst_user.id

--- a/cloudferrylib/os/compute/nova_compute.py
+++ b/cloudferrylib/os/compute/nova_compute.py
@@ -15,7 +15,6 @@
 
 import contextlib
 import copy
-import random
 import pprint
 import uuid
 
@@ -78,44 +77,6 @@ STATUSES_AFTER_MIGRATION = {ACTIVE: ACTIVE,
 
 CORRECT_STATUSES_AFTER_MIGRATION = {STATUSES_AFTER_MIGRATION[status]
                                     for status in ALLOWED_VM_STATUSES}
-
-
-class DestinationCloudNotOperational(RuntimeError):
-    pass
-
-
-class RandomSchedulerVmDeployer(object):
-    """Creates VM on destination. Tries to create VM on random compute host if
-    failed with the one picked by nova scheduler"""
-
-    def __init__(self, nova_compute_obj):
-        self.nc = nova_compute_obj
-
-    def deploy(self, create_params, client_conf):
-        LOG.info("Deploying instance '%s'", create_params['name'])
-        az = create_params['availability_zone']
-        try:
-            return self.nc.deploy_instance(create_params, client_conf)
-        except exception.TimeoutException:
-            hosts = self.nc.get_compute_hosts(availability_zone=az)
-            random.seed()
-            random.shuffle(hosts)
-
-            while hosts:
-                next_host = hosts.pop()
-                create_params['availability_zone'] = ':'.join([az, next_host])
-                LOG.info("Trying to deploy instance '%s' in '%s'",
-                         create_params['name'],
-                         create_params['availability_zone'])
-                try:
-                    return self.nc.deploy_instance(create_params, client_conf)
-                except exception.TimeoutException:
-                    pass
-
-        message = ("Unable to schedule VM '{vm}' on any of available compute "
-                   "nodes.").format(vm=create_params['name'])
-        LOG.error(message)
-        raise DestinationCloudNotOperational(message)
 
 
 class NovaCompute(compute.Compute):
@@ -515,7 +476,7 @@ class NovaCompute(compute.Compute):
         if target == 'resources':
             info = self._deploy_resources(info, **kwargs)
         elif target == 'instances':
-            info = self._deploy_instances(info)
+            info = self._deploy_instance(info, **kwargs)
         else:
             raise ValueError('Only "resources" or "instances" values allowed')
 
@@ -644,7 +605,7 @@ class NovaCompute(compute.Compute):
             self.update_quota(tenant_id=tenant_id, user_id=user_id,
                               **quota_info)
 
-    def deploy_instance(self, create_params, conf):
+    def try_deploy_instance(self, create_params, conf):
         with keystone.AddAdminUserToNonAdminTenant(
                 self.identity.keystone_client,
                 conf.cloud.user,
@@ -667,59 +628,63 @@ class NovaCompute(compute.Compute):
 
         return new_id
 
-    def _deploy_instances(self, info_compute):
-        new_ids = {}
-
+    def _deploy_instance(self, instance, **kwargs):
         client_conf = copy.deepcopy(self.config)
 
-        for _instance in info_compute['instances'].itervalues():
-            instance = _instance['instance']
-            with self._ensure_instance_flavor_exists(instance):
-                LOG.debug("creating instance %s", instance['name'])
-                create_params = {
-                    'name': instance['name'],
-                    'flavor': self.attr_override.get_attr(
-                        instance, 'flavor_id'),
-                    'key_name': self.attr_override.get_attr(
-                        instance, 'key_name'),
-                    'nics': instance['nics'],
-                    'image': instance['image_id'],
-                    'config_drive': instance['config_drive'],
-                    # user_id matches user_id on source
-                    'user_id': instance.get('user_id'),
-                    'availability_zone': self.attr_override.get_attr(
+        with self._ensure_instance_flavor_exists(instance):
+            LOG.debug("creating instance %s", instance['name'])
+            create_params = {
+                'name': instance['name'],
+                'flavor': self.attr_override.get_attr(
+                    instance, 'flavor_id'),
+                'key_name': self.attr_override.get_attr(
+                    instance, 'key_name'),
+                'nics': instance['nics'],
+                'image': instance['image_id'],
+                'config_drive': instance['config_drive'],
+                # user_id matches user_id on source
+                'user_id': instance.get('user_id'),
+                'availability_zone': self.attr_override.get_attr(
                         instance, 'availability_zone',
                         default=self.get_availability_zone(
                             instance['availability_zone'])),
-                    'scheduler_hints': {
-                        'group': self.attr_override.get_attr(
-                            instance, 'server_group')
-                    },
-                }
-                if instance['boot_mode'] == utl.BOOT_FROM_VOLUME:
-                    volume_id = instance['volumes'][0]['id']
-                    storage = self.cloud.resources[utl.STORAGE_RESOURCE]
-                    vol = storage.get_migrated_volume(volume_id)
+                'scheduler_hints': {
+                    'group': self.attr_override.get_attr(
+                        instance, 'server_group')
+                },
+            }
+            if instance['boot_mode'] == utl.BOOT_FROM_VOLUME:
+                volume_id = instance['volumes'][0]['id']
+                storage = self.cloud.resources[utl.STORAGE_RESOURCE]
+                vol = storage.get_migrated_volume(volume_id)
 
-                    if vol:
-                        create_params["block_device_mapping_v2"] = [{
-                            "source_type": "volume",
-                            "uuid": vol.id,
-                            "destination_type": "volume",
-                            "delete_on_termination": True,
-                            "boot_index": 0
-                        }]
-                        create_params['image'] = None
-                    else:
-                        msg = ("Bootable volume for instance '%s' is "
-                               "not present, volume will NOT be attached")
-                        LOG.warning(msg, instance['name'])
+                if vol:
+                    create_params["block_device_mapping_v2"] = [{
+                        "source_type": "volume",
+                        "uuid": vol.id,
+                        "destination_type": "volume",
+                        "delete_on_termination": True,
+                        "boot_index": 0
+                    }]
+                    create_params['image'] = None
+                else:
+                    msg = ("Bootable volume for instance '%s' is "
+                           "not present, volume will NOT be attached")
+                    LOG.warning(msg, instance['name'])
 
-                client_conf.cloud.tenant = instance['tenant_name']
-                new_id = RandomSchedulerVmDeployer(self).deploy(create_params,
-                                                                client_conf)
-                new_ids[new_id] = instance['id']
-        return new_ids
+            client_conf.cloud.tenant = instance['tenant_name']
+
+            az = kwargs.get('availability_zone', None)
+            if az:
+                create_params['availability_zone'] = az
+            else:
+                create_params['availability_zone'] =\
+                    self.attr_override.get_attr(
+                        instance, 'availability_zone',
+                        default=self.get_availability_zone(
+                            instance['availability_zone']))
+
+            return self.try_deploy_instance(create_params, client_conf)
 
     def create_instance(self, nclient, **kwargs):
         # do not provide key pair as boot argument, it will be updated with the

--- a/cloudferrylib/os/network/network_utils.py
+++ b/cloudferrylib/os/network/network_utils.py
@@ -1,0 +1,148 @@
+# Copyright 2016 Mirantis Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import copy
+
+from cloudferrylib.utils import log
+from cloudferrylib.utils import utils
+
+LOG = log.getLogger(__name__)
+
+
+def prepare_networks(info, keep_ip, network_resource, identity_resource):
+    info_compute = copy.deepcopy(info)
+
+    instances = info_compute[utils.INSTANCES_TYPE]
+
+    tenants = get_tenants(instances)
+
+    # disable DHCP in all subnets
+    reset_dhcp_in_subnets(network_resource,
+                          tenants,
+                          disable_dhcp=True)
+
+    for (id_inst, inst) in instances.iteritems():
+        params = []
+        networks_info = inst[utils.INSTANCE_BODY][utils.INTERFACES]
+        tenant_name = inst[utils.INSTANCE_BODY]['tenant_name']
+        tenant_id = identity_resource.get_tenant_id_by_name(tenant_name)
+        for src_net in networks_info:
+            dst_net = network_resource.get_network(src_net, tenant_id,
+                                                   keep_ip)
+            mac_address = src_net['mac_address']
+            ip_addresses = src_net['ip_addresses']
+
+            delete_existing_ports_on_dst(network_resource,
+                                         dst_net, ip_addresses,
+                                         mac_address)
+
+            sg_ids = get_security_groups_ids_for_tenant(network_resource,
+                                                        inst, tenant_id)
+
+            port = network_resource.create_port(
+                dst_net['id'], mac_address, ip_addresses, tenant_id,
+                keep_ip, sg_ids, src_net['allowed_address_pairs'])
+
+            floating_ip = check_floating_ip(network_resource,
+                                            src_net, port)
+
+            params.append({'net-id': dst_net['id'],
+                           'port-id': port['id'],
+                           'floatingip': floating_ip})
+        instances[id_inst][utils.INSTANCE_BODY]['nics'] = params
+    info_compute[utils.INSTANCES_TYPE] = instances
+
+    # Reset DHCP to the original settings
+    reset_dhcp_in_subnets(network_resource, tenants)
+
+    return info_compute
+
+
+def get_tenants(instances):
+    # Get all tenants, participated in migration process
+    tenants = set()
+    for instance in instances.values():
+        tenants.add(instance[utils.INSTANCE_BODY]['tenant_name'])
+
+    return tenants
+
+
+def reset_dhcp_in_subnets(network_resource, tenants, disable_dhcp=False):
+    subnets = network_resource.get_subnets()
+    for snet in subnets:
+        if snet['tenant_name'] in tenants:
+            if disable_dhcp:
+                # disable DHCP in all subnets
+                network_resource.reset_subnet_dhcp(snet['id'], False)
+            else:
+                # Reset DHCP to the original settings
+                network_resource.reset_subnet_dhcp(snet['id'],
+                                                   snet['enable_dhcp'])
+
+
+def delete_existing_ports_on_dst(network_resource,
+                                 dst_net,
+                                 ip_addresses,
+                                 mac_address):
+
+    for ip_address in ip_addresses:
+        port_dict = network_resource.check_existing_port(
+            dst_net['id'], mac_address, ip_address)
+        if port_dict:
+            network_resource.delete_port(port_dict['id'])
+
+
+def get_security_groups_ids_for_tenant(network_resource, inst, tenant_id):
+    security_groups = inst[utils.INSTANCE_BODY]['security_groups']
+    sg_ids = []
+    for sg in network_resource.get_security_groups():
+        if sg['tenant_id'] == tenant_id:
+            if sg['name'] in security_groups:
+                sg_ids.append(sg['id'])
+
+    return sg_ids
+
+
+def check_floating_ip(network_resource, src_net, port):
+    fip = None
+    src_fip = src_net['floatingip']
+    if src_fip:
+        dst_flotingips = network_resource.get_floatingips()
+        dst_flotingips_map = {
+            fl_ip['floating_ip_address']: fl_ip['id']
+            for fl_ip in dst_flotingips
+        }
+        # floating IP may be filtered and not exist on dest
+        dst_floatingip_id = dst_flotingips_map.get(src_fip)
+
+        if dst_floatingip_id is None:
+            LOG.warning("Floating IP '%s' is not available on "
+                        "destination, make sure floating IPs "
+                        "migrated correctly", src_fip)
+        else:
+            fip = {'dst_floatingip_id': dst_floatingip_id,
+                   'dst_port_id': port['id']}
+    return fip
+
+
+def associate_floatingip(info, network_resource):
+    info_compute = copy.deepcopy(info)
+
+    instance = info_compute[utils.INSTANCES_TYPE].values()[0]
+    networks_info = instance[utils.INSTANCE_BODY].get('nics', [])
+    for net in networks_info:
+        fip = net.get('floatingip')
+        if fip is not None:
+            network_resource.update_floatingip(
+                fip['dst_floatingip_id'], fip['dst_port_id'])

--- a/tests/cloudferrylib/os/actions/test_transport_instance.py
+++ b/tests/cloudferrylib/os/actions/test_transport_instance.py
@@ -1,0 +1,142 @@
+# Copyright 2016 Mirantis Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import mock
+
+from cloudferrylib.base import exception
+from cloudferrylib.os.actions import transport_instance
+from cloudferrylib.utils import utils
+
+from tests import test
+
+
+class DeployInstanceWithManualScheduling(test.TestCase):
+
+    @mock.patch("cloudferrylib.os.network.network_utils.prepare_networks")
+    @mock.patch("cloudferrylib.os.network.network_utils.associate_floatingip")
+    def test_tries_to_boot_vm_on_all_nodes(self,
+                                           associate_floatingip,
+                                           prepare_networks):
+
+        compute_hosts = ['host1', 'host2', 'host3']
+        num_computes = len(compute_hosts)
+        instance_body = {'availability_zone': 'somezone', 'name': 'vm1'}
+        one_instance = {
+            utils.INSTANCES_TYPE: {
+                'some_id': {
+                    utils.INSTANCE_BODY: instance_body,
+                }
+            }
+        }
+
+        dst_compute = mock.Mock()
+        dst_compute.get_compute_hosts.return_value = compute_hosts
+        dst_compute.deploy.side_effect = exception.TimeoutException(
+            None, None, None)
+
+        dst_cloud = mock.Mock()
+        dst_cloud.resources = {
+            utils.COMPUTE_RESOURCE: dst_compute,
+            utils.NETWORK_RESOURCE: mock.Mock(),
+            utils.IDENTITY_RESOURCE: mock.Mock(),
+        }
+
+        tr_inst = transport_instance.TransportInstance(mock.MagicMock())
+        tr_inst.cfg = mock.MagicMock()
+        tr_inst.cfg.migrate.keep_ip = True
+        tr_inst.cfg.migrate.keep_floatingip = True
+
+        tr_inst.dst_cloud = dst_cloud
+
+        self.assertRaises(
+            transport_instance.DestinationCloudNotOperational,
+            tr_inst._deploy_instance_on_random_host,
+            one_instance
+        )
+        self.assertEqual(associate_floatingip.call_count, num_computes)
+        self.assertEqual(prepare_networks.call_count, num_computes)
+        self.assertEqual(dst_compute.deploy.call_count, num_computes)
+
+    @mock.patch("cloudferrylib.os.network.network_utils.prepare_networks")
+    @mock.patch("cloudferrylib.os.network.network_utils.associate_floatingip")
+    def test_runs_only_one_boot_if_node_is_good(self,
+                                                associate_floatingip,
+                                                prepare_networks):
+        compute_hosts = mock.MagicMock()
+        compute_hosts.__iter__.return_value = ['host1', 'host2', 'host3']
+        compute_hosts.pop.return_value = 'host2'
+
+        instance_body = {'availability_zone': 'somezone', 'name': 'vm1'}
+        one_instance = {
+            utils.INSTANCES_TYPE: {
+                'some_id': {
+                    utils.INSTANCE_BODY: instance_body,
+                }
+            }
+        }
+
+        kwargs = {'availability_zone': 'somezone:host2'}
+
+        updated_instance_body = {
+            'availability_zone': 'somezone',
+            'name': 'vm1',
+            'nics': [{'floatingip': None,
+                      'net-id': 'id',
+                      'port-id': 'id'}]
+        }
+        updated_one_instance = {
+            utils.INSTANCES_TYPE: {
+                'some_id': {
+                    utils.INSTANCE_BODY: updated_instance_body
+                    }
+            }
+        }
+        prepare_networks.return_value = updated_one_instance
+
+        dst_compute = mock.Mock()
+        dst_compute.get_compute_hosts.return_value = compute_hosts
+
+        dst_cloud = mock.Mock()
+        dst_cloud.resources = {
+            utils.COMPUTE_RESOURCE: dst_compute,
+            utils.NETWORK_RESOURCE: mock.Mock(),
+            utils.IDENTITY_RESOURCE: mock.Mock(),
+        }
+
+        tr_inst = transport_instance.TransportInstance(mock.MagicMock())
+        tr_inst.cfg = mock.MagicMock()
+        tr_inst.cfg.migrate.keep_ip = True
+        tr_inst.cfg.migrate.keep_floatingip = True
+
+        tr_inst.dst_cloud = dst_cloud
+
+        tr_inst._deploy_instance_on_random_host(
+            one_instance
+        )
+
+        prepare_networks.assert_called_once_with(
+            one_instance,
+            tr_inst.cfg.migrate.keep_ip,
+            dst_cloud.resources[utils.NETWORK_RESOURCE],
+            dst_cloud.resources[utils.IDENTITY_RESOURCE],
+        )
+        associate_floatingip.assert_called_once_with(
+            prepare_networks.return_value,
+            dst_cloud.resources[utils.NETWORK_RESOURCE]
+        )
+        dst_compute.deploy.assert_called_once_with(
+            updated_instance_body,
+            **kwargs
+        )
+        self.assertEqual(dst_compute.deploy.call_count, 1)

--- a/tests/cloudferrylib/os/compute/test_nova.py
+++ b/tests/cloudferrylib/os/compute/test_nova.py
@@ -18,7 +18,6 @@ import mock
 from novaclient.v1_1 import client as nova_client
 from oslotest import mockpatch
 
-from cloudferrylib.base import exception
 from cloudferrylib.os.compute import nova_compute
 from cloudferrylib.utils import utils
 
@@ -375,39 +374,6 @@ class ComputeHostsTestCase(BaseNovaComputeTestCase):
         hosts = self.nova_client.get_compute_hosts(availability_zone='az')
 
         self.assertEqual(az_hosts, hosts)
-
-
-class DeployInstanceWithManualScheduling(test.TestCase):
-    def test_tries_to_boot_vm_on_all_nodes(self):
-        compute_hosts = ['host1', 'host2', 'host3']
-        num_computes = len(compute_hosts)
-        create_params = {'name': 'vm1', 'availability_zone': 'somezone'}
-        client_conf = mock.Mock()
-
-        nc = mock.Mock()
-        nc.get_availability_zone.return_value = 'nova'
-        nc.get_compute_hosts.return_value = compute_hosts
-        nc.deploy_instance.side_effect = exception.TimeoutException(
-            None, None, None)
-
-        deployer = nova_compute.RandomSchedulerVmDeployer(nc)
-        self.assertRaises(
-            nova_compute.DestinationCloudNotOperational,
-            deployer.deploy, create_params, client_conf)
-        self.assertEqual(nc.deploy_instance.call_count, num_computes + 1)
-
-    def test_runs_only_one_boot_if_node_is_good(self):
-        compute_hosts = ['host1', 'host2', 'host3']
-        create_params = {'name': 'vm1', 'availability_zone': 'somezone'}
-        client_conf = mock.Mock()
-
-        nc = mock.Mock()
-        nc.get_compute_hosts.return_value = compute_hosts
-
-        deployer = nova_compute.RandomSchedulerVmDeployer(nc)
-        deployer.deploy(create_params, client_conf)
-
-        self.assertEqual(nc.deploy_instance.call_count, 1)
 
 
 class FlavorDeploymentTestCase(test.TestCase):


### PR DESCRIPTION
Fix an issue when we trying boot VM in the same availability zone,
but on another host. For example we have this case when the VM failed
during deployment on the first host. Before this patch we had exception
"Port is still in use", because port is still attached to the failed VM.
With this patch CloudFerry recreate ports for the VM and trying boot it
on another host.