### PR TITLE
[CF-178] Reduce time to start VM migration

### DIFF
--- a/scenario/migrate_vms.yaml
+++ b/scenario/migrate_vms.yaml
@@ -47,7 +47,7 @@ rollback:
 
 process:
   - transport_instances_and_dependency_resources:
-      - act_identity_trans: True
+      - act_identity_trans: False
       - act_get_info_inst: True
       - init_iteration_instance:
           - init_iteration_instance_copy_var: True


### PR DESCRIPTION
- Remove task IdentityTransporter from migrate_vms.yaml
- Modify task FilterSimilarVMsFromDST