### PR TITLE
[CF-86] Use dd instead of sftp

### DIFF
--- a/cloudferrylib/os/image/glance_image.py
+++ b/cloudferrylib/os/image/glance_image.py
@@ -509,7 +509,8 @@ class GlanceImage(image.Image):
                     file_obj = img['resource'].get_ref_image(img['id'])
                     data_proxy = file_proxy.FileProxy(
                         file_obj,
-                        name="image %s ('%s')" % (img['name'], img['id']))
+                        name="image %s ('%s')" % (img['name'], img['id']),
+                        size=img['size'])
 
                     created_image = self.create_image(
                         id=img['id'],

--- a/cloudferrylib/utils/drivers/copy_engine.py
+++ b/cloudferrylib/utils/drivers/copy_engine.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 
-import os
 import math
+import os
 
 from cloudferrylib.utils import driver_transporter
 from cloudferrylib.utils import files
@@ -22,20 +22,11 @@ from cloudferrylib.utils import log
 from cloudferrylib.utils import remote_runner
 from cloudferrylib.utils import ssh_util
 
-
 LOG = log.getLogger(__name__)
 
 
 class FileCopyFailure(RuntimeError):
     pass
-
-
-def remote_file_size(runner, path):
-    return int(runner.run('stat --printf="%s" {path}'.format(path=path)))
-
-
-def remote_file_size_mb(runner, path):
-    return int(math.ceil(remote_file_size(runner, path) / (1024.0 * 1024.0)))
 
 
 def remote_md5_sum(runner, path):
@@ -180,7 +171,7 @@ class ScpCopier(driver_transporter.DriverTransporter):
                                                 password=dst_password,
                                                 sudo=True)
 
-        file_size = remote_file_size_mb(src_runner, src_path)
+        file_size = files.remote_file_size_mb(src_runner, src_path)
 
         partial_files = []
 

--- a/cloudferrylib/utils/file_proxy.py
+++ b/cloudferrylib/utils/file_proxy.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 Mirantis Inc.
+# Copyright (c) 2016 Mirantis Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the License);
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and#
 # limitations under the License.
 
-import errno
 import os
 import time
 
@@ -38,18 +37,8 @@ def get_file_size(file_obj):
             size = file_obj.tell()
             file_obj.seek(curr)
             return size
-        except IOError as e:
-            if e.errno == errno.ESPIPE:
-                # Illegal seek. This means the file object
-                # is a pipe (e.g the user is trying
-                # to pipe image data to the client,
-                # echo testdata | bin/glance add blah...), or
-                # that file object is empty, or that a file-like
-                # object which doesn't support 'seek/tell' has
-                # been supplied.
-                return
-            else:
-                raise
+        except IOError:
+            return
 
 
 class ProgressView(object):
@@ -134,4 +123,6 @@ class FileProxy(object):
         return data
 
     def __getattr__(self, item):
+        if item == 'seek':
+            raise AttributeError()
         return getattr(self.file_obj, item)

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,5 +24,3 @@ python-swiftclient==2.3.1
 pyyaml
 redis
 sqlalchemy
-# see https://github.com/paramiko/paramiko/issues/570 and https://github.com/paramiko/paramiko/pull/571
--e git://github.com/mirrorcoder/paramiko.git#egg=paramiko-1.16.0

--- a/tests/cloudferrylib/utils/test_file_proxy.py
+++ b/tests/cloudferrylib/utils/test_file_proxy.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 Mirantis Inc.
+# Copyright (c) 2016 Mirantis Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the License);
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and#
 # limitations under the License.
 
-import errno
 import mock
 import os
 
@@ -33,11 +32,8 @@ class GetFileSizeTestCase(test.TestCase):
                          file_obj.seek.mock_calls)
 
     def test_ioerror(self):
-        err = IOError()
-        err.errno = errno.ESPIPE
         file_obj = mock.Mock()
-        file_obj.tell.side_effect = (IOError, err)
-        self.assertRaises(IOError, file_proxy.get_file_size, file_obj)
+        file_obj.tell.side_effect = IOError
         self.assertIsNone(file_proxy.get_file_size(file_obj))
 
 


### PR DESCRIPTION
In some case sftp doesn't work, to fix it use dd command by ssh
and read a data from stdout of ssh tunnel.
Implement RemoteStdout class to execute a command and work with
stdout of command.