### PR TITLE
[CF-357] Migrate resources with filter by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,9 @@ process.
 
 ## Whole cloud migration
 
+Make sure you have `migrate_whole_cloud` option in `migrate` section of config
+is set to `True`.
+
 Use `migrate` command with config file specified:
 
 ```

--- a/cfglib.py
+++ b/cfglib.py
@@ -225,6 +225,8 @@ migrate_opts = [
     cfg.StrOpt('override_rules', default=None,
                help='Server creation parameter (e.g. server group) override '
                     'rules file path.'),
+    cfg.BoolOpt('migrate_whole_cloud', default=False,
+                help="Migrate the whole cloud despite the filter file."),
 ]
 
 mail = cfg.OptGroup(name='mail',

--- a/cloudferrylib/os/actions/get_filter.py
+++ b/cloudferrylib/os/actions/get_filter.py
@@ -12,26 +12,30 @@
 # See the License for the specific language governing permissions and#
 # limitations under the License.
 
+
 from cloudferrylib.base.action import action
-from cloudferrylib.utils import utils as utl
+from cloudferrylib.utils import utils
 
 
 class GetFilter(action.Action):
 
     def run(self, **kwargs):
-        search_opts, search_opts_img, search_opts_tenant = None, {}, {}
+        search_opts, search_opts_img, search_opts_tenant = {}, {}, {}
         search_opts_vol = {}
         filter_path = self.cfg.migrate.filter_path
-        if utl.read_yaml_file(filter_path):
-            filter_config = utl.read_yaml_file(filter_path)
-            if utl.INSTANCES_TYPE in filter_config:
-                search_opts = filter_config[utl.INSTANCES_TYPE]
-            if utl.IMAGES_TYPE in filter_config:
-                search_opts_img = filter_config[utl.IMAGES_TYPE]
-            if utl.VOLUMES_TYPE in filter_config:
-                search_opts_vol = filter_config[utl.VOLUMES_TYPE]
-            if utl.TENANTS_TYPE in filter_config:
-                search_opts_tenant = filter_config[utl.TENANTS_TYPE]
+
+        if (utils.read_yaml_file(filter_path) and
+                not self.cfg.migrate.migrate_whole_cloud):
+            filter_config = utils.read_yaml_file(filter_path)
+            if utils.INSTANCES_TYPE in filter_config:
+                search_opts = filter_config[utils.INSTANCES_TYPE]
+            if utils.IMAGES_TYPE in filter_config:
+                search_opts_img = filter_config[utils.IMAGES_TYPE]
+            if utils.VOLUMES_TYPE in filter_config:
+                search_opts_vol = filter_config[utils.VOLUMES_TYPE]
+            if utils.TENANTS_TYPE in filter_config:
+                search_opts_tenant = filter_config[utils.TENANTS_TYPE]
+
         return {
             'search_opts': search_opts,
             'search_opts_img': search_opts_img,

--- a/configs/config.ini
+++ b/configs/config.ini
@@ -217,6 +217,14 @@ override_rules = configs/override_rules.yaml
 # Time in seconds to wait for cinder objects creation. Set to 300 by default.
 storage_backend_timeout = 300
 
+# Migrate the whole cloud.
+# Values:
+# True - enabled. Whole cloud will be migrated despite the filter config file
+#                 is specified;
+# False - disabled (by default). Migrate resources and instances according to
+#         the filter config file.
+migrate_whole_cloud = False
+
 
 #==============================================================================
 # Mailing configuration

--- a/scenario/README.md
+++ b/scenario/README.md
@@ -3,7 +3,27 @@ Scenario
 
 ## Overview
 
-By default CloudFerry tool is going to migrate all resources and instances from the source cloud to the destination cloud.
+By default CloudFerry tool is going to migrate resources and instances,
+specified in the filter config file, from the source cloud to the destination
+cloud.
+Default location of filter config file is `configs/filter.yaml`, but it always
+can be changed by modifying main configuration file (configuration.ini).
+
+Example:
+```
+[migrate]
+filter_path = <new_filter_path>
+```
+
+If one wants to migrate ALL resources and instances from the source cloud to
+the destination cloud then need to modify main configuration file
+(configuration.ini) with:
+
+```
+[migrate]
+migrate_whole_cloud = True
+```
+
 Just use default file scenario(scenario/cold_migrate.yaml) and see README file for instructions to run migration.
 
 

--- a/tests/cloudferrylib/os/actions/test_check_filter.py
+++ b/tests/cloudferrylib/os/actions/test_check_filter.py
@@ -13,70 +13,182 @@
 # limitations under the License.
 
 
-from glanceclient import exc as glance_exc
+import copy
+
 import mock
-from tests import test
+
+from cinderclient import exceptions as cinder_exc
+from glanceclient import exc as glance_exc
+from keystoneclient import exceptions as keystone_exc
+from novaclient import exceptions as nova_exc
+from oslotest import mockpatch
 
 from cloudferrylib.base import exception
 from cloudferrylib.os.actions import check_filter
+from tests import test
 
 
 class CheckFilterTestCase(test.TestCase):
     def setUp(self):
         super(CheckFilterTestCase, self).setUp()
 
+        fake_utils = mock.Mock()
+        utils_patch = mockpatch.Patch(
+            "cloudferrylib.os.actions.check_filter.utils", new=fake_utils)
+        self.useFixture(utils_patch)
+
+        self.src_image = mock.Mock()
+        self.src_compute = mock.Mock()
+        self.src_storage = mock.Mock()
+        self.src_identity = mock.Mock()
+
         fake_src_cloud = mock.Mock()
-        self.fake_src_image = mock.Mock()
-
         fake_src_cloud.resources = {
-            'image': self.fake_src_image,
+            fake_utils.IMAGE_RESOURCE: self.src_image,
+            fake_utils.COMPUTE_RESOURCE: self.src_compute,
+            fake_utils.STORAGE_RESOURCE: self.src_storage,
+            fake_utils.IDENTITY_RESOURCE: self.src_identity
         }
 
-        self.fake_init = {
-            'src_cloud': fake_src_cloud,
-        }
+        fake_config = mock.Mock()
+        fake_config.migrate.migrate_whole_cloud = False
+        fake_config.migrate.filter_path = '/fake/filter_path.yaml'
 
-    def test_check_opts_img_with_error_in_filter_config(self):
-        fake_action = check_filter.CheckFilter(self.fake_init,
-                                               cloud='src_cloud')
+        fake_init = {'src_cloud': fake_src_cloud, 'cfg': fake_config}
+        self.fake_action = check_filter.CheckFilter(fake_init,
+                                                    cloud='src_cloud')
 
-        opts = {
-            'images_list': 'foo',
-            'exclude_images_list': 'bar',
-        }
+        self.opts = dict(search_opts_tenant={}, search_opts={},
+                         search_opts_vol={}, search_opts_img={})
+
+    @mock.patch("cloudferrylib.os.actions.check_filter.utils")
+    def test_no_filter_file(self, fake_utils):
+        fake_utils.check_file.return_value = False
+
+        self.assertRaises(exception.AbortMigrationError, self.fake_action.run)
+
+    @mock.patch("cloudferrylib.os.actions.check_filter.utils")
+    def test_empty_filter(self, fake_utils):
+        fake_utils.read_yaml_file.return_value = {}
+
+        self.assertRaises(exception.AbortMigrationError, self.fake_action.run)
+
+    def test_no_get_filter_action_before(self):
+        self.assertRaises(exception.AbortMigrationError, self.fake_action.run)
+
+    def test_filter_non_existing_tenant(self):
+        opts = copy.deepcopy(self.opts)
+        opts['search_opts_tenant'] = {'tenant_id': ['non_existing_tenant_id']}
+        self.src_identity.keystone_client.tenants.get.side_effect = (
+            keystone_exc.NotFound)
 
         self.assertRaises(exception.AbortMigrationError,
-                          fake_action._check_opts_img,
-                          opts)
+                          self.fake_action.run, **opts)
 
-    def test_check_opts_img_if_image_exists(self):
-        fake_action = check_filter.CheckFilter(self.fake_init,
-                                               cloud='src_cloud')
-        image = mock.Mock()
+    def test_filter_existing_tenant(self):
+        opts = copy.deepcopy(self.opts)
+        opts['search_opts_tenant'] = {'tenant_id': ['existing_tenant_id']}
 
-        opts = {
-            'images_list': [image.id]
-        }
-        self.fake_src_image.glance_client.images.get.return_value = image
+        self.fake_action.run(**opts)
 
-        fake_action._check_opts_img(opts)
+        self.src_identity.keystone_client.tenants.get.assert_called_once_with(
+            'existing_tenant_id')
 
-        self.fake_src_image.glance_client.images.\
-            get.assert_called_once_with(image.id)
+    def test_filter_no_tenants(self):
+        self.assertRaises(exception.AbortMigrationError,
+                          self.fake_action.run, **self.opts)
 
-    def test_check_opts_img_if_doesnt_image_exist(self):
-        fake_action = check_filter.CheckFilter(self.fake_init,
-                                               cloud='src_cloud')
-        image = mock.Mock()
-        opts = {
-            'images_list': [image.id]
-        }
-        self.fake_src_image.glance_client.images.\
-            get.side_effect = glance_exc.HTTPNotFound
+    def test_filter_several_tenants(self):
+        opts = copy.deepcopy(self.opts)
+        opts['search_opts_tenant'] = {
+            'tenant_id': ['existing_tenant_id', 'one_more_existing_tenant_id']}
 
-        self.assertRaises(glance_exc.HTTPNotFound,
-                          fake_action._check_opts_img,
-                          opts)
+        self.assertRaises(exception.AbortMigrationError,
+                          self.fake_action.run, **opts)
 
-        self.fake_src_image.glance_client.images.\
-            get.assert_called_once_with(image.id)
+    def test_filter_existing_instance(self):
+        opts = copy.deepcopy(self.opts)
+        opts['search_opts_tenant'] = {'tenant_id': ['existing_tenant_id']}
+        opts['search_opts'] = {'id': ['existing_instance_id']}
+
+        self.fake_action.run(**opts)
+
+        self.src_compute.nova_client.servers.get.assert_called_once_with(
+            'existing_instance_id')
+
+    def test_filter_non_existing_instance(self):
+        opts = copy.deepcopy(self.opts)
+        opts['search_opts_tenant'] = {'tenant_id': ['existing_tenant_id']}
+        opts['search_opts'] = {'id': ['non_existing_instance_id']}
+
+        self.src_compute.nova_client.servers.get.side_effect = (
+            nova_exc.NotFound(404))
+
+        self.assertRaises(exception.AbortMigrationError,
+                          self.fake_action.run, **opts)
+
+    def test_filter_existing_volume(self):
+        opts = copy.deepcopy(self.opts)
+        opts['search_opts_tenant'] = {'tenant_id': ['existing_tenant_id']}
+        opts['search_opts_vol'] = {'volumes_list': ['existing_volume_id']}
+
+        self.fake_action.run(**opts)
+
+        self.src_storage.cinder_client.volumes.get.assert_called_once_with(
+            'existing_volume_id')
+
+    def test_filter_non_existing_volume(self):
+        opts = copy.deepcopy(self.opts)
+        opts['search_opts_tenant'] = {'tenant_id': ['existing_tenant_id']}
+        opts['search_opts_vol'] = {'volumes_list': ['non_existing_volume_id']}
+
+        self.src_storage.cinder_client.volumes.get.side_effect = (
+            cinder_exc.NotFound(404))
+
+        self.assertRaises(exception.AbortMigrationError,
+                          self.fake_action.run, **opts)
+
+    def test_filter_valid_date(self):
+        opts = copy.deepcopy(self.opts)
+        opts['search_opts_tenant'] = {'tenant_id': ['existing_tenant_id']}
+        opts['search_opts_vol'] = {'date': "1991-08-24 00:00:00"}
+
+        self.fake_action.run(**opts)
+
+    def test_filter_invalid_date(self):
+        opts = copy.deepcopy(self.opts)
+        opts['search_opts_tenant'] = {'tenant_id': ['existing_tenant_id']}
+        opts['search_opts_vol'] = {'date': "03-16-2014"}
+
+        self.assertRaises(exception.AbortMigrationError,
+                          self.fake_action.run, **opts)
+
+    def test_filter_existing_image(self):
+        opts = copy.deepcopy(self.opts)
+        opts['search_opts_tenant'] = {'tenant_id': ['existing_tenant_id']}
+        opts['search_opts_img'] = {'exclude_images_list': ['existing_img_id']}
+
+        self.fake_action.run(**opts)
+
+        self.src_image.glance_client.images.get.assert_called_once_with(
+            'existing_img_id')
+
+    def test_filter_non_existing_image(self):
+        opts = copy.deepcopy(self.opts)
+        opts['search_opts_tenant'] = {'tenant_id': ['existing_tenant_id']}
+        opts['search_opts_img'] = {'images_list': ['non_existing_image_id']}
+
+        self.src_image.glance_client.images.get.side_effect = (
+            glance_exc.NotFound)
+
+        self.assertRaises(exception.AbortMigrationError,
+                          self.fake_action.run, **opts)
+
+    def test_image_conflict_options(self):
+        opts = copy.deepcopy(self.opts)
+        opts['search_opts_tenant'] = {'tenant_id': ['existing_tenant_id']}
+        opts['search_opts_img'] = {'exclude_images_list': ['existing_img_id'],
+                                   'images_list': ['another_existing_img_id']}
+
+        self.assertRaises(exception.AbortMigrationError,
+                          self.fake_action.run, **opts)


### PR DESCRIPTION
Remove default functionality of migrating whole cloud, if filter is
absent or empty. If the filter file is empty or if the filter file can
not be found or read, CloudFerry will raise an exception, unless there
is an option in the migrate section of CF config file to the effect of
`migrate_whole_cloud = True`.

Make `CheckFilter` return all invalid values (IDs of tenants, volumes,
VMs or images) in the filter config file instead of simple fail on the
first one.