### PR TITLE
[CF-401] Fix reset_state not makeing several attempts

### DIFF
--- a/cloudferry/lib/os/compute/nova_compute.py
+++ b/cloudferry/lib/os/compute/nova_compute.py
@@ -1060,7 +1060,7 @@ class NovaCompute(compute.Compute):
         self.mysql_connector.execute(sql)
 
     def reset_state(self, vm_id):
-        self.get_instance(vm_id).reset_state()
+        self.nova_client.servers.reset_state(vm_id)
 
 
 def host_available(compute_host):


### PR DESCRIPTION
NovaCompute.reset_state don't make additional attempts on recieving
unexpected errors (like HTTP 503) which results in failure to clean
up VMs which errored or timed out in the end of migration. This
patch fixes that.