### PR TITLE
CF-319 Remove non-migrated volumes

### DIFF
--- a/cloudferrylib/os/storage/plugins/copy_mechanisms.py
+++ b/cloudferrylib/os/storage/plugins/copy_mechanisms.py
@@ -52,11 +52,15 @@ class RemoteFileCopy(CopyMechanism):
             'path_dst': destination_object.path
         }
 
-        copier = base.get_copier(context.src_cloud, context.dst_cloud, data)
-
         try:
+            copier = base.get_copier(context.src_cloud,
+                                     context.dst_cloud,
+                                     data)
+
             copier.transfer(data)
-        except base.FileCopyError as e:
+        except (base.FileCopyError,
+                base.CopierCannotBeUsed,
+                base.CopierNotFound) as e:
             msg = ("Copying file from {src_host}@{src_file} to "
                    "{dst_host}@{dst_file}, error: {err}").format(
                 src_host=source_object.host,


### PR DESCRIPTION
Steps to reproduce

 1. Set invalid path for bbcp executable in `[bbcp] path` config option
 2. Run volume migration
 3. Notice unhandled exception
 4. Put correct value to `[bbcp] path`
 5. Run volume migration again
 6. Notice volume was skipped as already migrated

Actual behavior

 - Volume is skipped as "migrated" even though it's empty

Expected behavior

 - Volume should be removed on CopyEngine initialization failure