### PR TITLE
[CF-276] Optimize `get_tenants_list`

### DIFF
--- a/cloudferrylib/base/action/action.py
+++ b/cloudferrylib/base/action/action.py
@@ -14,6 +14,7 @@
 
 
 from cloudferrylib.scheduler import task
+from cloudferrylib.utils import utils
 
 
 class Action(task.Task):
@@ -37,3 +38,52 @@ class Action(task.Task):
 
     def restore(self):
         pass
+
+    def get_similar_tenants(self):
+        """
+        Get SRC tenant ID to DST tenant ID mapping.
+
+        :return dict: {<src_tenant_id>: <dst_tenant_id>, ...}
+        """
+
+        src_identity = self.src_cloud.resources[utils.IDENTITY_RESOURCE]
+        dst_identity = self.dst_cloud.resources[utils.IDENTITY_RESOURCE]
+
+        src_tenants = src_identity.get_tenants_list()
+        dst_tenants = dst_identity.get_tenants_list()
+
+        dst_tenant_map = {tenant.name.lower(): tenant.id for tenant in
+                          dst_tenants}
+
+        similar_tenants = {}
+
+        for src_tenant in src_tenants:
+            src_tnt_name = src_tenant.name.lower()
+            if src_tnt_name in dst_tenant_map:
+                similar_tenants[src_tenant.id] = dst_tenant_map[src_tnt_name]
+
+        return similar_tenants
+
+    def get_similar_users(self):
+        """
+        Get SRC user ID to DST user ID mapping.
+
+        :return dict: {<src_user_id>: <dst_user_id>, ...}
+        """
+
+        src_identity = self.src_cloud.resources[utils.IDENTITY_RESOURCE]
+        dst_identity = self.dst_cloud.resources[utils.IDENTITY_RESOURCE]
+
+        src_users = src_identity.get_users_list()
+        dst_users = dst_identity.get_users_list()
+
+        dst_usr_map = {user.name.lower(): user.id for user in dst_users}
+
+        similar_users = {}
+
+        for src_user in src_users:
+            src_user_name = src_user.name.lower()
+            if src_user_name in dst_usr_map:
+                similar_users[src_user.id] = dst_usr_map[src_user_name]
+
+        return similar_users

--- a/cloudferrylib/os/actions/filter_similar_vms_from_dst.py
+++ b/cloudferrylib/os/actions/filter_similar_vms_from_dst.py
@@ -44,21 +44,6 @@ class FilterSimilarVMsFromDST(action.Action):
         self.similar_isntances = collections.defaultdict(set)
         self.conflict_instances = collections.defaultdict(set)
 
-    def get_similar_tenants(self):
-        src_identity = self.src_cloud.resources[utils.IDENTITY_RESOURCE]
-        dst_identity = self.dst_cloud.resources[utils.IDENTITY_RESOURCE]
-        src_tenants = src_identity.read_info()['tenants']
-        dst_tenants = {t['tenant']['name']: t['tenant']['id']
-                       for t in dst_identity.read_info()['tenants']}
-        similar_tenants = {}
-        for ts in src_tenants:
-            index = ts['tenant']['name']
-            if index in dst_tenants:
-                similar_tenants[ts['tenant']['id']] = dst_tenants[index]
-            else:
-                similar_tenants[ts['tenant']['id']] = ''
-        return similar_tenants
-
     def run(self, **kwargs):
         self.src_instances = kwargs['info']['instances']
         if 'identity_info' in kwargs:

--- a/cloudferrylib/os/actions/transport_compute_resources.py
+++ b/cloudferrylib/os/actions/transport_compute_resources.py
@@ -24,7 +24,7 @@ LOG = log.getLogger(__name__)
 
 
 class TransportComputeResources(action.Action):
-    def run(self, info=None, identity_info=None, **kwargs):
+    def run(self, info=None, **kwargs):
         info = copy.deepcopy(info)
         target = 'resources'
         search_opts = {'target': target}
@@ -34,8 +34,12 @@ class TransportComputeResources(action.Action):
         dst_compute = self.dst_cloud.resources[utl.COMPUTE_RESOURCE]
 
         info_res = src_compute.read_info(**search_opts)
+
+        tenant_map = self.get_similar_tenants()
+        user_map = self.get_similar_users()
+
         new_info = dst_compute.deploy(info_res, target=target,
-                                      identity_info=identity_info)
+                                      tenant_map=tenant_map, user_map=user_map)
 
         if info:
             new_info[utl.INSTANCES_TYPE] = info[utl.INSTANCES_TYPE]

--- a/cloudferrylib/os/compute/nova_compute.py
+++ b/cloudferrylib/os/compute/nova_compute.py
@@ -482,15 +482,14 @@ class NovaCompute(compute.Compute):
         Deploy compute resources except instances to the cloud.
 
         :param info: Info about compute resources to deploy,
-        :param identity_info: Identity info.
+        :param tenant_map: SRC tenant ID to DST tenant ID mapping. Format:
+                           {<src_tenant_id>: <dst_tenant_id>, ...}
+        :param user_map: SRC user ID to DST user ID mapping. Format:
+                         {<src_user_id>: <dst_user_id>, ...}
         """
 
-        identity_info = kwargs.get('identity_info')
-
-        tenant_map = {tenant['tenant']['id']: tenant['meta']['new_id'] for
-                      tenant in identity_info['tenants']}
-        user_map = {user['user']['id']: user['meta']['new_id'] for user in
-                    identity_info['users']}
+        tenant_map = kwargs.get('tenant_map')
+        user_map = kwargs.get('user_map')
 
         self._deploy_flavors(info['flavors'], tenant_map)
         if self.config['migrate']['migrate_quotas']:

--- a/scenario/migrate_vms.yaml
+++ b/scenario/migrate_vms.yaml
@@ -45,13 +45,9 @@ preparation:
 rollback:
   - restore_from_vm_snapshot_dst: True
   - restore_from_vm_snapshot_src: True
-  - image_rollback_dst: False
-  - restore_from_snapshot: False
-
 
 process:
   - transport_instances_and_dependency_resources:
-      - act_identity_trans: False
       - act_get_info_inst: True
       - init_iteration_instance:
           - init_iteration_instance_copy_var: True

--- a/scenario/stages/4_transport_compute_resources.yaml
+++ b/scenario/stages/4_transport_compute_resources.yaml
@@ -13,5 +13,4 @@ rollback:
 process:
   - act_get_filter: True
   - act_check_filter: True
-  - act_identity_trans: True
   - act_comp_res_trans: True

--- a/scenario/stages_without_rollback/4_transport_compute_resources.yaml
+++ b/scenario/stages_without_rollback/4_transport_compute_resources.yaml
@@ -11,5 +11,4 @@ preparation:
 process:
   - act_get_filter: True
   - act_check_filter: True
-  - act_identity_trans: True
   - act_comp_res_trans: True

--- a/scenario/stages_without_rollback/migrate_vms.yaml
+++ b/scenario/stages_without_rollback/migrate_vms.yaml
@@ -47,7 +47,6 @@ rollback:
 
 process:
   - transport_instances_and_dependency_resources:
-      - act_identity_trans: True
       - act_get_info_inst: True
       - init_iteration_instance:
           - init_iteration_instance_copy_var: True


### PR DESCRIPTION
Rename `get_tenants_list` to `_get_required_tenants_list` and use it
only for `read_info` method of `KeystoneIdentity` resource. This method
should be called only for Identity resources migration. For other cases
simple `get_tenants_list` method was created.

Get rid of Identity's `read_info` method calls in the whole project
(mostly from actions) and use `get_tenants_list` method instead.

Add tenants and users mapping obtaining method to base action class. It
allows to use it in inheritor classes and also to get rid of
`identity_transporter` action before migrating Compute resources and VMs
(calculate mapping instead of using Identity's transportation results).
Thereby identity transporter is no longer a dependency for any other
action.

Refactor related scenarios.