### PR TITLE
CF-388 HTTP 400 Bad Request on nova boot

### DIFF
--- a/cloudferrylib/os/compute/nova_compute.py
+++ b/cloudferrylib/os/compute/nova_compute.py
@@ -649,7 +649,7 @@ class NovaCompute(compute.Compute):
                 self.identity.keystone_client,
                 conf.cloud.user,
                 conf.cloud.tenant):
-            nclient = self.get_client(conf)
+            nclient = self.proxy(self.get_client(conf), conf)
             new_id = self.create_instance(nclient, **create_params)
             try:
                 self.wait_for_status(new_id, self.get_status, 'active',


### PR DESCRIPTION
Nova boot fails with HTTP 400 Bad Request error on the server side,
which leads to failures in creating VM. The error appears randomly
and is caused by unstable Openstack environment, thus the fix would
simply retry `[migrate] retry` number of times.