### PR TITLE
Fix and optimize functional tests

### DIFF
--- a/cloudferry_devlab/cloudferry_devlab/tests/functional_test.py
+++ b/cloudferry_devlab/cloudferry_devlab/tests/functional_test.py
@@ -148,7 +148,7 @@ class FunctionalTest(unittest.TestCase):
         roles = [i['name'] for i in config.roles]
         return self._get_keystone_resources('roles', roles)
 
-    def filter_vms(self):
+    def get_src_vm_objects_specified_in_config(self):
         vms = self.migration_utils.get_all_vms_from_config()
         vms_names = [vm['name'] for vm in vms if not vm.get('broken')]
         opts = {'search_opts': {'all_tenants': 1}}
@@ -264,7 +264,7 @@ class FunctionalTest(unittest.TestCase):
 
     def tenant_exists(self, keystone_client, tenant_id):
         try:
-            keystone_client.get(tenant_id)
+            keystone_client.tenants.get(tenant_id)
         except ks_exceptions.NotFound:
             return False
         return True

--- a/cloudferry_devlab/cloudferry_devlab/tests/testcases/test_resource_migration.py
+++ b/cloudferry_devlab/cloudferry_devlab/tests/testcases/test_resource_migration.py
@@ -528,11 +528,12 @@ class ResourceMigrationTests(functional_test.FunctionalTest):
         :param name:
         :param config_drive:
         :param key_name:"""
-        src_vms = self.filter_vms()
+        src_vms = self.get_src_vm_objects_specified_in_config()
         dst_vms = self.dst_cloud.novaclient.servers.list(
             search_opts={'all_tenants': 1})
 
-        filtering_data = self.filtering_utils.filter_vms(src_vms)
+        filtering_data = self.filtering_utils\
+            .filter_vms_with_filter_config_file(src_vms)
         src_vms = filtering_data[0]
 
         src_vms = [vm for vm in src_vms if vm.status != 'ERROR']

--- a/cloudferry_devlab/cloudferry_devlab/tests/testcases/test_vm_migration.py
+++ b/cloudferry_devlab/cloudferry_devlab/tests/testcases/test_vm_migration.py
@@ -18,7 +18,7 @@ import unittest
 
 from nose.plugins.attrib import attr
 
-import cloudferry_devlab.tests.config as config
+from cloudferry_devlab.tests import config
 from cloudferry_devlab.tests import functional_test
 
 
@@ -26,40 +26,60 @@ class VmMigration(functional_test.FunctionalTest):
 
     def setUp(self):
         super(VmMigration, self).setUp()
-        src_vms = self.filter_vms()
+
+        src_vms = self.get_src_vm_objects_specified_in_config()
         if not src_vms:
             self.skipTest("Nothing to migrate - source vm list is empty")
-        self.dst_vms = self.dst_cloud.novaclient.servers.list(
-            search_opts={'all_tenants': 1})
-        if not self.dst_vms:
-            self.fail("No VM's on destination. Either Migration was not "
-                      "successful for resource 'VM' or it was not initiated")
+
+        src_vms = self.filtering_utils\
+            .filter_vms_with_filter_config_file(src_vms)[0]
+        if not src_vms:
+            self.skipTest("Nothing to migrate - check the filter config "
+                          "file. Probably in the instances id list in the "
+                          "config file is not specified VMs for migration "
+                          "or is specified tenant id and VMs that not belong "
+                          "to this tenant.")
+
         src_vms = [vm for vm in src_vms if vm.status != 'ERROR' and
                    self.tenant_exists(self.src_cloud.keystoneclient,
                                       vm.tenant_id)]
-        self.dst_vm_indexes = []
-        for vm in src_vms:
-            if vm.name not in config.vms_not_in_filter:
-                self.dst_vm_indexes.append(
-                    [x.name for x in self.dst_vms].index(vm.name))
+        if not src_vms:
+            self.fail("All VMs in SRC was in error state or "
+                      "VM's tenant in SRC doesn't exist")
+
+        dst_vms = self.dst_cloud.novaclient.servers.list(
+            search_opts={'all_tenants': 1})
+        if not dst_vms:
+            self.fail("No VM's on destination. Either Migration was not "
+                      "successful for resource 'VM' or it was not initiated")
+
+        self.src_dst_vms = []
+        for s_vm in src_vms:
+            for d_vm in dst_vms:
+                if s_vm.name == d_vm.name:
+                    self.src_dst_vms.append({
+                        'src_vm': s_vm,
+                        'dst_vm': d_vm,
+                    })
+
         file_path = os.path.join(self.cloudferry_dir,
-                                 'pre_migration_vm_states.json')
+                                 config.pre_migration_vm_states_file)
         with open(file_path) as data_file:
-            self.before_migr_states = json.load(data_file)
-        self.filter_vms = self.filtering_utils.filter_vms(src_vms)
+            self.original_states = json.load(data_file)
 
     @attr(migrated_tenant=['admin', 'tenant1', 'tenant2'])
     def test_vms_not_in_filter_stay_active_on_src(self):
         """Validate VMs which not icluded in filter stays active on SRC cloud.
         """
-        original_states = self.before_migr_states
         for vm in config.vms_not_in_filter:
             vm_list = [x for x in self.src_cloud.novaclient.servers.list(
-                search_opts={'all_tenants': 1}) if x.name == vm]
-            for filtered_vm in vm_list:
-                self.assertTrue(
-                    filtered_vm.status == original_states[filtered_vm.name],
-                    msg="Vm %s has wrong state" % filtered_vm.name)
+                       search_opts={'all_tenants': 1}) if x.name == vm]
+
+            for vm_obj in vm_list:
+                self.assertEqual(
+                    vm_obj.status,
+                    self.original_states[vm_obj.name],
+                    msg="Vm %s has wrong state" % vm_obj.name)
 
     @attr(migrated_tenant=['admin', 'tenant1', 'tenant2'])
     def test_vm_not_in_filter_did_not_migrate(self):
@@ -67,60 +87,50 @@ class VmMigration(functional_test.FunctionalTest):
         dst_vms = [x.name for x in self.dst_cloud.novaclient.servers.list(
                    search_opts={'all_tenants': 1})]
         for vm in config.vms_not_in_filter:
-            self.assertTrue(vm not in dst_vms,
-                            'VM migrated despite that it was not included in '
-                            'filter, VM info: \n{}'.format(vm))
+            msg = 'VM migrated despite that it was '\
+                   'not included in filter, VM info: \n{vm}'
+            self.assertNotIn(vm, dst_vms, msg=msg.format(vm=vm))
 
     @attr(migrated_tenant=['admin', 'tenant1', 'tenant2'])
     def test_cold_migrate_vm_state(self):
         """Validate VMs were cold migrated with correct states."""
-        original_states = self.before_migr_states
-        for vm_name in original_states.keys():
-            if vm_name in config.vms_not_in_filter:
-                original_states.pop(vm_name)
-        src_vms = self.filter_vms[0]
-        for src_vm, vm_index in zip(src_vms, self.dst_vm_indexes):
-            if src_vm.name in original_states.keys():
-                if original_states[src_vm.name] == 'ACTIVE' or \
-                        original_states[src_vm.name] == 'VERIFY_RESIZE':
-                    self.assertTrue(
-                        src_vm.status == 'SHUTOFF' and
-                        self.dst_vms[vm_index].status == 'ACTIVE')
-                else:
-                    self.assertTrue(
-                        src_vm.status == 'SHUTOFF' and
-                        self.dst_vms[vm_index].status == 'SHUTOFF')
+        for vms in self.src_dst_vms:
+            dst_vm = vms['dst_vm']
+            src_vm = vms['src_vm']
+            if self.original_states[src_vm.name] == 'ACTIVE' or \
+                    self.original_states[src_vm.name] == 'VERIFY_RESIZE':
+                self.assertEqual(src_vm.status, 'SHUTOFF')
+                self.assertEqual(dst_vm.status, 'ACTIVE')
             else:
-                self.assertTrue(src_vm.status == 'SHUTOFF' and
-                                self.dst_vms[vm_index].status == 'ACTIVE')
+                self.assertEqual(src_vm.status, 'SHUTOFF')
+                self.assertEqual(dst_vm.status, 'SHUTOFF')
 
     @attr(migrated_tenant=['admin', 'tenant1', 'tenant2'])
     def test_cold_migrate_vm_ip(self):
         """Validate VMs were cold migrated with correct IPs."""
-        src_vms = self.filter_vms[0]
-        for src_vm, vm_index in zip(src_vms, self.dst_vm_indexes):
+        for vms in self.src_dst_vms:
+            dst_vm = vms['dst_vm']
+            src_vm = vms['src_vm']
             for src_net in src_vm.addresses:
                 for src_net_addr, dst_net_addr in zip(src_vm.addresses
                                                       [src_net],
-                                                      self.dst_vms[vm_index]
-                                                      .addresses[src_net]):
-                    self.assertTrue(src_net_addr['addr'] ==
-                                    dst_net_addr['addr'])
+                                                      dst_vm.addresses
+                                                      [src_net]):
+                    self.assertEqual(src_net_addr['addr'],
+                                     dst_net_addr['addr'])
 
     @attr(migrated_tenant=['admin', 'tenant1', 'tenant2'])
     def test_cold_migrate_vm_security_groups(self):
         """Validate VMs were cold migrated with correct security groups."""
-        src_vms = self.filter_vms[0]
-        for src_vm, vm_index in zip(src_vms, self.dst_vm_indexes):
+        for vms in self.src_dst_vms:
             dst_sec_group_names = [x['name'] for x in
-                                   self.dst_vms[vm_index].security_groups]
-            for security_group in src_vm.security_groups:
-                self.assertTrue(security_group['name'] in dst_sec_group_names)
+                                   vms['dst_vm'].security_groups]
+            for security_group in vms['src_vm'].security_groups:
+                self.assertIn(security_group['name'], dst_sec_group_names)
 
     @unittest.skip("Temporarily disabled: image's id changes after migrating")
     def test_cold_migrate_vm_image_id(self):
         """Validate VMs were cold migrated with correct image ids."""
-        src_vms = self.filter_vms[0]
-        for src_vm, vm_index in zip(src_vms, self.dst_vm_indexes):
-            self.assertTrue(src_vm.image.id ==
-                            self.dst_vms[vm_index].image.id)
+        for vms in self.src_dst_vms:
+            self.assertEqual(vms['dst_vm'].image['id'],
+                             vms['src_vm'].image['id'])

--- a/cloudferry_devlab/cloudferry_devlab/tests/utils.py
+++ b/cloudferry_devlab/cloudferry_devlab/tests/utils.py
@@ -60,18 +60,32 @@ class FilteringUtils(Utils):
                 for tenant in config.tenants
                 if 'deleted' not in tenant and not tenant['deleted']]
 
-    def filter_vms(self, src_data_list):
+    def filter_vms_with_filter_config_file(self, src_data_list):
         loaded_data = self.load_file(self.filter_file_path)
         filter_dict = loaded_data[0]
+
+        current_data_list = list(src_data_list)
         popped_vm_list = []
-        if 'instances' not in filter_dict:
-            return [src_data_list, []]
-        for vm in src_data_list[:]:
-            if vm.id not in filter_dict['instances']['id']:
-                popped_vm_list.append(vm)
-                index = src_data_list.index(vm)
-                src_data_list.pop(index)
-        return [src_data_list, popped_vm_list]
+
+        if 'tenants' in filter_dict:
+            filtered_vms_by_tenant = []
+            for vm in current_data_list:
+                if vm.tenant_id in filter_dict['tenants']['tenant_id']:
+                    filtered_vms_by_tenant.append(vm)
+                else:
+                    popped_vm_list.append(vm)
+            current_data_list = filtered_vms_by_tenant
+
+        if 'instances' in filter_dict:
+            filtered_vms_by_id = []
+            for vm in current_data_list:
+                if vm.id in filter_dict['instances']['id']:
+                    filtered_vms_by_id.append(vm)
+                else:
+                    popped_vm_list.append(vm)
+            current_data_list = filtered_vms_by_id
+
+        return [current_data_list, popped_vm_list]
 
     def filter_images(self, src_data_list):
         loaded_data = self.load_file(self.filter_file_path)


### PR DESCRIPTION
Fix the `tenant_exists()` method in the `FunctionalTest` class.
Before this changes the method every time returns `False`,
because it called the wrong method of keystone client.
Because of this some tests in the `VmMigration` class were skipped.

Fix filtering process for vms according migration rules.