### PR TITLE
[CF-229] Recreate an image from vm in case of ssl error.

### DIFF
--- a/cloudferrylib/os/actions/convert_compute_to_image.py
+++ b/cloudferrylib/os/actions/convert_compute_to_image.py
@@ -85,6 +85,8 @@ class ConvertComputeToImage(action.Action):
                         missing_images[instance_id] = image_id
             else:
                 compute_ignored_images[instance_id] = instance
+        if missing_images:
+            LOG.warning('List of broken images: %s', missing_images.values())
         return {
             self.target_output: image_info,
             'compute_ignored_images': compute_ignored_images,


### PR DESCRIPTION
Catch ZeroReturnError and reraise as ImageDownloadError to skip
a broken image.
Add additional log messages.