### PR TITLE
[CF-383] Add stage for matching objects in clouds

### DIFF
--- a/cloudferrylib/config.py
+++ b/cloudferrylib/config.py
@@ -145,7 +145,7 @@ class OpenstackCloud(bases.Hashable, bases.Representable,
         credential = fields.Nested(Credential.Schema)
         scope = fields.Nested(Scope.Schema)
         ssh_settings = fields.Nested(SshSettings.Schema, load_from='ssh')
-        discover = OneOrMore(fields.String(), default=MODEL_LIST)
+        discover = OneOrMore(fields.String(), missing=MODEL_LIST)
 
         @marshmallow.post_load
         def to_cloud(self, data):
@@ -232,7 +232,7 @@ class Configuration(bases.Hashable, bases.Representable,
         @marshmallow.validates_schema(skip_on_field_errors=True)
         def check_migration_have_correct_source_and_dict(self, data):
             clouds = data['clouds']
-            migrations = data['migrations']
+            migrations = data.get('migrations', {})
             for migration_name, migration in migrations.items():
                 if migration.source not in clouds:
                     raise marshmallow.ValidationError(

--- a/cloudferrylib/os/discovery/keystone.py
+++ b/cloudferrylib/os/discovery/keystone.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 import logging
 
-from marshmallow import fields
 from keystoneclient import exceptions
 
 from cloudferrylib.os.discovery import model
@@ -25,9 +24,9 @@ LOG = logging.getLogger(__name__)
 class Tenant(model.Model):
     class Schema(model.Schema):
         object_id = model.PrimaryKey('id')
-        name = fields.String(required=True)
-        enabled = fields.Boolean(required=True)
-        description = fields.String(allow_none=True)
+        name = model.String(required=True)
+        enabled = model.Boolean(required=True)
+        description = model.String(allow_none=True)
 
     @classmethod
     def load_missing(cls, cloud, object_id):
@@ -44,3 +43,7 @@ class Tenant(model.Model):
         with model.Session() as session:
             for tenant in identity_client.tenants.list():
                 session.store(Tenant.load_from_cloud(cloud, tenant))
+
+    def equals(self, other):
+        # pylint: disable=no-member
+        return self.name.lower() == other.name.lower()

--- a/fabfile.py
+++ b/fabfile.py
@@ -221,6 +221,16 @@ def estimate_migration(config_path, migration, debug=False):
 
 
 @task
+def link(config_path, debug=False):
+    """
+        :config_name - name of config yaml-file, example 'config.yaml'
+    """
+    cfg = config.load(load_yaml_config(config_path, debug))
+    stage.execute_stage('cloudferrylib.os.discovery.stages.LinkStage', cfg,
+                        force=True)
+
+
+@task
 def show_unused_resources(config_path, cloud, count=100, tenant=None,
                           debug=False):
     cfg = config.load(load_yaml_config(config_path, debug))

--- a/tests/cloudferrylib/test_stage.py
+++ b/tests/cloudferrylib/test_stage.py
@@ -25,14 +25,15 @@ def fqname(cls):
 
 
 class TestStage(stage.Stage):
-    def __init__(self):
+    def __init__(self, config):
+        super(TestStage, self).__init__(config)
         self.invalidated = False
 
-    def signature(self, config):
-        return config
+    def signature(self):
+        return self.config
 
-    def execute(self, config):
-        self._execute(config, self.invalidated)
+    def execute(self):
+        self._execute(self.config, self.invalidated)
 
     def invalidate(self, old_signature, new_signature, force=False):
         self._invalidate(old_signature, new_signature)

--- a/tests/cloudferrylib/utils/test_query.py
+++ b/tests/cloudferrylib/utils/test_query.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 from cloudferrylib.os.discovery import model
 from cloudferrylib.utils import query
-from marshmallow import fields
 from tests.cloudferrylib.utils import test_local_db
 import mock
 
@@ -21,8 +20,8 @@ import mock
 class TestMode(model.Model):
     class Schema(model.Schema):
         object_id = model.PrimaryKey('id')
-        field1 = fields.String()
-        field2 = fields.String()
+        field1 = model.String()
+        field2 = model.String()
 
 CLASS_FQN = TestMode.__module__ + '.' + TestMode.__name__
 


### PR DESCRIPTION
 1) Add ability to store objects of several types to Reference(many=True)
    fields.
 2) Add ``links`` attribute to base schema which will hold links to objects
    that are copies of original object.
 3) Modify Reference deserialize code to not include references to objects
    that are not exist in database. We don't want to remove any links from
    DB, but we don't want stale links to be visible to our code.
 4) Slightly refactor stages framework to store config as attribute instead
    of passing it as argument.
 5) Implement matching objects from different clouds.