### PR TITLE
[CF-433] Handle image deleted from glance backend.

### DIFF
--- a/cloudferry/lib/os/discovery/nova.py
+++ b/cloudferry/lib/os/discovery/nova.py
@@ -18,6 +18,7 @@ from cloudferry.lib.os.discovery import cinder
 from cloudferry.lib.os.discovery import glance
 from cloudferry.lib.os.discovery import keystone
 from cloudferry.lib.os.discovery import model
+from cloudferry.lib.utils import qemu_img
 from cloudferry.lib.utils import remote
 from cloudferry.lib.os import clients
 
@@ -51,6 +52,10 @@ class EphemeralDisk(model.Model):
     class Schema(model.Schema):
         path = model.String(required=True)
         size = model.Integer(required=True)
+        format = model.String(required=True)
+        base_path = model.String(required=True)
+        base_size = model.Integer(required=True)
+        base_format = model.String(required=True)
 
 
 @model.type_alias('vms')
@@ -190,16 +195,23 @@ def _list_ephemeral(remote_executor, server):
         target, path = split
         if target in volume_targets or not path.startswith('/'):
             continue
-        try:
-            size_str = remote_executor.sudo('stat -c %s {path}', path=path)
-        except remote.RemoteFailure:
-            LOG.error('Unable to get size of ephemeral disk "%s" for server '
-                      '%s, skipping disk.', path, server.object_id,
-                      exc_info=True)
-            continue
-        size = int(size_str.strip())
-        eph_disk = EphemeralDisk.load({'path': path, 'size': size})
-        result.append(eph_disk)
+
+        size, base_path, format = _get_disk_info(remote_executor, path)
+        if base_path is not None:
+            base_size, _, base_format = _get_disk_info(
+                remote_executor, base_path)
+        else:
+            base_size = base_format = None
+        if size is not None:
+            eph_disk = EphemeralDisk.load({
+                'path': path,
+                'size': size,
+                'format': format,
+                'base_path': base_path,
+                'base_size': base_size,
+                'base_format': base_format,
+            })
+            result.append(eph_disk)
     return result
 
 
@@ -207,3 +219,14 @@ def list_available_compute_hosts(compute_client):
     return set(c.host
                for c in compute_client.services.list(binary='nova-compute')
                if c.state == 'up' and c.status == 'enabled')
+
+
+def _get_disk_info(remote_executor, path):
+    try:
+        size_str = remote_executor.sudo('stat -c %s {path}', path=path)
+    except remote.RemoteFailure:
+        LOG.error('Unable to get size of "%s", skipping disk.', path,
+                  exc_info=True)
+        return None, None, None
+    disk_info = qemu_img.get_disk_info(remote_executor, path)
+    return int(size_str.strip()), disk_info.backing_filename, disk_info.format

--- a/cloudferry/lib/utils/local_db.py
+++ b/cloudferry/lib/utils/local_db.py
@@ -79,7 +79,8 @@ class Transaction(object):
             self._tls.top_level = self
             self._conn = sqlite3.connect(
                 SQLITE3_DATABASE_FILE,
-                detect_types=sqlite3.PARSE_DECLTYPES | sqlite3.PARSE_COLNAMES)
+                detect_types=sqlite3.PARSE_DECLTYPES | sqlite3.PARSE_COLNAMES,
+                timeout=3600)
             self._conn.row_factory = _Row
             self._conn.isolation_level = None
             execute_saved_statements(self._conn)


### PR DESCRIPTION
Glance use some sort of backend for storing images. It can be
Swift/Ceph/filesystem. Image file can be deleted from this backend
through SSH for filesystem backend, or through Swift API for Swift
backend or through Librados for Ceph backend. Glance will not that
image was deleted and will consider the image as active, but will
raise 404 error when you will try to download image file.
This patch handle such situation, falling back to restoring image
from compute nodes.
