### PR TITLE
CF-79 Add migration of floating IPs into pre-created networks.

### DIFF
--- a/devlab/generate_load.py
+++ b/devlab/generate_load.py
@@ -968,6 +968,20 @@ class Prerequisites(base.BasePrerequisites):
                                               self.config.dst_unassociated_fip,
                                               ext_net_id)
 
+    def create_ext_net_map_yaml(self):
+        src_ext_nets = [net['name'] for net in self.config.networks
+                        if net.get('router:external')]
+        dst_ext_nets = [net['name'] for net in self.config.dst_networks
+                        if net.get('router:external')]
+        with open(self.config.ext_net_map, "w") as f:
+            for src_net in src_ext_nets:
+                for dst_net in dst_ext_nets:
+                    if src_net == dst_net:
+                        src_net_id = self.get_net_id(src_net)
+                        dst_net_id = self.dst_cloud.get_net_id(dst_net)
+                        f.write('{src_net}: {dst_net}'.format(
+                                src_net=src_net_id, dst_net=dst_net_id))
+
     def run_preparation_scenario(self):
         LOG.info('Creating tenants')
         self.create_tenants()
@@ -1034,6 +1048,8 @@ class Prerequisites(base.BasePrerequisites):
         self.create_user_on_dst()
         LOG.info('Creating networks on dst')
         self.create_dst_networking()
+        LOG.info('Creating networks map')
+        self.create_ext_net_map_yaml()
 
 
 if __name__ == '__main__':

--- a/devlab/tests/config.py
+++ b/devlab/tests/config.py
@@ -51,6 +51,10 @@ filters_file_naming_template = 'filter_{tenant_name}.yaml'
 pre_migration_vm_states_file = 'pre_migration_vm_states.json'
 """Path to store vm states file"""
 
+ext_net_map = 'ext_net_map.yaml'
+"""This file contains map of relationships between external networks on source
+and destination clouds."""
+
 users = [
     {'name': 'user1', 'password': 'passwd1', 'email': 'mail@example.com',
      'tenant': 'tenant1', 'enabled': True},


### PR DESCRIPTION
 - Create external network in source cloud
 - Create the same external network in destination cloud
 - Create several (5) floating IPs in source cloud
 - Add following to CloudFerry config:
```
[migrate]
ext_net_map = <source to dest external network mapping>
```
 - Run migration
 - Verify floating IPs migrated successfully