### PR TITLE
CF-317 Networking migration documentation

### DIFF
--- a/docs/user/configuration.rst
+++ b/docs/user/configuration.rst
@@ -19,6 +19,7 @@ Based on :file:`CloudFerry/configs/config.ini`. This file contains generic
 migration configuration options as well as credentials to access source and
 destination cloud resources.
 
+.. _scenario-files-config:
 
 Scenario files
 --------------

--- a/docs/user/networking.rst
+++ b/docs/user/networking.rst
@@ -1,0 +1,15 @@
+============================
+Neutron networking migration
+============================
+
+.. toctree::
+    :maxdepth: 2
+
+    networking/overview
+    networking/general_rules
+    networking/net_and_subnet_migration
+    networking/external_networks
+    networking/routers
+    networking/ports
+    networking/security_groups
+    networking/lbaas

--- a/docs/user/networking/external_networks.rst
+++ b/docs/user/networking/external_networks.rst
@@ -1,0 +1,70 @@
+=================
+External networks
+=================
+
+External networks migration follows :ref:`general-neutron-migration-rules`
+and :ref:`network-and-subnet-migration` with a number of specific details.
+
+External networks with overlapping CIDRs
+----------------------------------------
+
+In case source and destination cloud external networks don't match exactly
+and their CIDRs overlap, (for example 10.0.0.100-200 range in source cloud
+and 10.0.0.150-250 range in destination) CloudFerry will not start migration
+and operator is expected to resolve this problem manually.
+
+Mapping external networks from source cloud to destination
+----------------------------------------------------------
+
+There are many cases when external networks in source cloud don't match
+those in destination. In order to run migration in those cases CloudFerry
+allows mapping between source and destination external networks, which is
+specified in networks mapping YAML file with format::
+
+    <source cloud external net id 1>: <destination cloud external net id 1>
+    <source cloud external net id 2>: <destination cloud external net id 2>
+    ...
+    <source cloud external net id N>: <destination cloud external net id N>
+
+The file is specified with ``[migrate] ext_net_map`` config option.
+
+.. important::
+
+    When external networks mapping is used, floating IPs will **not** be
+    kept regardless of ``[migrate] keep_floating_ip`` option value and
+    even if mapped networks are identical.
+
+
+Floating IPs
+------------
+
+Floating IP migration depends on two config options:
+
+ - ``keep_floatingip`` in ``[migrate]`` group
+ - ``ext_net_map`` in ``[migrate]`` group
+
+
+``keep_floatingip``
+^^^^^^^^^^^^^^^^^^^
+
+When ``keep_floatingip`` option is set to ``True``, CloudFerry attempts to
+migrate floating IPs to destination cloud without modifying them. Neutron APIs
+do not provide ways of specifying particular floating IP, thus this change is
+done at DB level and is very dangerous.
+
+.. warning::
+
+    ``keep_floatingip`` option may be dangerous because it involves
+    direct modification of destination cloud neutron database
+
+
+When ``keep_floatingip`` option is disabled floating IPs are allocated in
+the same external network in destination, but IP addresses are **not kept**.
+
+
+``ext_net_map``
+^^^^^^^^^^^^^^^
+
+``ext_net_map`` option defines mapping between source cloud external
+networks and destination cloud external networks. With mapping set floating
+IPs are not kept during migration.

--- a/docs/user/networking/general_rules.rst
+++ b/docs/user/networking/general_rules.rst
@@ -1,0 +1,8 @@
+.. _general-neutron-migration-rules:
+
+=======================
+General migration rules
+=======================
+
+ - Neutron objects UUIDs are **not** kept;
+ - Remaining neutron objects attributes are kept whenever possible.

--- a/docs/user/networking/lbaas.rst
+++ b/docs/user/networking/lbaas.rst
@@ -1,0 +1,13 @@
+=======================
+LBaaS migration process
+=======================
+
+CloudFerry supports migration of following LBaaS objects:
+
+ - Pools
+ - Monitors
+ - Members
+ - VIPs
+
+All LBaaS objects are created using neutron APIs and don't have any specific
+config options

--- a/docs/user/networking/net_and_subnet_migration.rst
+++ b/docs/user/networking/net_and_subnet_migration.rst
@@ -1,0 +1,33 @@
+.. _network-and-subnet-migration:
+
+==============================
+Networks and subnets migration
+==============================
+
+Since networks have virtually no value without subnets, these two objects
+are treated as a single object during migration.
+
+Following attributes are kept during migration of networks and subnets:
+
+ - Network attributes:
+     - Tenant. If tenant does not exist in destination - network is skipped;
+     - Network name;
+     - Admin state (UP or DOWN);
+     - Shared or not shared;
+     - Private or external;
+     - Network type (flat, VLAN, GRE, VXLAN, etc). If source cloud network
+       type is not supported in destination cloud - migration does not start.
+     - Segmentation ID, if available in destination. Otherwise neutron
+       allocates new segmentation ID;
+ - Subnet attributes:
+     - Subnet name;
+     - DHCP status (enabled or not);
+     - CIDR;
+     - Allocation pools;
+     - IP version;
+
+Shared private networks
+-----------------------
+
+Shared networks are accessible from all tenants, so they will be migrated
+regardless of :ref:`filtering rules <filter-configuration>`.

--- a/docs/user/networking/overview.rst
+++ b/docs/user/networking/overview.rst
@@ -1,0 +1,30 @@
+==========================
+Network migration overview
+==========================
+
+Network migration is perhaps the most complicated part of migration process.
+Primarily because there is a need to determine whether networking object
+(network, subnet, port, router) already exists in destination cloud or not.
+
+Since networking migration may introduce a lot of problems, there is a
+mandatory preliminary check which detects all the potential conflicts
+between source and destination cloud, and is implemented in ``check_networks``
+:ref:`action <scenario-files-config>`.
+
+Following objects are supported as part of networking migration:
+
+ - Networks
+    - Private tenant networks
+    - Shared networks
+    - External networks
+ - Subnets
+ - Routers
+ - Ports
+ - Floating IPs
+ - Security groups
+ - Load balancer objects
+    - Pools
+    - Monitors
+    - Members
+    - VIPs
+ - Neutron quotas

--- a/docs/user/networking/ports.rst
+++ b/docs/user/networking/ports.rst
@@ -1,0 +1,11 @@
+=======================
+Ports migration process
+=======================
+
+CloudFerry allows migration of neutron ports as independent step if all the
+dependencies (neutron networks and keystone tenants) already exist in
+destination.
+
+CloudFerry supports both attached (VM's ports) and detached port
+(standalone) migration. Detached port migration can be useful in cases when
+neutron ports are used as load balancers.

--- a/docs/user/networking/routers.rst
+++ b/docs/user/networking/routers.rst
@@ -1,0 +1,29 @@
+=========================
+Routers migration process
+=========================
+
+Private tenant routers migration
+--------------------------------
+
+Private router migration (routers which only connect private tenant
+networks) is dead simple:
+
+ - Read router list from source clond;
+ - Create routers using neutron APIs in destination cloud.
+
+
+External router migration
+-------------------------
+
+External routers are more tricky, because they can be shared between tenants.
+Thus the process for external router migration is as follows:
+
+ - Get router list from source cloud;
+ - If tenant's network is routed through a router belonging to a different
+   tenant - this tenant is added to the list of tenants, which need to be
+   migrated and is migrated prior to router migration;
+ - If router is connected to external network which belongs to a different
+   tenant - this tenant is added to the list of tenants which need to be
+   migrated and is migrated prior to router migration;
+ - When all dependencies are available in destination router is created
+   using neutron APIs.

--- a/docs/user/networking/security_groups.rst
+++ b/docs/user/networking/security_groups.rst
@@ -1,0 +1,6 @@
+=================================
+Security groups migration process
+=================================
+
+Security groups are simply migrated using neutron APIs and based on
+filtering rules.

--- a/docs/user/user_doc_index.rst
+++ b/docs/user/user_doc_index.rst
@@ -10,6 +10,7 @@ End-user CloudFerry documentation
     quick_start_guide
     configuration
     nova_compute_migration
+    networking
     glance_image_migration
     cinder_migration
     copy_mechanisms


### PR DESCRIPTION
Documents how neutron networking objects are migrated:

 - Networks
 - Subnets
 - Floating IPs
 - Security groups
 - Ports
 - Routers