### PR TITLE
[CF-352] Abort generate_load.py when vm spawned in ERROR state

### DIFF
--- a/cloudferry_devlab/cloudferry_devlab/tests/base.py
+++ b/cloudferry_devlab/cloudferry_devlab/tests/base.py
@@ -267,6 +267,9 @@ class BasePrerequisites(object):
 
     def check_vm_state(self, srv_id):
         srv = self.novaclient.servers.get(srv_id)
+        if srv.status == 'ERROR':
+            msg = 'VM with id {0} was spawned in error state'
+            raise RuntimeError(msg.format(srv_id))
         return srv.status == 'ACTIVE'
 
     def check_image_state(self, img_id):


### PR DESCRIPTION
Raise RuntimeError exception when VM becoming in error state, do not wait until temeout will be expired.