### PR TITLE
[CF-249] Fix floating IPs migration

### DIFF
--- a/cloudferrylib/os/actions/check_networks.py
+++ b/cloudferrylib/os/actions/check_networks.py
@@ -462,7 +462,7 @@ class NetworkInfo(object):
 class Network(object):
     def __init__(self, info):
         self.info = info
-        self.subnets_hash = set()
+        self.subnets_hash = info['subnets_hash']
         self.subnets = []
         self.id = info['id']
         self.hash = info['res_hash']
@@ -474,7 +474,6 @@ class Network(object):
 
     def add_subnet(self, info):
         self.subnets.append(info)
-        self.subnets_hash.add(info['res_hash'])
 
     def check_network_overlapping(self, network):
         for subnet in network.subnets:

--- a/cloudferrylib/os/network/neutron.py
+++ b/cloudferrylib/os/network/neutron.py
@@ -398,9 +398,12 @@ class NeutronNetwork(network.Network):
         get_tenant_name = identity_res.get_tenants_func()
 
         subnets = []
+        subnets_hash = set()
+
         for subnet in net['subnets']:
             snet = self.convert_subnets(subnet, cloud)
             subnets.append(snet)
+            subnets_hash.add(snet['res_hash'])
 
         result = {
             'name': net['name'],
@@ -414,6 +417,7 @@ class NeutronNetwork(network.Network):
             'provider:physical_network': net['provider:physical_network'],
             'provider:network_type': net['provider:network_type'],
             'provider:segmentation_id': net['provider:segmentation_id'],
+            'subnets_hash': subnets_hash,
             'meta': {},
         }
 
@@ -1146,31 +1150,23 @@ class NeutronNetwork(network.Network):
         LOG.info("Creating networks on destination")
         identity = self.identity_client
 
-        existing_nets = {n['res_hash']: n for n in self.get_networks()}
-        existing_subnets = {sn['res_hash']: sn for sn in self.get_subnets()}
+        existing_networks = self.get_networks()
 
         # we need to handle duplicates in segmentation ids
-        dst_seg_ids = get_segmentation_ids_from_net_list(
-            existing_nets.values())
+        dst_seg_ids = get_segmentation_ids_from_net_list(existing_networks)
 
         for src_net in networks:
             network_detached_ports = [p for p in detached_ports
                                       if p['network_id'] == src_net['id']]
 
             # Check network for existence on destination cloud
-            if src_net['res_hash'] in existing_nets:
-                # Check all network's subnets for existence on DST cloud
-                for subnet in src_net['subnets']:
-                    if subnet['res_hash'] not in existing_subnets:
-                        break
-                else:
-                    LOG.info("DST cloud already has the same network "
-                             "with name '%s' in tenant '%s'",
-                             src_net['name'], src_net['tenant_name'])
-                    self.deploy_detached_ports(
-                        existing_nets[src_net['res_hash']],
-                        network_detached_ports)
-                    continue
+            dst_net = self.get_dst_net_by_src_net(existing_networks, src_net)
+            if dst_net:
+                LOG.info("DST cloud already has the same "
+                         "network with name '%s' in tenant '%s'",
+                         src_net['name'], src_net['tenant_name'])
+                self.deploy_detached_ports(dst_net, network_detached_ports)
+                continue
 
             LOG.debug("Trying to create network '%s'", src_net['name'])
             tenant_id = identity.get_tenant_id_by_name(src_net['tenant_name'])
@@ -1541,12 +1537,46 @@ class NeutronNetwork(network.Network):
         return hash(tuple(hash_list))
 
     def get_new_extnet_id(self, src_net_id, src_nets, dst_nets):
+        """
+        Get ID of similar external network form DST.
+
+        :param src_net_id: External network ID from SRC cloud,
+        :param src_nets: Networks list from SRC cloud,
+        :param dst_nets: Networks list from DST cloud,
+
+        :return unicode: External network ID from DST, that matches with the
+                         similar network from SRC.
+        """
+
         if src_net_id in self.ext_net_map:
             dst_net_id = self.ext_net_map[src_net_id]
         else:
-            net_hash = self.get_res_hash_by_id(src_nets, src_net_id)
-            dst_net_id = self.get_res_by_hash(dst_nets, net_hash)['id']
+            src_net = get_network_from_list_by_id(src_net_id, src_nets)
+            dst_net = self.get_dst_net_by_src_net(dst_nets, src_net)
+
+            if not dst_net:
+                return
+
+            dst_net_id = dst_net['id']
+
         return dst_net_id
+
+    @staticmethod
+    def get_dst_net_by_src_net(existing_networks, src_net):
+        """
+        Get the same Network object from DST cloud.
+
+        :param existing_networks: Existing networks list on DST cloud,
+        :param src_net: Network object from SRC,
+
+        :return dict: Network object from DST, that matches with the same
+                      network from SRC.
+        """
+
+        for net in existing_networks:
+            if (net['res_hash'] == src_net['res_hash'] and
+                    net['subnets_hash'] == src_net['subnets_hash']):
+                return net
 
 
 class Router(object):

--- a/tests/cloudferrylib/os/actions/test_check_networks.py
+++ b/tests/cloudferrylib/os/actions/test_check_networks.py
@@ -68,6 +68,7 @@ class CheckNetworksTestCase(test.TestCase):
     def test_empty_dst(self):
         src_net_info = {'networks': [{'id': 'id1',
                                       'res_hash': 1,
+                                      'subnets_hash': {2},
                                       "provider:physical_network": None,
                                       'provider:network_type': 'local',
                                       'provider:segmentation_id': None,
@@ -86,6 +87,7 @@ class CheckNetworksTestCase(test.TestCase):
     def test_equals_networks(self):
         src_net_info = {'networks': [{'id': 'id1',
                                       'res_hash': 1,
+                                      'subnets_hash': {2},
                                       "provider:physical_network": None,
                                       'provider:network_type': 'local',
                                       'provider:segmentation_id': None,
@@ -98,6 +100,7 @@ class CheckNetworksTestCase(test.TestCase):
                         'floating_ips': []}
         dst_net_info = {'networks': [{'id': 'id2',
                                       'res_hash': 1,
+                                      'subnets_hash': {2},
                                       "provider:physical_network": None,
                                       'provider:network_type': 'local',
                                       'provider:segmentation_id': None,
@@ -113,6 +116,7 @@ class CheckNetworksTestCase(test.TestCase):
     def test_equals_and_new_networks(self):
         src_net_info = {'networks': [{'id': 'id1',
                                       'res_hash': 1,
+                                      'subnets_hash': {2, 5},
                                       "provider:physical_network": None,
                                       'provider:network_type': 'local',
                                       'provider:segmentation_id': None,
@@ -130,6 +134,7 @@ class CheckNetworksTestCase(test.TestCase):
                         'floating_ips': []}
         dst_net_info = {'networks': [{'id': 'id2',
                                       'res_hash': 1,
+                                      'subnets_hash': {2},
                                       "provider:physical_network": None,
                                       'provider:network_type': 'local',
                                       'provider:segmentation_id': None,
@@ -145,6 +150,7 @@ class CheckNetworksTestCase(test.TestCase):
     def test_diff(self):
         src_net_info = {'networks': [{'id': 'id1',
                                       'res_hash': 1,
+                                      'subnets_hash': {1},
                                       "provider:physical_network": None,
                                       'provider:network_type': 'local',
                                       'provider:segmentation_id': None,
@@ -158,6 +164,7 @@ class CheckNetworksTestCase(test.TestCase):
                         'floating_ips': []}
         dst_net_info = {'networks': [{'id': 'id2',
                                       'res_hash': 1,
+                                      'subnets_hash': {3},
                                       "provider:physical_network": None,
                                       'provider:network_type': 'local',
                                       'provider:segmentation_id': None,
@@ -174,6 +181,7 @@ class CheckNetworksTestCase(test.TestCase):
     def test_overlap(self):
         src_net_info = {'networks': [{'id': 'id1',
                                       'res_hash': 1,
+                                      'subnets_hash': {2},
                                       "provider:physical_network": None,
                                       'provider:network_type': 'local',
                                       'provider:segmentation_id': None,
@@ -186,6 +194,7 @@ class CheckNetworksTestCase(test.TestCase):
                         'floating_ips': []}
         dst_net_info = {'networks': [{'id': 'id2',
                                       'res_hash': 1,
+                                      'subnets_hash': {3},
                                       "provider:physical_network": None,
                                       'provider:network_type': 'local',
                                       'provider:segmentation_id': None,
@@ -202,6 +211,7 @@ class CheckNetworksTestCase(test.TestCase):
     def test_check_segmentation_id_overlapping_no_dst_networks(self):
         src_net_info = {'networks': [{'id': 'id1',
                                       'res_hash': 1,
+                                      'subnets_hash': {},
                                       "provider:physical_network": None,
                                       'provider:network_type': 'gre',
                                       'provider:segmentation_id': 200,
@@ -218,6 +228,7 @@ class CheckNetworksTestCase(test.TestCase):
     def test_check_segmentation_id_overlapping_same_network(self):
         src_net_info = {'networks': [{'id': 'id1',
                                       'res_hash': 1,
+                                      'subnets_hash': {},
                                       "provider:physical_network": None,
                                       'provider:network_type': 'gre',
                                       'provider:segmentation_id': 200,
@@ -227,6 +238,7 @@ class CheckNetworksTestCase(test.TestCase):
 
         dst_net_info = {'networks': [{'id': 'id2',
                                       'res_hash': 1,
+                                      'subnets_hash': {},
                                       "provider:physical_network": None,
                                       'provider:network_type': 'gre',
                                       'provider:segmentation_id': 200,
@@ -355,6 +367,7 @@ class CheckNetworksTestCase(test.TestCase):
     def test_no_instance_in_external_network(self):
         src_net_info = {'networks': [{'id': 'fake_network_id',
                                       'res_hash': 1,
+                                      'subnets_hash': {2},
                                       "provider:physical_network": None,
                                       'provider:network_type': 'local',
                                       'provider:segmentation_id': None,
@@ -373,6 +386,7 @@ class CheckNetworksTestCase(test.TestCase):
     def test_instance_in_external_network(self):
         src_net_info = {'networks': [{'id': 'fake_network_id',
                                       'res_hash': 1,
+                                      'subnets_hash': {2},
                                       "provider:physical_network": None,
                                       'provider:network_type': 'local',
                                       'provider:segmentation_id': None,
@@ -392,6 +406,7 @@ class CheckNetworksTestCase(test.TestCase):
     def test_allocation_pools_overlap(self):
         src_net_info = {'networks': [{'id': 'id1',
                                       'res_hash': 1,
+                                      'subnets_hash': {2},
                                       "provider:physical_network": None,
                                       'provider:network_type': 'local',
                                       'provider:segmentation_id': None,
@@ -411,6 +426,7 @@ class CheckNetworksTestCase(test.TestCase):
 
         dst_net_info = {'networks': [{'id': 'id2',
                                       'res_hash': 1,
+                                      'subnets_hash': {3},
                                       "provider:physical_network": None,
                                       'provider:network_type': 'local',
                                       'provider:segmentation_id': None,
@@ -432,6 +448,7 @@ class CheckNetworksTestCase(test.TestCase):
     def test_allocation_pools_no_overlap(self):
         src_net_info = {'networks': [{'id': 'id1',
                                       'res_hash': 1,
+                                      'subnets_hash': {2},
                                       "provider:physical_network": None,
                                       'provider:network_type': 'local',
                                       'provider:segmentation_id': None,
@@ -449,6 +466,7 @@ class CheckNetworksTestCase(test.TestCase):
 
         dst_net_info = {'networks': [{'id': 'id2',
                                       'res_hash': 1,
+                                      'subnets_hash': {3},
                                       "provider:physical_network": None,
                                       'provider:network_type': 'local',
                                       'provider:segmentation_id': None,
@@ -471,6 +489,7 @@ class CheckNetworksTestCase(test.TestCase):
     def test_allocation_pools_same_network_and_subnet(self):
         src_net_info = {'networks': [{'id': 'id1',
                                       'res_hash': 1,
+                                      'subnets_hash': {3},
                                       "provider:physical_network": None,
                                       'provider:network_type': 'local',
                                       'provider:segmentation_id': None,
@@ -490,6 +509,7 @@ class CheckNetworksTestCase(test.TestCase):
 
         dst_net_info = {'networks': [{'id': 'id2',
                                       'res_hash': 1,
+                                      'subnets_hash': {3},
                                       "provider:physical_network": None,
                                       'provider:network_type': 'local',
                                       'provider:segmentation_id': None,

--- a/tests/cloudferrylib/os/network/test_neutron.py
+++ b/tests/cloudferrylib/os/network/test_neutron.py
@@ -95,6 +95,7 @@ class NeutronTestCase(test.TestCase):
                            'provider:network_type': 'gre',
                            'provider:segmentation_id': 5,
                            'res_hash': 'fake_net_hash_1',
+                           'subnets_hash': {'fake_subnet_hash_1'},
                            'meta': {}}
 
         self.net_2_info = {'name': 'fake_network_name_2',
@@ -109,6 +110,7 @@ class NeutronTestCase(test.TestCase):
                            'provider:network_type': 'vlan',
                            'provider:segmentation_id': 10,
                            'res_hash': 'fake_net_hash_2',
+                           'subnets_hash': {'fake_subnet_hash_2'},
                            'meta': {}}
 
         self.subnet_1_info = {'name': 'fake_subnet_name_1',


### PR DESCRIPTION
Change the way of networks comparison. Collect all subnets hashes of
each network and use it for more accurate networks comparison
(identify which network on DST matches with the same network from SRC).