### PR TITLE
CF-205 Authenticate with credentials

### DIFF
--- a/cloudferrylib/os/identity/keystone.py
+++ b/cloudferrylib/os/identity/keystone.py
@@ -212,20 +212,7 @@ class KeystoneIdentity(identity.Identity):
         LOG.info("Done")
 
     def get_client(self):
-        """ Getting keystone client using authentication with admin auth token.
-
-        :return: OpenStack Keystone Client instance
-        """
-
-        auth_ref = self._get_client_by_creds().auth_ref
-
-        return keystone_client.Client(auth_ref=auth_ref,
-                                      endpoint=self.config.cloud.auth_url,
-                                      cacert=self.config.cloud.cacert,
-                                      insecure=self.config.cloud.insecure)
-
-    def _get_client_by_creds(self):
-        """Authenticating with a user name and password.
+        """ Getting keystone client using authentication with user/password.
 
         :return: OpenStack Keystone Client instance
         """

--- a/tests/cloudferrylib/os/identity/test_keystone.py
+++ b/tests/cloudferrylib/os/identity/test_keystone.py
@@ -443,7 +443,7 @@ class KeystoneClientTestCase(test.TestCase):
         config.cloud.cacert = cacert
 
         ks = keystone.KeystoneIdentity(config, cloud)
-        ks._get_client_by_creds()
+        ks.get_client()
 
         ks_client.assert_called_with(
             region_name=region,
@@ -475,7 +475,7 @@ class KeystoneClientTestCase(test.TestCase):
         config.cloud.cacert = cacert
 
         ks = keystone.KeystoneIdentity(config, cloud)
-        ks._get_client_by_creds()
+        ks.get_client()
 
         ks_client.assert_called_with(
             tenant_name=tenant,


### PR DESCRIPTION
Previous implementation authenticated twice with credentials and
then passed token to authenticate with token. This patch modifies
behavior to only authenticate with credentials.