### PR TITLE
CF-451 Fix image migration functional tests to work with migrate2

### DIFF
--- a/cloudferry_devlab/cloudferry_devlab/tests/functional_test.py
+++ b/cloudferry_devlab/cloudferry_devlab/tests/functional_test.py
@@ -208,7 +208,7 @@ class FunctionalTest(unittest.TestCase):
         all_images = self.migration_utils.get_all_images_from_config()
         filtered_images = _image_exclude_filter(all_images)
 
-        image_list = self.src_cloud.glanceclient.images.list(is_public=None)
+        image_list = self.src_cloud.glanceclient.images.list(is_public=False)
         return [i for i in image_list if i.name in filtered_images]
 
     def filter_volumes(self):

--- a/cloudferry_devlab/cloudferry_devlab/tests/testcases/test_glance_image_migration.py
+++ b/cloudferry_devlab/cloudferry_devlab/tests/testcases/test_glance_image_migration.py
@@ -67,6 +67,7 @@ class GlanceMigrationTests(functional_test.FunctionalTest):
                       % missed_members)
 
     @attr(migrated_tenant=['admin', 'tenant1', 'tenant2'])
+    @attr(migration_engine=['migrate2'])
     @generate('name', 'disk_format', 'container_format', 'size', 'checksum',
               'status', 'deleted', 'min_disk', 'protected', 'min_ram',
               'is_public', 'virtual_size', 'id')
@@ -94,6 +95,7 @@ class GlanceMigrationTests(functional_test.FunctionalTest):
                                                 parameter=param)
 
     @attr(migrated_tenant=['admin', 'tenant1', 'tenant2'])
+    @attr(migration_engine=['migrate2'])
     def test_migrate_deleted_glance_images_only_once(self):
         """Validate deleted and broken images were migrated to dst only once.
 
@@ -168,6 +170,7 @@ class GlanceMigrationTests(functional_test.FunctionalTest):
             self.fail(msg)
 
     @attr(migrated_tenant=['admin', 'tenant1', 'tenant2'])
+    @attr(migration_engine=['migrate2'])
     def test_glance_images_not_in_filter_did_not_migrate(self):
         """Validate images not in filter weren't migrated."""
         migrated_images_not_in_filter = [image for image in
@@ -179,6 +182,7 @@ class GlanceMigrationTests(functional_test.FunctionalTest):
                       'in filter, Images info: \n{}'.format(
                         migrated_images_not_in_filter))
 
+    @attr(migration_engine=['migrate2'])
     def test_glance_image_deleted_and_migrated_second_time_with_new_id(self):
         """Validate deleted images were migrated second time with new id."""
         src_images = []


### PR DESCRIPTION
Added migrate2 tag to tests.
Fixed image list requesting without public ones.
Fixed missed description for a test.