### PR TITLE
CF-304 Nova compute objects migration documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -143,7 +143,7 @@ html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path = ['_static']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -105,8 +105,8 @@ Filter file is a standard YAML file with following syntax::
             - <volume_id1>
             - <volume_id2>
 
-When :dfn:`exclude_public_and_members` is set to :keyword:`True`, all the
-public images and images which have membership in the tenant specified in
+When :dfn:`exclude_public_and_members` is set to ``True``, all the public
+images and images which have membership in the tenant specified in
 :dfn:`tenant_id` are not included in migration list. In other words, only
 images which directly belong to :dfn:`tenant_id` are migrated, all the
 dependencies are ignored. See more in :ref:`glance-image-migration`.

--- a/docs/glance_image_migration.rst
+++ b/docs/glance_image_migration.rst
@@ -31,7 +31,9 @@ Process
 -------
 
  1. Download image from source cloud using glance APIs;
- 2. Upload image to destination cloud using glance APIs.
+ 2. Upload image to destination cloud using glance APIs;
+ 3. Glance image UUID will be kept in destination, unless an image with the
+    same ID exists or existed previously.
 
 .. note::
 
@@ -54,3 +56,11 @@ override this behavior by making :dfn:`exclude_public_and_members` option
 enabled in :ref:`filter file <filter-configuration>`. If it still tries to
 migrate all the images - make sure you have :dfn:`act_get_filter` action
 enabled in your scenario.
+
+
+**Q**: Glance APIs allow specifying glance images IDs, but image I
+migrated has different ID. WTF???
+
+**A**: Glance image IDs are only kept if image with that ID does not exist or
+existed previously in destination cloud. Glance keeps deleted images and their
+IDs and does allow to create image with the ID already known to glance.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,6 +13,7 @@ Contents:
    installation
    quick_start_guide
    configuration
+   nova_compute_migration
    glance_image_migration
 
 
@@ -22,4 +23,3 @@ Indices and tables
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
-

--- a/docs/nova_compute_migration.rst
+++ b/docs/nova_compute_migration.rst
@@ -1,0 +1,69 @@
+=============================
+Nova non-VM objects migration
+=============================
+
+:dfn:`act_comp_res_trans` action which can be found in
+:file:`cold_migrate.yaml` and :file:`4_transport_compute_resources.yaml`
+allows user to migrate following nova compute objects:
+
+ - nova user quotas;
+ - nova tenant quotas;
+ - nova flavors.
+
+
+.. note::
+
+    User quotas have only become available with Icehouse (2014.1) Openstack
+    release and they allow to control quotas for each user. This means that
+    user quotas will not be migrated in case source cloud is Grizzly or
+    earlier release.
+
+
+Quota migration process
+-----------------------
+
+Quota migration process only involves nova APIs, so the process from the
+high level is following:
+
+ 1. Retrieve all quotas based on :ref:`filtering rules <filter-configuration>`
+    from source cloud using nova APIs;
+ 2. Create user and tenant quotas to destination cloud using nova APIs.
+
+
+.. warning::
+
+    Default nova user and tenant quotas are configured in :file:`nova.conf`
+    and are **not** transferred to the destination cloud, Openstack services
+    configuration migration is beyond CloudFerry functionality.
+
+
+Flavor migration process
+------------------------
+
+.. note::
+
+    Flavors UUID are kept during migration
+
+
+.. note::
+
+    If flavor with the same ID exists in destination, but differs from
+    flavor in source -- it will be deleted and replaced with flavor from
+    source cloud
+
+
+Flavors are one of the few objects in Openstack which allow setting UUID
+through APIs, which may lead to a situation when destination cloud already has
+flavor with the same ID as flavor in the source cloud, yet different (for
+example number of VCPUs are different). This creates a special case for
+migration process:
+
+ 1. Retrieve list of flavors from source based on
+    :ref:`filtering rules <filter-configuration>` using nova APIs;
+ 2. Try to create flavor in destination cloud with the same ID and all
+    flavor attributes (number of VCPUs, RAM, ephemeral storage, etc.);
+ 3. In case flavor with the same ID, but with different attributes exists in
+    destination -- this flavor is **removed**, and flavor from source cloud
+    is created instead;
+ 4. For private flavors -- share flavor with tenants it was shared in the
+    source cloud.


### PR DESCRIPTION
Documents migration of non-VM nova objects:
 - flavors
 - user quotas
 - tenant quotas