### PR TITLE
[CF-201] Extend functional tests to verify deleted image in dst with the same ID

### DIFF
--- a/devlab/generate_load.py
+++ b/devlab/generate_load.py
@@ -168,8 +168,8 @@ class Prerequisites(base.BasePrerequisites):
 
         def _get_body_for_image_creating(_image):
             # Possible parameters for image creating
-            params = ['name', 'location', 'disk_format', 'container_format',
-                      'is_public', 'copy_from']
+            params = ['id', 'name', 'location', 'disk_format',
+                      'container_format', 'is_public', 'copy_from']
             return {param: _image[param] for param in params
                     if param in _image}
 
@@ -189,12 +189,29 @@ class Prerequisites(base.BasePrerequisites):
         self.switch_user(user=self.username, password=self.password,
                          tenant=self.tenant)
 
+        dst_img_ids = []
         for image in self.config.images:
-            img = self.glanceclient.images.create(
-                **_get_body_for_image_creating(image))
+            image_body = _get_body_for_image_creating(image)
+            img = self.glanceclient.images.create(**image_body)
             img_ids.append(img.id)
+            if image.get('upload_on_dst'):
+                if not self.dst_cloud:
+                    self.dst_cloud = Prerequisites(
+                        cloud_prefix='DST',
+                        configuration_ini=self.configuration_ini,
+                        config=self.config)
+                dst_img_id = self.dst_cloud.glanceclient.images.create(
+                    **image_body)
+                dst_img_ids.append(dst_img_id)
+
         self.wait_until_objects_created(img_ids, self.check_image_state,
                                         TIMEOUT)
+
+        if dst_img_ids and self.dst_cloud:
+            self.wait_until_objects_created(
+                dst_img_ids,
+                self.chech_image_state_on_dst,
+                TIMEOUT)
 
         tenant_list = self.keystoneclient.tenants.list()
         for image_id in img_ids:
@@ -209,6 +226,10 @@ class Prerequisites(base.BasePrerequisites):
 
         if getattr(self.config, 'create_zero_image', None):
             self.glanceclient.images.create()
+
+    def chech_image_state_on_dst(self, img_id):
+        img = self.dst_cloud.glanceclient.images.get(img_id)
+        return img.status == 'active'
 
     def update_filtering_file(self):
         src_cloud = Prerequisites(cloud_prefix='SRC',
@@ -894,6 +915,26 @@ class Prerequisites(base.BasePrerequisites):
             self.migration_utils.execute_command_on_vm(
                 self.get_vagrant_vm_ip(), cmd, username='root', password='')
 
+    def delete_image_on_dst(self):
+        """ Method delete images with a 'delete_on_dst' flag on
+        the destenation cloud. During migration CF must migrate the image
+        and generate new UUID for the image, because image with the original
+        UUID has been deleted.
+        """
+
+        if not self.dst_cloud:
+            self.dst_cloud = Prerequisites(
+                cloud_prefix='DST',
+                configuration_ini=self.configuration_ini,
+                config=self.config)
+
+        all_images = self.migration_utils.get_all_images_from_config()
+        images_to_delete = [image for image in all_images
+                            if image.get('delete_on_dst')]
+        for image in images_to_delete:
+            image_id = self.dst_cloud.get_image_id(image['name'])
+            self.dst_cloud.glanceclient.images.delete(image_id)
+
     def break_images(self):
         all_images = self.migration_utils.get_all_images_from_config()
         images_to_break = [image for image in all_images
@@ -970,6 +1011,8 @@ class Prerequisites(base.BasePrerequisites):
         self.break_vm()
         LOG.info('Breaking Images')
         self.break_images()
+        LOG.info('Delete images on dst')
+        self.delete_image_on_dst()
         LOG.info('Updating filtering')
         self.update_filtering_file()
         LOG.info('Creating vm snapshots')

--- a/devlab/tests/config.py
+++ b/devlab/tests/config.py
@@ -360,7 +360,14 @@ images = [
      'container_format': 'bare', 'broken': True},
     # Image, deleted using glance delete command
     {'name': 'deleted_image', 'copy_from': img_url, 'disk_format': 'qcow2',
-     'container_format': 'bare', 'is_deleted': True}
+     'container_format': 'bare', 'is_deleted': True},
+    # Image will be created on src and dst with the same UUID.
+    # After that deleted from dst before migration.
+    # CF must create new UUID during migration for this image
+    # and migrate it successfully
+    {'name': 'deleted_on_dst', 'id': 'e38390f0-e660-42fc-b8cd-db163fce1510',
+     'copy_from': img_url, 'disk_format': 'qcow2',
+     'container_format': 'bare', 'upload_on_dst': True, 'delete_on_dst': True}
 ]
 """Images to create/delete"""
 


### PR DESCRIPTION
Image will be created on src and dst with the same UUID.
After that deleted from dst before migration with the
generate_load.py script. In this case CF mustcreate new
UUID during migration for this image and migrate it successfully.