### PR TITLE
[CF-397] Remove CloudFerry log Rotating

### DIFF
--- a/configs/logging_config.yaml
+++ b/configs/logging_config.yaml
@@ -46,6 +46,7 @@ handlers:
     filters: [show_current_task]
     level: INFO
   debug:
+    maxBytes: 0
     backupCount: 20
     class: cloudferrylib.utils.log.RunRotatingFileHandler
     encoding: utf-8
@@ -56,6 +57,7 @@ handlers:
     maxBytes: 100M
     filters: [show_current_task]
   info:
+    maxBytes: 0
     backupCount: 20
     class: cloudferrylib.utils.log.RunRotatingFileHandler
     encoding: utf-8


### PR DESCRIPTION
Removed CloudFerry log Rotating by setting maxBytes parametre to 0.
BackupCount parametre has been kept as originally equal to 20.
As per Loggin handlers description: "if either of maxBytes
or backupCount is zero, rollover never occurs".