### PR TITLE
CF-380, 338 Post migration tests fail being unable to connect to VM.

### DIFF
--- a/cloudferry_devlab/cloudferry_devlab/generate_load.py
+++ b/cloudferry_devlab/cloudferry_devlab/generate_load.py
@@ -397,10 +397,10 @@ class Prerequisites(base.BasePrerequisites):
             return vm_ids
 
         vms = create_vms(self.config.vms)
+
         for tenant in self.config.tenants:
             if not tenant.get('vms'):
                 continue
-
             # To create vm with proper keypair, need to switch to right user
             keypairs = set([vm['key_name'] for vm in tenant['vms']
                             if vm.get('key_name')])
@@ -429,9 +429,9 @@ class Prerequisites(base.BasePrerequisites):
             self.switch_user(user=user['name'], password=user['password'],
                              tenant=tenant['name'])
             vms.extend(create_vms(vms_wo_keypairs))
+
         self.switch_user(user=self.username, password=self.password,
                          tenant=self.tenant)
-
         self.wait_until_objects_created(vms, self.check_vm_state, TIMEOUT)
 
     def create_vm_snapshots(self):

--- a/cloudferry_devlab/cloudferry_devlab/tests/config.py
+++ b/cloudferry_devlab/cloudferry_devlab/tests/config.py
@@ -210,7 +210,7 @@ tenants = [
      },
      'vms': [
          {'name': 'tn2server1', 'image': 'image1', 'flavor': 'flavorname2',
-          'fip': True, 'key_name': 'key2'},
+          'fip': True, 'key_name': 'key2', 'nics': [{'net-id': 'tenantnet2'}]},
          {'name': 'keypair_test_server', 'image': 'deleted_image',
           'flavor': 'flavorname2', 'key_name': 'key2', 'nics': [
               {'net-id': 'tenantnet2'}], 'fip': True}],


### PR DESCRIPTION
Fixed external network selection logic in test setUP method.
Fixed jenkins fails to boot VM or to attach cinder volume to VM.
Fixed issues in tests:
- {{VerifyDstCloudFunctionality.test_cinder_volume}}
- {{VerifyDstCloudFunctionality.test_create_vm}}