### PR TITLE
[CF-270] Create black list feature for images in filter file

### DIFF
--- a/cloudferrylib/os/actions/check_filter.py
+++ b/cloudferrylib/os/actions/check_filter.py
@@ -108,6 +108,14 @@ class CheckFilter(action.Action):
 
     def _check_opts_img(self, opts):
         image_resource = self.cloud.resources[utl.IMAGE_RESOURCE]
+        if opts and \
+                opts.get('images_list') and opts.get('exclude_images_list'):
+            raise exception.AbortMigrationError(
+                "In the filter config file was specified "
+                "'images_list' and 'exclude_images_list'. "
+                "Must either specify - 'images_list' or "
+                "'exclude_images_list'.")
+
         if opts and opts.get('images_list'):
             images_list = opts['images_list']
             for img_id in images_list:

--- a/cloudferrylib/utils/filters.py
+++ b/cloudferrylib/utils/filters.py
@@ -43,6 +43,11 @@ class FilterYaml(object):
         images = fy.get('images', {})
         return images.get('images_list', [])
 
+    def get_excluded_image_ids(self):
+        fy = self.get_filter_yaml()
+        images = fy.get('images', {})
+        return images.get('exclude_images_list', [])
+
     def is_public_and_member_images_filtered(self):
         fy = self.get_filter_yaml()
         images = fy.get('images', {})

--- a/configs/filter.yaml
+++ b/configs/filter.yaml
@@ -9,6 +9,9 @@
 #    images_list:
 #        - <image_id1>
 #        - <image_id2>
+#    exclude_images_list:
+#        - <image_id1>
+#        - <image_id2>
 #    dont_include_public_and_members_from_other_tenants: True
 #volumes:
 #    volumes_list:

--- a/docs/user/configuration.rst
+++ b/docs/user/configuration.rst
@@ -100,11 +100,20 @@ Filter file is a standard YAML file with following syntax::
         images_list:
             - <image_id1>
             - <image_id2>
+        #exclude_images_list:
+        #    - <image_id1>
+        #    - <image_id2>
         dont_include_public_and_members_from_other_tenants: False
     volumes:
         volumes_list:
             - <volume_id1>
             - <volume_id2>
+
+In the config file you can specify either ``images_list`` or
+``exclude_images_list`` in the images section. If you specified
+``images_list`` only images specified in this list will be migrated.
+If you specified ``exclude_images_list`` all images exclude images in
+the list will be migrated.
 
 When :dfn:`dont_include_public_and_members_from_other_tenants` is set to
 ``True`` (to which it is set by default), all the public images and images

--- a/tests/cloudferrylib/os/actions/test_check_filter.py
+++ b/tests/cloudferrylib/os/actions/test_check_filter.py
@@ -1,0 +1,82 @@
+# Copyright 2016 Mirantis Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from glanceclient import exc as glance_exc
+import mock
+from tests import test
+
+from cloudferrylib.base import exception
+from cloudferrylib.os.actions import check_filter
+
+
+class CheckFilterTestCase(test.TestCase):
+    def setUp(self):
+        super(CheckFilterTestCase, self).setUp()
+
+        fake_src_cloud = mock.Mock()
+        self.fake_src_image = mock.Mock()
+
+        fake_src_cloud.resources = {
+            'image': self.fake_src_image,
+        }
+
+        self.fake_init = {
+            'src_cloud': fake_src_cloud,
+        }
+
+    def test_check_opts_img_with_error_in_filter_config(self):
+        fake_action = check_filter.CheckFilter(self.fake_init,
+                                               cloud='src_cloud')
+
+        opts = {
+            'images_list': 'foo',
+            'exclude_images_list': 'bar',
+        }
+
+        self.assertRaises(exception.AbortMigrationError,
+                          fake_action._check_opts_img,
+                          opts)
+
+    def test_check_opts_img_if_image_exists(self):
+        fake_action = check_filter.CheckFilter(self.fake_init,
+                                               cloud='src_cloud')
+        image = mock.Mock()
+
+        opts = {
+            'images_list': [image.id]
+        }
+        self.fake_src_image.glance_client.images.get.return_value = image
+
+        fake_action._check_opts_img(opts)
+
+        self.fake_src_image.glance_client.images.\
+            get.assert_called_once_with(image.id)
+
+    def test_check_opts_img_if_doesnt_image_exist(self):
+        fake_action = check_filter.CheckFilter(self.fake_init,
+                                               cloud='src_cloud')
+        image = mock.Mock()
+        opts = {
+            'images_list': [image.id]
+        }
+        self.fake_src_image.glance_client.images.\
+            get.side_effect = glance_exc.HTTPNotFound
+
+        self.assertRaises(glance_exc.HTTPNotFound,
+                          fake_action._check_opts_img,
+                          opts)
+
+        self.fake_src_image.glance_client.images.\
+            get.assert_called_once_with(image.id)

--- a/tests/cloudferrylib/utils/test_filters.py
+++ b/tests/cloudferrylib/utils/test_filters.py
@@ -52,6 +52,11 @@ class FilterYamlTestCase(test.TestCase):
         fy = filters.FilterYaml(filters_file)
         self.assertEqual(list(), fy.get_image_ids())
 
+    def test_returns_empty_list_for_get_excluded_image_ids(self):
+        filters_file = u""
+        fy = filters.FilterYaml(filters_file)
+        self.assertEqual(list(), fy.get_excluded_image_ids())
+
     def test_returns_empty_list_if_nothing_in_instance_ids(self):
         filters_file = u""
         fy = filters.FilterYaml(filters_file)
@@ -83,6 +88,23 @@ class FilterYamlTestCase(test.TestCase):
         self.assertTrue(isinstance(filtered_instances, list))
         self.assertIn(instance1, filtered_instances)
         self.assertIn(instance2, filtered_instances)
+
+    def test_returns_images_from_excluded_image_ids(self):
+        image1 = 'image1'
+        image2 = 'image2'
+        filters_file = u"""
+        images:
+            exclude_images_list:
+                - {image1}
+                - {image2}
+        """.format(image1=image1, image2=image2)
+
+        fy = filters.FilterYaml(filters_file)
+        filtered_images = fy.get_excluded_image_ids()
+
+        self.assertTrue(isinstance(filtered_images, list))
+        self.assertIn(image1, filtered_images)
+        self.assertIn(image2, filtered_images)
 
     def test_returns_images_from_image_ids(self):
         image1 = 'image1'


### PR DESCRIPTION
Add a new option in the section 'image' in the filter config file - exclude_images_list. This option allow to specify images list that will be excluded during the migration process. All other images will be migrated.
If the 'images_list' and 'exclude_images_list' were specified exception will be raised. It means that in the filter config file must exists only one option - 'images_list' or 'exclude_images_list'.