### PR TITLE
[SC-186] Fix copy ephemeral disk when flavor was deleted.

### DIFF
--- a/cloudferrylib/os/compute/nova_compute.py
+++ b/cloudferrylib/os/compute/nova_compute.py
@@ -302,9 +302,6 @@ class NovaCompute(compute.Compute):
                         compute_res.nova_client.volumes.get_server_volumes(
                             instance.id))]
 
-        is_ephemeral = compute_res.get_flavor_from_id(
-            instance.flavor['id'], include_deleted=True).ephemeral > 0
-
         is_ceph = cfg.compute.backend.lower() == utl.CEPH
         direct_transfer = cfg.migrate.direct_compute_transfer
 
@@ -344,6 +341,9 @@ class NovaCompute(compute.Compute):
             'host_dst': None
         }
 
+        flav_details = instances.get_flav_details(compute_res.mysql_connector,
+                                                  instance.id)
+        is_ephemeral = flav_details['ephemeral_gb'] > 0
         if is_ephemeral:
             ephemeral_path['path_src'] = utl.get_disk_path(
                 instance,
@@ -363,8 +363,6 @@ class NovaCompute(compute.Compute):
                 instance,
                 instance_block_info,
                 is_ceph_ephemeral=is_ceph)
-        flav_details = instances.get_flav_details(compute_res.mysql_connector,
-                                                  instance.id)
         flav_name = compute_res.get_flavor_from_id(instance.flavor['id'],
                                                    include_deleted=True).name
         flav_details.update({'name': flav_name})


### PR DESCRIPTION
If flavor was deleted and then recreated with same ID, nova will
return old flavor for GET request in grizzly clouds. After this patch
code no longer rely on what nova returned in GET request, and use data
from SQL database instead.