### PR TITLE
CF-323 Fix glance image migration in jenkins

### DIFF
--- a/devlab/generate_load.py
+++ b/devlab/generate_load.py
@@ -240,7 +240,8 @@ class Prerequisites(base.BasePrerequisites):
                 'id': []
             },
             'images': {
-                'images_list': []
+                'images_list': [],
+                'dont_include_public_and_members_from_other_tenants': False
             }
         }
         all_img_ids = []


### PR DESCRIPTION
Steps to reproduce

 - Run icehouse to juno or grizzly to juno jobs

Actual result

 - test_migrate_glance_image_belongs_to_deleted_tenant test is failing:

```
    Image image6 is not in DST image list: [u'cirros_image_for_tenant4',
    u'restored image 1a58733b-5515-49cf-9e0e-8bb615c9e2a2 from host
    192.168.1.3', u'restored image f60557a1-0cc0-41ca-a28e-5024a20d7a0c from
    host 192.168.1.3', u'image3', u'Cirros 0.3.0 x86_64', u'image1',
    u'without_checksum', u'image4', u'image2', u'cirros-0.3.3-x86_64']
```

Expected result

 - All tests should succeed