### PR TITLE
Migrate config_drive instance parameter.

### DIFF
--- a/cloudferrylib/os/compute/nova_compute.py
+++ b/cloudferrylib/os/compute/nova_compute.py
@@ -383,6 +383,8 @@ class NovaCompute(compute.Compute):
         else:
             server_group = None
 
+        config_drive = utl.get_disk_path(instance, instance_block_info,
+                                         disk=utl.DISK_CONFIG)
         inst = {'instance': {'name': instance.name,
                              'instance_name': instance_name,
                              'id': instance.id,
@@ -408,7 +410,8 @@ class NovaCompute(compute.Compute):
                              'is_ephemeral': is_ephemeral,
                              'volumes': volumes,
                              'user_id': instance.user_id,
-                             'server_group': server_group
+                             'server_group': server_group,
+                             'config_drive': config_drive is not None,
                              },
                 'ephemeral': ephemeral_path,
                 'diff': diff,
@@ -685,6 +688,7 @@ class NovaCompute(compute.Compute):
                         instance, 'key_name'),
                     'nics': instance['nics'],
                     'image': instance['image_id'],
+                    'config_drive': instance['config_drive'],
                     # user_id matches user_id on source
                     'user_id': instance.get('user_id'),
                     'availability_zone': self.attr_override.get_attr(

--- a/cloudferrylib/utils/utils.py
+++ b/cloudferrylib/utils/utils.py
@@ -52,6 +52,7 @@ STATUS = 'status'
 
 DISK = "disk"
 DISK_EPHEM = "disk.local"
+DISK_CONFIG = "disk.config"
 LEN_UUID_INSTANCE = 36
 
 HOST_SRC = 'host_src'


### PR DESCRIPTION
When instance is created in cloud with config_drive = True option in nova.conf, VM instances don't automatically get config_drive parameter set to True on creation. This means that when migrating VMs we need to check if drive.config is attached to instance in order to find out which config_drive value to set on instance creation.