### PR TITLE
CF-459 Verify subnet's DHCP option is preserved during migration

### DIFF
--- a/cloudferry_devlab/cloudferry_devlab/generate_load.py
+++ b/cloudferry_devlab/cloudferry_devlab/generate_load.py
@@ -448,7 +448,8 @@ class Prerequisites(base.BasePrerequisites):
         def get_body_for_subnet_creating(_subnet):
             # Possible parameters for subnet creating
             params = ['name', 'cidr', 'allocation_pools', 'dns_nameservers',
-                      'host_routes', 'ip_version', 'network_id', 'tenant_id']
+                      'host_routes', 'ip_version', 'network_id', 'tenant_id',
+                      'enable_dhcp']
             return {param: _subnet[param] for param in params
                     if param in _subnet}
 

--- a/cloudferry_devlab/cloudferry_devlab/tests/config.py
+++ b/cloudferry_devlab/cloudferry_devlab/tests/config.py
@@ -135,7 +135,7 @@ tenants = [
          {'name': 'tenant1_net2', 'admin_state_up': True,
           'subnets': [
               {'cidr': '10.6.2.0/24', 'ip_version': 4, 'name': 't1_s2',
-               'routers_to_connect': ['tn2_router']}]
+               'enable_dhcp': False, 'routers_to_connect': ['tn2_router']}]
           }
      ],
      'routers': [
@@ -336,7 +336,8 @@ tenants = [
           'provider:network_type': 'gre',
           'subnets': [
               {'cidr': '40.40.40.0/24', 'ip_version': 4,
-               'name': 'segm_id_test_subnet_2', 'connect_to_ext_router': False,
+               'name': 'segm_id_test_subnet_2', 'enable_dhcp': False,
+               'connect_to_ext_router': False,
                }
               ]
           }],

--- a/cloudferry_devlab/cloudferry_devlab/tests/testcases/test_resource_migration.py
+++ b/cloudferry_devlab/cloudferry_devlab/tests/testcases/test_resource_migration.py
@@ -439,7 +439,8 @@ class ResourceMigrationTests(functional_test.FunctionalTest):
         src_subnets = self.filter_subnets()
         dst_subnets = self.dst_cloud.neutronclient.list_subnets()
 
-        for param in ['name', 'gateway_ip', 'cidr', 'dns_nameservers']:
+        for param in ['name', 'gateway_ip', 'cidr', 'dns_nameservers',
+                      'enable_dhcp']:
             self.validate_neutron_resource_parameter_in_dst(
                 src_subnets, dst_subnets, resource_name='subnets',
                 parameter=param)


### PR DESCRIPTION
Added dhcp_enable parameter to admin's and non-admin's subnets.
Added dhcp_enable parameter validation.