### PR TITLE
[CF-234] Fix key-pairs from deleted users under admin

### DIFF
--- a/cfglib.py
+++ b/cfglib.py
@@ -192,7 +192,11 @@ migrate_opts = [
     cfg.BoolOpt('keep_network_interfaces_order', default=True,
                 help="Keep the order of network interfaces of instances."),
     cfg.BoolOpt('keep_usage_quotas_inst', default=True,
-                help="Keep the usage quotas for instances.")
+                help="Keep the usage quotas for instances."),
+    cfg.BoolOpt('skip_orphaned_keypairs', default=True,
+                help="If it is set to False - key pairs belonging to deleted "
+                     "tenant or to deleted user on SRC will be assigned to "
+                     "the admin on DST, otherwise skipped.")
 ]
 
 mail = cfg.OptGroup(name='mail',

--- a/cloudferrylib/os/actions/transport_compute_resources.py
+++ b/cloudferrylib/os/actions/transport_compute_resources.py
@@ -95,11 +95,15 @@ class TransportKeyPairs(action.Action):
         dst_users = {}
         key_pairs = self.kp_db_broker.get_all_keypairs(self.src_cloud)
 
+        # If we want to skip orphaned key pairs - we should not switch
+        # to the admin if dst_user doesn't exist
+        fallback_to_admin = not self.cfg.migrate.skip_orphaned_keypairs
+
         for key_pair in key_pairs:
             if key_pair.user_id not in dst_users:
                 dst_user = keystone.get_dst_user_from_src_user_id(
                     src_keystone, dst_keystone, key_pair.user_id,
-                    fallback_to_admin=True)
+                    fallback_to_admin=fallback_to_admin)
                 dst_users[key_pair.user_id] = dst_user
             else:
                 dst_user = dst_users[key_pair.user_id]

--- a/configs/config.ini
+++ b/configs/config.ini
@@ -95,6 +95,9 @@ migrate_users = True
 #Enable recalculating usage of quotas when we change user of instance
 keep_usage_quotas_inst = True
 
+# Skip key pairs that belong to deleted tenant or to deleted user on SRC.
+# If it's set to False - the key pairs will be assigned to the admin.
+skip_orphaned_keypairs = True
 
 # Direct data transmission between (src and dst) compute nodes via ssh tunnel.
 # Values:

--- a/tests/cloudferrylib/os/actions/test_keypair_migration.py
+++ b/tests/cloudferrylib/os/actions/test_keypair_migration.py
@@ -107,6 +107,9 @@ class KeyPairMigrationTestCase(test.TestCase):
 
             tkp.src_cloud = mock.MagicMock()
             tkp.dst_cloud = mock.MagicMock()
+            tkp.cfg = mock.Mock()
+            tkp.cfg.migrate.skip_orphaned_keypairs = True
+
             src_users = tkp.src_cloud.resources[
                 utl.IDENTITY_RESOURCE].keystone_client.users
             src_users.find.side_effect = keystoneclient.exceptions.NotFound
@@ -131,6 +134,9 @@ class KeyPairMigrationTestCase(test.TestCase):
                                     kp_db_broker=db_broker)
         tkp.src_cloud = mock.MagicMock()
         tkp.dst_cloud = mock.MagicMock()
+        tkp.cfg = mock.Mock()
+        tkp.cfg.migrate.skip_orphaned_keypairs = True
+
         tkp.run()
 
         self.assertTrue(db_broker.store_keypair.call_count == num_keypairs)


### PR DESCRIPTION
Keypairs from deleted tenants and users not suppose to be
migrated under admin tenant. We would like to drop them
from being migrated as there is no need for them.