### PR TITLE
[CF-5] Migrate DNS name servers

### DIFF
--- a/cloudferrylib/os/network/neutron.py
+++ b/cloudferrylib/os/network/neutron.py
@@ -451,6 +451,7 @@ class NeutronNetwork(network.Network):
             'external': net['router:external'],
             'network_id': snet['network_id'],
             'tenant_name': get_tenant_name(snet['tenant_id']),
+            'dns_nameservers': snet['dns_nameservers'],
             'meta': {},
         }
 
@@ -1315,6 +1316,7 @@ class NeutronNetwork(network.Network):
                     'allocation_pools': snet['allocation_pools'],
                     'gateway_ip': snet['gateway_ip'],
                     'ip_version': snet['ip_version'],
+                    'dns_nameservers': snet['dns_nameservers'],
                     'tenant_id': created_net['tenant_id']
                 }
             }

--- a/tests/cloudferrylib/os/network/test_neutron.py
+++ b/tests/cloudferrylib/os/network/test_neutron.py
@@ -124,6 +124,7 @@ class NeutronTestCase(test.TestCase):
                               'network_id': 'fake_network_id_1',
                               'tenant_name': 'fake_tenant_name_1',
                               'res_hash': 'fake_subnet_hash_1',
+                              'dns_nameservers': ['5.5.5.5'],
                               'meta': {}}
 
         self.subnet_2_info = {'name': 'fake_subnet_name_2',
@@ -431,6 +432,7 @@ class NeutronTestCase(test.TestCase):
                                          'ip_version': 4,
                                          'gateway_ip': 'fake_gateway_ip_1',
                                          'cidr': '1.1.1.0/24',
+                                         'dns_nameservers': ['5.5.5.5'],
                                          'id': 'fake_subnet_id_1'}]}
 
         self.neutron_mock_client().list_networks.return_value = fake_net_list
@@ -470,6 +472,7 @@ class NeutronTestCase(test.TestCase):
                                          'ip_version': 4,
                                          'gateway_ip': 'fake_gateway_ip_1',
                                          'cidr': '1.1.1.0/24',
+                                         'dns_nameservers': ['5.5.5.5'],
                                          'id': 'fake_subnet_id_1'}]}
 
         self.neutron_mock_client().list_subnets.return_value = fake_subnet_list


### PR DESCRIPTION
Add `dns_nameservers` parameter to Neutron subnets entity.