### PR TITLE
Remove identity from glance with no rollback stage

### DIFF
--- a/scenario/stages_without_rollback/3_get_and_transfer_images.yaml
+++ b/scenario/stages_without_rollback/3_get_and_transfer_images.yaml
@@ -8,6 +8,5 @@ preparation:
 process:
   - act_get_filter: True
   - act_check_filter: True
-  - act_identity_trans: True
   - act_get_info_images: True
   - act_deploy_images: True


### PR DESCRIPTION
This patch removes act_identity_trans task from scenario/stages_without_rollback/3_get_and_transfer_images.yaml.