### PR TITLE
[CF-294] Fix getting nonexistent instance for deploy_instance function

### DIFF
--- a/cloudferrylib/os/compute/nova_compute.py
+++ b/cloudferrylib/os/compute/nova_compute.py
@@ -658,10 +658,11 @@ class NovaCompute(compute.Compute):
                                      stop_statuses=[ERROR])
             except exception.TimeoutException:
                 LOG.warning("Failed to create instance '%s'", new_id)
-                instance = self.get_instance(new_id)
-                if instance.fault:
-                    LOG.debug("Error message of failed instance '%s': %s",
-                              new_id, instance.fault)
+                if self.instance_exists(new_id):
+                    instance = self.get_instance(new_id)
+                    if instance.fault:
+                        LOG.debug("Error message of failed instance '%s': %s",
+                                  new_id, instance.fault)
                 self._failed_instances.append(new_id)
                 raise
 


### PR DESCRIPTION
Check that failed instance exists.