### PR TITLE
[CF-4] Fix cloudferrylib references

### DIFF
--- a/cloudferry/fabfile.py
+++ b/cloudferry/fabfile.py
@@ -220,7 +220,7 @@ def link(config_path, debug=False):
         :config_name - name of config yaml-file, example 'config.yaml'
     """
     cfg = config.load(load_yaml_config(config_path, debug))
-    stage.execute_stage('cloudferrylib.os.discovery.stages.LinkStage', cfg,
+    stage.execute_stage('cloudferry.lib.os.discovery.stages.LinkStage', cfg,
                         force=True)
 
 

--- a/cloudferry/lib/os/discovery/cinder.py
+++ b/cloudferry/lib/os/discovery/cinder.py
@@ -23,7 +23,7 @@ LOG = logging.getLogger(__name__)
 
 class Attachment(model.Model):
     class Schema(model.Schema):
-        server = model.Reference('cloudferrylib.os.discovery.nova.Server')
+        server = model.Reference('cloudferry.lib.os.discovery.nova.Server')
         device = model.String(required=True)
 
 

--- a/cloudferry/lib/os/discovery/stages.py
+++ b/cloudferry/lib/os/discovery/stages.py
@@ -80,7 +80,7 @@ class DiscoverStage(stage.Stage):
 
 class LinkStage(stage.Stage):
     dependencies = [
-        'cloudferrylib.os.discovery.stages.DiscoverStage',
+        'cloudferry.lib.os.discovery.stages.DiscoverStage',
     ]
 
     def signature(self):

--- a/cloudferry/lib/stage.py
+++ b/cloudferry/lib/stage.py
@@ -33,7 +33,7 @@ class Stage(object):
     def __init__(self, config):
         """
         Stage constructor
-        :param config: cloudferrylib.config.Configuration instance
+        :param config: cloudferry.lib.config.Configuration instance
         :return:
         """
         self.config = config

--- a/tests/lib/os/actions/test_transport_instance.py
+++ b/tests/lib/os/actions/test_transport_instance.py
@@ -14,17 +14,17 @@
 
 import mock
 
-from cloudferrylib.base import exception
-from cloudferrylib.os.actions import transport_instance
-from cloudferrylib.utils import utils
+from cloudferry.lib.base import exception
+from cloudferry.lib.os.actions import transport_instance
+from cloudferry.lib.utils import utils
 
 from tests import test
 
 
 class DeployInstanceWithManualScheduling(test.TestCase):
 
-    @mock.patch("cloudferrylib.os.network.network_utils.prepare_networks")
-    @mock.patch("cloudferrylib.os.network.network_utils.associate_floatingip")
+    @mock.patch("cloudferry.lib.os.network.network_utils.prepare_networks")
+    @mock.patch("cloudferry.lib.os.network.network_utils.associate_floatingip")
     def test_tries_to_boot_vm_on_all_nodes(self,
                                            associate_floatingip,
                                            prepare_networks):
@@ -69,8 +69,8 @@ class DeployInstanceWithManualScheduling(test.TestCase):
         self.assertEqual(prepare_networks.call_count, num_computes)
         self.assertEqual(dst_compute.deploy.call_count, num_computes)
 
-    @mock.patch("cloudferrylib.os.network.network_utils.prepare_networks")
-    @mock.patch("cloudferrylib.os.network.network_utils.associate_floatingip")
+    @mock.patch("cloudferry.lib.os.network.network_utils.prepare_networks")
+    @mock.patch("cloudferry.lib.os.network.network_utils.associate_floatingip")
     def test_runs_only_one_boot_if_node_is_good(self,
                                                 associate_floatingip,
                                                 prepare_networks):


### PR DESCRIPTION
Move test_transport_instances module to the correct folder.
Rename all cloudferrylib references to cloudferry.lib.