### PR TITLE
Restart nova-compute instead of start it

### DIFF
--- a/devlab/provision/cleanup_nova_instances.sh
+++ b/devlab/provision/cleanup_nova_instances.sh
@@ -15,10 +15,10 @@ tables_to_remove=(
     instances
 )
 
-stop nova-compute
+service nova-compute stop
 
 for t in ${tables_to_remove[*]}; do
     mysql -uroot -psecret -e "delete from ${t}" nova
 done
 
-start nova-compute
+service nova-compute restart

--- a/devlab/provision/qemu.sh
+++ b/devlab/provision/qemu.sh
@@ -7,9 +7,9 @@
 set -e
 set -x
 
-stop nova-compute
+service nova-compute stop
 add-apt-repository cloud-archive:icehouse
 apt-get update
 apt-get -y install -o 'Dpkg::Options::=--force-confold' qemu
 apt-get install --reinstall libvirt-bin python-libvirt
-start nova-compute
+service nova-compute restart


### PR DESCRIPTION
Now we have monit on all our openstack boxes. It can start openstack processes itself.