### PR TITLE
[CF-218] Use a correct availability zone

### DIFF
--- a/tests/cloudferrylib/os/compute/test_nova.py
+++ b/tests/cloudferrylib/os/compute/test_nova.py
@@ -383,6 +383,7 @@ class DeployInstanceWithManualScheduling(test.TestCase):
         client_conf = mock.Mock()
 
         nc = mock.Mock()
+        nc.get_availability_zone.return_value = 'nova'
         nc.get_compute_hosts.return_value = compute_hosts
         nc.deploy_instance.side_effect = exception.TimeoutException(
             None, None, None)


### PR DESCRIPTION
Implement get_availability_zone function which returns a default zone
if the original does not exist.
The get_compute_hosts function doesn't check an availability zone.