### PR TITLE
Remove file path from logs

### DIFF
--- a/configs/logging_config.yaml
+++ b/configs/logging_config.yaml
@@ -15,7 +15,7 @@ formatters:
       CRITICAL: purple
   console_colored:
     (): colorlog.ColoredFormatter
-    format: '%(log_color)s%(levelname)-8s%(reset)s %(current_task)s [%(pathname)s:%(lineno)s] %(asctime)s %(message)s'
+    format: '%(log_color)s%(levelname)-8s%(reset)s %(current_task)s %(asctime)s %(message)s'
     datefmt: '%m-%d %H:%M:%S'
     log_colors:
       DEBUG: green


### PR DESCRIPTION
Removes file path from logging output in order to save space, and since
that information is often not really valuable.