### PR TITLE
[CF-362,456] Extend functional tests to include verification of blacklisted images

### DIFF
--- a/cloudferry_devlab/cloudferry_devlab/tests/base.py
+++ b/cloudferry_devlab/cloudferry_devlab/tests/base.py
@@ -25,6 +25,8 @@ from neutronclient.v2_0 import client as neutron
 from novaclient import exceptions as nova_exceptions
 from novaclient.v2 import client as nova
 from swiftclient import client as swift_client
+from nose.config import Config, all_config_files
+from nose.plugins.manager import DefaultPluginManager
 
 from cloudferry_devlab.tests import test_exceptions
 import cloudferry_devlab.tests.utils as utils
@@ -454,6 +456,20 @@ class BasePrerequisites(object):
                 logger.warning('There was some problems during state change:\n'
                                '%s' % e)
         return vm_id, vm_state
+
+
+def get_nosetest_cmd_attribute_val(attribute):
+    env = os.environ
+    manager = DefaultPluginManager()
+    cfg_files = all_config_files()
+    tmp_config = Config(env=env, files=cfg_files, plugins=manager)
+    tmp_config.configure()
+    try:
+        attr_list = getattr(tmp_config.options, 'attr')
+        value = dict(token.split('=') for token in attr_list)
+        return value[attribute]
+    except TypeError:
+        return None
 
 
 def get_dict_from_config_file(config_file):

--- a/cloudferry_devlab/cloudferry_devlab/tests/config.py
+++ b/cloudferry_devlab/cloudferry_devlab/tests/config.py
@@ -60,6 +60,9 @@ logging_configuration = {
 filters_file_naming_template = 'filter_{tenant_name}.yaml'
 """Naming template for filter files."""
 
+all_tenants_filter_filename = 'all_tenants_filter.yaml'
+"""All tenants filter file."""
+
 ext_net_map = 'ext_net_map.yaml'
 """This file contains map of relationships between external networks on source
 and destination clouds."""
@@ -86,6 +89,8 @@ users = [
      'tenant': 'tenant3', 'enabled': True},
     {'name': 'user9', 'password': 'passwd', 'email': 'user8@example.com',
      'tenant': 'tenant5', 'enabled': True},
+    {'name': 'user11', 'password': 'passwd', 'email': 'user11@example.com',
+     'tenant': 'tenant7', 'enabled': True}
 ]
 """Users to create/delete"""
 
@@ -371,6 +376,11 @@ tenants = [
          ],
      'images': [{'name': 'cirros_image_for_tenant5', 'copy_from': img_url,
                  'is_public': True}],
+     },
+    {'name': 'tenant7', 'description': 'Tenant7 filter has excluded images',
+     'enabled': True, 'exclude_images': True,
+     'images': [{'name': 'image7', 'copy_from': img_url, 'is_public': False},
+                {'name': 'image8', 'copy_from': img_url, 'is_public': False}]
      }
 ]
 """Tenants to create/delete"""
@@ -428,7 +438,10 @@ create_zero_image = True
 """Create zero image, without any parameters"""
 
 images_not_included_in_filter = ['image5']
-"""Images not to be migrated"""
+"""Images not to be included in filter"""
+
+images_blacklisted = ['image7']
+"""Images blacklisted"""
 
 vms_not_in_filter = ['not_in_filter']
 """Instances not to be included in filter"""

--- a/cloudferry_devlab/cloudferry_devlab/tests/functional_test.py
+++ b/cloudferry_devlab/cloudferry_devlab/tests/functional_test.py
@@ -23,6 +23,7 @@ import cloudferry_devlab.tests.config as config
 from cloudferry_devlab import generate_load
 from cloudferry_devlab.tests import test_exceptions
 import cloudferry_devlab.tests.utils as utils
+from cloudferry_devlab.tests import base
 
 
 def suppress_dependency_logging():
@@ -61,9 +62,11 @@ class FunctionalTest(unittest.TestCase):
         self.migration_utils = utils.MigrationUtils(config)
         self.config_ini_path = config_ini['general']['configuration_ini_path']
         self.cloudferry_dir = config_ini['general']['cloudferry_dir']
+        tenant = base.get_nosetest_cmd_attribute_val('migrated_tenant')
         filter_path = config_ini['general'].get(
             'filter_path',
-            get_option_from_config_ini('filter_path'))
+            get_option_from_config_ini('filter_path')) if tenant \
+            else config.all_tenants_filter_filename
         self.filtering_utils = utils.FilteringUtils(
             os.path.join(self.cloudferry_dir, filter_path))
 

--- a/cloudferry_devlab/cloudferry_devlab/tests/images.py
+++ b/cloudferry_devlab/cloudferry_devlab/tests/images.py
@@ -1,0 +1,49 @@
+# Copyright 2015 Mirantis Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from cloudferry_devlab.tests import test_exceptions
+
+
+class Blacklisted(object):
+
+    def __init__(self, config, glanceclient):
+        self.config = config
+        self.glanceclient = glanceclient
+
+    def get_blacklisted_img_ids(self):
+        """Get Blacklisted Image IDs."""
+
+        blacklisted_img_ids = []
+        try:
+            blacklisted_img_ids = [self._get_image_id(img)
+                                   for img in self.config.images_blacklisted]
+        except test_exceptions.NotFound:
+            pass
+        return blacklisted_img_ids
+
+    def _get_image_id(self, image_name):
+        for image in self.glanceclient.images.list():
+            if image.name == image_name:
+                return image.id
+        raise test_exceptions.NotFound('Image with name "%s" was not found'
+                                       % image_name)
+
+    def filter_images(self):
+        img_list = [x.__dict__['id'] for x in
+                    self.glanceclient.images.list(search_opts={
+                        'is_public': False})]
+        exclude_img_ids = self.get_blacklisted_img_ids()
+        included_img_ids = [img for img in img_list
+                            if img not in exclude_img_ids]
+        return included_img_ids


### PR DESCRIPTION
1) Below scenario added to functional tests (CF-362)

- Create image
- Add image to filter file as black listed
- Run image migration
- Make sure all images except for black-listed migrated successfully

2) Fixed the issue that last set of Functional Tests referring filter file of last migrated tenant for resource validation (CF-456)