### PR TITLE
[CF-450] Refactor discovery/model.py

### DIFF
--- a/cloudferry/cli/base.py
+++ b/cloudferry/cli/base.py
@@ -15,7 +15,7 @@
 import yaml
 
 from cloudferry import cfglib
-from cloudferry.lib import config
+from cloudferry import config
 from cloudferry.lib.utils import log
 
 

--- a/cloudferry/discover.py
+++ b/cloudferry/discover.py
@@ -1,0 +1,192 @@
+# Copyright 2016 Mirantis Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import abc
+import logging
+
+from cloudferry import model
+from cloudferry.lib.utils import utils
+
+LOG = logging.getLogger(__name__)
+
+
+class NotFound(Exception):
+    pass
+
+
+class DiscovererNotFound(Exception):
+    """
+    Exception that should be raised to abort migration of single resource.
+    """
+
+    def __init__(self, discoverer_class, *args):
+        super(DiscovererNotFound, self).__init__(
+            'Discoverer for % not found.',
+            utils.qualname(discoverer_class), *args)
+
+    def __str__(self):
+        try:
+            return self.args[0] % self.args[1:]
+        except Exception:  # pylint: disable=broad-except
+            return '{} % {}'.format(repr(self.args[0]), repr(self.args[1:]))
+
+
+class Discoverer(object):
+    __metaclass__ = abc.ABCMeta
+    discovered_class = None
+
+    def __init__(self, config, cloud):
+        self.config = config
+        self.cloud = cloud
+
+    @abc.abstractmethod
+    def discover_all(self):
+        """
+        Method should get list of all objects in the cloud, convert them to
+        ``model.Model`` instances using ``load`` classmethod and store them to
+        database.
+        """
+        return
+
+    @abc.abstractmethod
+    def discover_one(self, uuid):
+        """
+        Method should retrieve object from the cloud using it's unique
+        identifier ``uuid``, convert it to ``model.Model`` instances using
+        ``load`` classmethod and return it.
+        """
+        return
+
+    @abc.abstractmethod
+    def load_from_cloud(self, data):
+        """
+        Method should convert data retrieved using OpenStack client to
+        ``model.Model`` instances using ``load`` classmethod and return it.
+        """
+        return
+
+    def find_obj(self, model_class, uuid):
+        """
+        Find instance of ``model_class`` in local database or through single
+        object discovery (if absent in local database).
+        :param model_class: model class object
+        :param uuid: object identifier
+        :return: model class instance
+        """
+        model_qualname = utils.qualname(model_class)
+        LOG.debug('Trying to find %s with ID %s in cloud %s',
+                  model_qualname, uuid, self.cloud.name)
+        if uuid is None:
+            return None
+        object_id = model.ObjectId(uuid, self.cloud.name)
+        try:
+            with model.Session() as session:
+                if session.is_missing(model_class, object_id):
+                    LOG.debug('Object %s with ID %s is stored as missing',
+                              model_qualname, object_id)
+                    return None
+                return session.retrieve(model_class, object_id)
+        except model.NotFound:
+            LOG.debug('Object %s with ID %s not found in local database',
+                      model_qualname, object_id)
+
+        try:
+            discoverer_class = self.cloud.discoverers.get(model_class)
+            if discoverer_class is None:
+                LOG.warning('Can\'t find discoverer class for %s',
+                            model_qualname)
+                raise DiscovererNotFound(model_class)
+            LOG.debug('Trying to discover %s with ID %s using %s',
+                      model_qualname, object_id,
+                      utils.qualname(discoverer_class))
+            discoverer = discoverer_class(self.config, self.cloud)
+            with model.Session() as session:
+                obj = discoverer.discover_one(uuid)
+                session.store(obj)
+                return obj
+        except NotFound:
+            LOG.warning('Object %s with uuid %s not found in cloud %s',
+                        model_class.get_class_qualname(), uuid,
+                        self.cloud.name)
+            with model.Session() as session:
+                session.store_missing(
+                    model_class, model.ObjectId(uuid, self.cloud.name))
+        except model.ValidationError as e:
+            LOG.warning('Invalid %s with uuid %s in cloud %s: %s',
+                        model_class.get_class_qualname(), uuid,
+                        self.cloud.name, e)
+        return None
+
+    def find_ref(self, model_class, uuid):
+        """
+        Find instance of ``model_class`` in local database or through single
+        object discovery (if absent in local database) and return serialized
+        form of reference.
+        :param model_class: model class object
+        :param uuid: object identifier
+        :return: dictionary
+        """
+        obj = self.find_obj(model_class, uuid)
+        if obj is None:
+            return None
+        else:
+            return obj.primary_key.to_dict(obj.get_class())
+
+    def make_id(self, uuid):
+        """
+        Returns serialized form of identifier for objects that are discovered
+        by discoverer.
+        :param uuid: object unique identifier
+        :return: dictionary
+        """
+        return self.make_ref(self.discovered_class, uuid)
+
+    def make_ref(self, model_class, uuid):
+        """
+        Returns serialized form of identifier for objects that are referenced
+        by discovered objects.
+        :param model_class: referenced object class
+        :param uuid: object unique identifier
+        :return: dictionary
+        """
+        return {
+            'id': uuid,
+            'cloud': self.cloud.name,
+            'type': model_class.get_class_qualname(),
+        }
+
+
+def discover_all(cfg, cloud):
+    """
+    Discovers all objects using discoverers specified for the cloud.
+    :param cfg: config.Configuration instance
+    :param cloud: config.Cloud instance
+    """
+    for discoverer_class in cloud.discoverers.values():
+        LOG.debug('Starting discovering %s using %s',
+                  utils.qualname(discoverer_class.discovered_class),
+                  utils.qualname(discoverer_class))
+        discoverer = discoverer_class(cfg, cloud)
+        discoverer.discover_all()
+        LOG.debug('Finished discovering %s using %s',
+                  utils.qualname(discoverer_class.discovered_class),
+                  utils.qualname(discoverer_class))
+
+
+def load_from_cloud(cfg, cloud, model_class, data):
+    discoverer_class = cloud.discoverers.get(model_class)
+    if discoverer_class is None:
+        LOG.error('Can\'t find discoverer for %s', utils.qualname(model_class))
+        raise DiscovererNotFound(model_class)
+    discoverer = discoverer_class(cfg, cloud)
+    return discoverer.load_from_cloud(data)

--- a/cloudferry/lib/os/estimation/procedures.py
+++ b/cloudferry/lib/os/estimation/procedures.py
@@ -16,9 +16,9 @@ import collections
 import heapq
 import logging
 
-from cloudferry.lib.os.discovery import model
 from cloudferry.lib.utils import query
 from cloudferry.lib.utils import sizeof_format
+from cloudferry import model
 
 LOG = logging.getLogger(__name__)
 G = sizeof_format.size_multiplier('G')
@@ -27,14 +27,15 @@ G = sizeof_format.size_multiplier('G')
 class ProcedureBase(object):
     def __init__(self, cfg, migration_name):
         self.migration = cfg.migrations[migration_name]
-        self.src = self.migration.source
-        self.dst = self.migration.destination
+        self.src_cloud = cfg.clouds[self.migration.source]
+        self.dst_cloud = cfg.clouds[self.migration.destination]
 
     def get_objects(self, model_name, exclude_objects=None):
         klass = model.get_model(model_name)
         with model.Session() as session:
-            for obj in self.migration.query.search(session, self.src, klass):
-                if (obj.find_link(self.dst) or
+            for obj in self.migration.query.search(session, self.src_cloud,
+                                                   klass):
+                if (obj.find_link(self.dst_cloud) or
                         (exclude_objects is not None and
                          obj.object_id in exclude_objects)):
                     continue

--- a/cloudferry/lib/os/migrate/base.py
+++ b/cloudferry/lib/os/migrate/base.py
@@ -19,7 +19,8 @@ from taskflow import retry
 from taskflow import task
 from taskflow.patterns import linear_flow
 
-from cloudferry.lib.os.discovery import model
+from cloudferry import discover
+from cloudferry import model
 from cloudferry.lib.utils import taskflow_utils
 from cloudferry.lib.utils import utils
 
@@ -139,6 +140,16 @@ class MigrationTask(task.Task):
             return obj_dict
         return model_cls.load(obj_dict['object'])
 
+    def load_from_cloud(self, model_class, cloud, data):
+        """
+        Returns new model instance based on data from cloud.
+        :param model_class: model.Model derived class
+        :param cloud: config.Cloud instance
+        :param data: data from OpenStack client
+        :return: model_class instance
+        """
+        return discover.load_from_cloud(self.config, cloud, model_class, data)
+
 
 class RememberMigration(MigrationTask):
     """
@@ -165,7 +176,7 @@ def create_migration_flow(obj, config, migration):
     :return: migration flow for an object
     """
 
-    if obj.find_link(migration.destination) is not None:
+    if obj.find_link(config.clouds[migration.destination]) is not None:
         return None
     cls = obj.get_class()
     flow_factories = migration.migration_flow_factories

--- a/cloudferry/lib/utils/query.py
+++ b/cloudferry/lib/utils/query.py
@@ -14,7 +14,7 @@
 import jmespath
 import jmespath.exceptions
 
-from cloudferry.lib.os.discovery import model
+from cloudferry import model
 
 
 class DictSubQuery(object):

--- a/cloudferry/lib/utils/taskflow_utils.py
+++ b/cloudferry/lib/utils/taskflow_utils.py
@@ -81,7 +81,10 @@ def execute_flow(flow):
         engine.run()
     except exceptions.WrappedFailure as wf:
         for failure in wf:
-            traceback.print_exception(*failure.exc_info)
+            if failure.exc_info is not None:
+                traceback.print_exception(*failure.exc_info)
+            else:
+                print failure
 
 
 def create_graph_flow(name, objs, subflow_factory_fn, *args, **kwargs):

--- a/cloudferry/model/compute.py
+++ b/cloudferry/model/compute.py
@@ -1,0 +1,83 @@
+# Copyright 2016 Mirantis Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from cloudferry import model
+from cloudferry.model import identity
+from cloudferry.model import image as image_model
+from cloudferry.model import storage
+
+
+@model.type_alias('flavors')
+class Flavor(model.Model):
+    object_id = model.PrimaryKey()
+
+    def equals(self, other):
+        # pylint: disable=no-member
+        # TODO: replace with implementation that make sense
+        if super(Flavor, self).equals(other):
+            return True
+        return self.object_id.id == other.object_id.id
+
+
+class SecurityGroup(model.Model):
+    name = model.String(required=True)
+
+
+class EphemeralDisk(model.Model):
+    path = model.String(required=True)
+    size = model.Integer(required=True)
+    format = model.String(required=True)
+    base_path = model.String(required=True, allow_none=True)
+    base_size = model.Integer(required=True, allow_none=True)
+    base_format = model.String(required=True, allow_none=True)
+
+
+@model.type_alias('vms')
+class Server(model.Model):
+    object_id = model.PrimaryKey()
+    name = model.String(required=True)
+    security_groups = model.Nested(SecurityGroup, many=True, missing=list)
+    status = model.String(required=True)
+    tenant = model.Dependency(identity.Tenant)
+    image = model.Dependency(image_model.Image, allow_none=True)
+    image_membership = model.Dependency(image_model.ImageMember,
+                                        allow_none=True)
+    user_id = model.String(required=True)  # TODO: user reference
+    key_name = model.String(required=True, allow_none=True)
+    flavor = model.Dependency(Flavor)
+    config_drive = model.String(required=True)
+    availability_zone = model.String(required=True, allow_none=True)
+    host = model.String(required=True)
+    hypervisor_hostname = model.String(required=True)
+    instance_name = model.String(required=True)
+    metadata = model.Dict(missing=dict)
+    ephemeral_disks = model.Nested(EphemeralDisk, many=True, missing=list)
+    attached_volumes = model.Dependency(storage.Attachment, many=True,
+                                        missing=list)
+    # TODO: ports
+
+    def equals(self, other):
+        # pylint: disable=no-member
+        if super(Server, self).equals(other):
+            return True
+        # TODO: consider comparing metadata
+        # TODO: consider comparing security_groups
+        if not self.tenant.equals(other.tenant):
+            return False
+        if not self.flavor.equals(other.flavor):
+            return False
+        if not self.image.equals(other.image):
+            return False
+        if self.key_name != other.key_name or self.name != other.name:
+            return False
+        return True

--- a/cloudferry/model/identity.py
+++ b/cloudferry/model/identity.py
@@ -1,0 +1,28 @@
+# Copyright 2016 Mirantis Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from cloudferry import model
+
+
+@model.type_alias('tenants')
+class Tenant(model.Model):
+    object_id = model.PrimaryKey()
+    name = model.String(required=True)
+    enabled = model.Boolean(required=True)
+    description = model.String(allow_none=True)
+
+    def equals(self, other):
+        # pylint: disable=no-member
+        if super(Tenant, self).equals(other):
+            return True
+        return self.name.lower() == other.name.lower()

--- a/cloudferry/model/image.py
+++ b/cloudferry/model/image.py
@@ -1,0 +1,67 @@
+# Copyright 2016 Mirantis Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from cloudferry import model
+from cloudferry.model import identity
+
+
+@model.type_alias('image_members')
+class ImageMember(model.Model):
+    object_id = model.PrimaryKey()
+    image = model.Dependency('cloudferry.model.image.Image')
+    member = model.Dependency('cloudferry.model.identity.Tenant')
+    can_share = model.Boolean(missing=False)
+
+    @staticmethod
+    def make_uuid(image, tenant):
+        return '{0}:{1}'.format(image.object_id.id, tenant.object_id.id)
+
+    def equals(self, other):
+        # pylint: disable=no-member
+        if super(ImageMember, self).equals(other):
+            return True
+        return self.image.equals(other.image) and \
+            self.member.equals(other.member) and \
+            self.can_share == other.can_share
+
+
+@model.type_alias('images')
+class Image(model.Model):
+    object_id = model.PrimaryKey()
+    name = model.String(allow_none=True)
+    tenant = model.Dependency(identity.Tenant)
+    checksum = model.String(allow_none=True)
+    size = model.Integer()
+    virtual_size = model.Integer(allow_none=True, missing=None)
+    is_public = model.Boolean()
+    protected = model.Boolean()
+    container_format = model.String(missing='qcow2')
+    disk_format = model.String(missing='bare')
+    min_disk = model.Integer(required=True)
+    min_ram = model.Integer(required=True)
+    properties = model.Dict()
+    members = model.Reference(ImageMember, many=True, missing=list)
+    status = model.String()
+
+    def equals(self, other):
+        # pylint: disable=no-member
+        if super(Image, self).equals(other):
+            return True
+        # TODO: consider comparing properties
+        return self.tenant.equals(other.tenant) and \
+            self.name == other.name and \
+            self.checksum == other.checksum and \
+            self.size == other.size and \
+            self.is_public == other.is_public and \
+            self.container_format == other.container_format and \
+            self.disk_format == other.disk_format

--- a/cloudferry/model/storage.py
+++ b/cloudferry/model/storage.py
@@ -1,0 +1,46 @@
+# Copyright 2016 Mirantis Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from cloudferry import model
+from cloudferry.model import identity
+
+
+@model.type_alias('volume_attachments')
+class Attachment(model.Model):
+    object_id = model.PrimaryKey()
+    server = model.Reference('cloudferry.model.compute.Server',
+                             ensure_existence=False)
+    volume = model.Dependency('cloudferry.model.storage.Volume')
+    device = model.String(required=True)
+
+    def equals(self, other):
+        # pylint: disable=no-member
+        if super(Attachment, self).equals(other):
+            return True
+        if self.server is None:
+            return False
+        return self.server.equals(other.server) and self.device == other.device
+
+
+@model.type_alias('volumes')
+class Volume(model.Model):
+    object_id = model.PrimaryKey()
+    name = model.String(required=True, allow_none=True)
+    description = model.String(required=True, allow_none=True)
+    availability_zone = model.String(required=True)
+    encrypted = model.Boolean(missing=False)
+    host = model.String(required=True)
+    size = model.Integer(required=True)
+    tenant = model.Dependency(identity.Tenant, required=True)
+    metadata = model.Dict(missing=dict)
+    volume_type = model.String(required=True)

--- a/tests/lib/utils/test_query.py
+++ b/tests/lib/utils/test_query.py
@@ -13,44 +13,51 @@
 # limitations under the License.
 import mock
 
-from cloudferry.lib.os.discovery import model
+from cloudferry import model
 from cloudferry.lib.utils import query
 from tests.lib.utils import test_local_db
 
 
 class TestMode(model.Model):
-    class Schema(model.Schema):
-        object_id = model.PrimaryKey('id')
-        field1 = model.String()
-        field2 = model.String()
+    object_id = model.PrimaryKey()
+    field1 = model.String()
+    field2 = model.String()
 
 CLASS_FQN = TestMode.__module__ + '.' + TestMode.__name__
 
 
 class StageTestCase(test_local_db.DatabaseMockingTestCase):
+    @staticmethod
+    def _make_id(model_class, uuid, cloud='test_cloud'):
+        return {
+            'id': uuid,
+            'cloud': cloud,
+            'type': model_class.get_class_qualname(),
+        }
+
     def setUp(self):
         super(StageTestCase, self).setUp()
 
         self.cloud = mock.MagicMock()
         self.cloud.name = 'test_cloud'
 
-        self.obj1 = TestMode.load_from_cloud(self.cloud, {
-            'id': 'id1',
+        self.obj1 = TestMode.load({
+            'object_id': self._make_id(TestMode, 'id1'),
             'field1': 'a',
             'field2': 'a',
         })
-        self.obj2 = TestMode.load_from_cloud(self.cloud, {
-            'id': 'id2',
+        self.obj2 = TestMode.load({
+            'object_id': self._make_id(TestMode, 'id2'),
             'field1': 'a',
             'field2': 'b',
         })
-        self.obj3 = TestMode.load_from_cloud(self.cloud, {
-            'id': 'id3',
+        self.obj3 = TestMode.load({
+            'object_id': self._make_id(TestMode, 'id3'),
             'field1': 'b',
             'field2': 'a',
         })
-        self.obj4 = TestMode.load_from_cloud(self.cloud, {
-            'id': 'id4',
+        self.obj4 = TestMode.load({
+            'object_id': self._make_id(TestMode, 'id4'),
             'field1': 'b',
             'field2': 'b',
         })

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -14,123 +14,92 @@
 import mock
 import uuid
 
-from cloudferry.lib.os.discovery import model
+from cloudferry import model
 from tests.lib.utils import test_local_db
 
 
 class ExampleReferenced(model.Model):
-    class Schema(model.Schema):
-        object_id = model.PrimaryKey()
-        qux = model.Integer(required=True)
+    object_id = model.PrimaryKey()
+    qux = model.Integer(required=True)
 
     @classmethod
-    def load_missing(cls, cloud, object_id):
-        result = ExampleReferenced.load({
-            'object_id': {
-                'cloud': object_id.cloud,
-                'id': object_id.id,
-                'type': 'tests.lib.os.discovery.test_model.'
-                        'ExampleReferenced',
-            },
-            'qux': 1337,
-        })
-        result.mark_dirty()
-        return result
+    def create_object(cls, cloud, cloud_obj_id):
+        with model.Session() as session:
+            session.store(ExampleReferenced.load({
+                'object_id': {
+                    'cloud': cloud,
+                    'id': cloud_obj_id,
+                    'type': cls.get_class_qualname(),
+                },
+                'qux': 1337,
+            }))
 
 
 class ExampleNested(model.Model):
-    class Schema(model.Schema):
-        foo = model.String(required=True)
-        ref = model.Dependency(ExampleReferenced, required=True)
-        refs = model.Dependency(ExampleReferenced, required=True, many=True)
-        ref_none = model.Dependency(ExampleReferenced, missing=None,
-                                    allow_none=True)
-        refs_none = model.Dependency(ExampleReferenced, missing=None,
-                                     many=True, allow_none=True)
+    foo = model.String(required=True)
+    ref = model.Dependency(ExampleReferenced, required=True)
+    refs = model.Dependency(ExampleReferenced, required=True, many=True)
+    ref_none = model.Dependency(ExampleReferenced, missing=None,
+                                allow_none=True)
+    refs_none = model.Dependency(ExampleReferenced, missing=None,
+                                 many=True, allow_none=True)
 
 
 class Simple(model.Model):
-    class Schema(model.Schema):
-        foo = model.String(required=True)
+    foo = model.String(required=True)
 
 
 class Example(model.Model):
-    class Schema(model.Schema):
-        object_id = model.PrimaryKey()
-        bar = model.String(required=True)
-        baz = model.Nested(ExampleNested)
-        ref = model.Dependency(ExampleReferenced, required=True)
-        refs = model.Dependency(ExampleReferenced, required=True, many=True)
-        ref_none = model.Dependency(ExampleReferenced, missing=None,
-                                    allow_none=True)
-        refs_none = model.Dependency(ExampleReferenced, missing=None,
-                                     many=True, allow_none=True)
+    object_id = model.PrimaryKey()
+    bar = model.String(required=True)
+    baz = model.Nested(ExampleNested)
+    ref = model.Dependency(ExampleReferenced, required=True)
+    refs = model.Dependency(ExampleReferenced, required=True, many=True)
+    ref_none = model.Dependency(ExampleReferenced, missing=None,
+                                allow_none=True)
+    refs_none = model.Dependency(ExampleReferenced, missing=None,
+                                 many=True, allow_none=True)
 
     count = 0
 
     @classmethod
-    def load_missing(cls, cloud, object_id):
-        return Example.load_from_cloud(cloud, cls.generate_cloud_data())
-
-    @classmethod
-    def generate_cloud_data(cls, object_id=None):
+    def generate_data(cls, object_id=None, cloud='test_cloud'):
         cls.count += 1
         if object_id is None:
             object_id = uuid.uuid5(uuid.NAMESPACE_DNS, 'test%d' % cls.count)
         ref1 = uuid.uuid5(uuid.NAMESPACE_DNS, 'ref1_%d' % cls.count)
         ref2 = uuid.uuid5(uuid.NAMESPACE_DNS, 'ref2_%d' % cls.count)
-        return {
-            'object_id': str(object_id),
-            'bar': 'some non-random string',
-            'ref': str(ref1),
-            'refs': [str(ref2)],
-            'baz': {
-                'foo': 'other non-random string',
-                'ref': str(ref1),
-                'refs': [str(ref2)],
-            },
-        }
-
-    @classmethod
-    def generate_clean_data(cls, object_id=None):
-        cls.count += 1
-        if object_id is None:
-            object_id = uuid.uuid5(uuid.NAMESPACE_DNS, 'test%d' % cls.count)
-        ref1 = uuid.uuid5(uuid.NAMESPACE_DNS, 'ref1_%d' % cls.count)
-        ref2 = uuid.uuid5(uuid.NAMESPACE_DNS, 'ref2_%d' % cls.count)
+        ExampleReferenced.create_object(cloud, str(ref1))
+        ExampleReferenced.create_object(cloud, str(ref2))
         return {
             'object_id': {
-                'cloud': 'test_cloud',
+                'cloud': cloud,
                 'id': str(object_id),
-                'type': 'tests.lib.os.discovery.test_model.Example',
+                'type': Example.get_class_qualname(),
             },
             'bar': 'some non-random string',
             'baz': {
                 'foo': 'other non-random string',
                 'ref': {
-                    'cloud': 'test_cloud',
+                    'cloud': cloud,
                     'id': str(ref1),
-                    'type': 'tests.lib.os.discovery.test_model.'
-                            'ExampleReferenced',
+                    'type': ExampleReferenced.get_class_qualname(),
                 },
                 'refs': [{
-                    'cloud': 'test_cloud',
+                    'cloud': cloud,
                     'id': str(ref2),
-                    'type': 'tests.lib.os.discovery.test_model.'
-                            'ExampleReferenced',
+                    'type': ExampleReferenced.get_class_qualname(),
                 }],
             },
             'ref': {
-                'cloud': 'test_cloud',
+                'cloud': cloud,
                 'id': str(ref1),
-                'type': 'tests.lib.os.discovery.test_model.'
-                        'ExampleReferenced',
+                'type': ExampleReferenced.get_class_qualname(),
             },
             'refs': [{
-                'cloud': 'test_cloud',
+                'cloud': cloud,
                 'id': str(ref2),
-                'type': 'tests.lib.os.discovery.test_model.'
-                        'ExampleReferenced',
+                'type': ExampleReferenced.get_class_qualname(),
             }],
         }
 
@@ -154,71 +123,72 @@ class ModelTestCase(test_local_db.DatabaseMockingTestCase):
             self.assertEqual(1337, obj.ref.qux)
             self.assertEqual(1337, obj.refs[0].qux)
 
-    def test_load_from_cloud(self):
-        data = Example.generate_cloud_data()
-        obj = Example.load_from_cloud(self.cloud, data)
-        self._validate_example_obj(
-            model.ObjectId(data['object_id'], 'test_cloud'), obj)
+    @staticmethod
+    def _make_id(model_class, cloud_obj_id, cloud='test_cloud'):
+        return {
+            'id': cloud_obj_id,
+            'cloud': cloud,
+            'type': model_class.get_class_qualname(),
+        }
 
     def test_load(self):
-        data = Example.generate_clean_data()
+        data = Example.generate_data()
         obj = Example.load(data)
         self._validate_example_obj(
             model.ObjectId(data['object_id']['id'], 'test_cloud'), obj, False)
 
     def test_non_dirty(self):
-        obj = Example.load(Example.generate_clean_data())
+        obj = Example.load(Example.generate_data())
         self.assertTrue(obj.is_dirty('objects'))
 
     def test_simple_dirty(self):
-        obj = Example.load(Example.generate_clean_data())
+        obj = Example.load(Example.generate_data())
         obj.bar = 'value is changed'
         self.assertTrue(obj.is_dirty('objects'))
 
     def test_nested_dirty(self):
-        obj = Example.load(Example.generate_clean_data())
+        obj = Example.load(Example.generate_data())
         obj.baz.foo = 'value is changed'
         self.assertTrue(obj.is_dirty('objects'))
 
     def test_ref_dirty(self):
-        obj = Example.load(Example.generate_clean_data())
-        ref_obj = ExampleReferenced.load_from_cloud(self.cloud, {
-            'object_id': 'hello',
+        obj = Example.load(Example.generate_data())
+        ref_obj = ExampleReferenced.load({
+            'object_id': self._make_id(ExampleReferenced, 'hello'),
             'qux': 313373,
         })
         obj.ref = ref_obj
         self.assertTrue(obj.is_dirty('objects'))
 
     def test_refs_dirty(self):
-        obj = Example.load(Example.generate_clean_data())
-        ref_obj = ExampleReferenced.load_from_cloud(self.cloud, {
-            'object_id': 'hello',
+        obj = Example.load(Example.generate_data())
+        ref_obj = ExampleReferenced.load({
+            'object_id': self._make_id(ExampleReferenced, 'hello'),
             'qux': 313373,
         })
         obj.refs.append(ref_obj)
         self.assertTrue(obj.is_dirty('objects'))
 
     def test_nested_ref_dirty(self):
-        obj = Example.load(Example.generate_clean_data())
-        ref_obj = ExampleReferenced.load_from_cloud(self.cloud, {
-            'object_id': 'hello',
+        obj = Example.load(Example.generate_data())
+        ref_obj = ExampleReferenced.load({
+            'object_id': self._make_id(ExampleReferenced, 'hello'),
             'qux': 313373,
         })
         obj.baz.ref = ref_obj
         self.assertTrue(obj.is_dirty('objects'))
 
     def test_nested_refs_dirty(self):
-        obj = Example.load(Example.generate_clean_data())
-        ref_obj = ExampleReferenced.load_from_cloud(self.cloud, {
-            'object_id': 'hello',
+        obj = Example.load(Example.generate_data())
+        ref_obj = ExampleReferenced.load({
+            'object_id': self._make_id(ExampleReferenced, 'hello'),
             'qux': 313373,
         })
         obj.baz.refs.append(ref_obj)
         self.assertTrue(obj.is_dirty('objects'))
 
     def test_store_retrieve(self):
-        data = Example.generate_cloud_data()
-        orig_obj = Example.load_from_cloud(self.cloud, data)
+        orig_obj = Example.load(Example.generate_data())
         object_id = orig_obj.object_id
         with model.Session() as session:
             session.store(orig_obj)
@@ -231,8 +201,7 @@ class ModelTestCase(test_local_db.DatabaseMockingTestCase):
                 object_id, session.retrieve(Example, object_id))
 
     def test_store_list(self):
-        data = Example.generate_cloud_data()
-        orig_obj = Example.load_from_cloud(self.cloud, data)
+        orig_obj = Example.load(Example.generate_data())
         object_id = orig_obj.object_id
         with model.Session() as session:
             session.store(orig_obj)
@@ -243,30 +212,28 @@ class ModelTestCase(test_local_db.DatabaseMockingTestCase):
             self._validate_example_obj(object_id, session.list(Example)[0])
 
     def test_store_list_cloud(self):
-        data = Example.generate_cloud_data()
-        orig_obj1 = Example.load_from_cloud(self.cloud, data)
+        orig_obj1 = Example.load(Example.generate_data(cloud=self.cloud.name))
         object1_id = orig_obj1.object_id
-        orig_obj2 = Example.load_from_cloud(self.cloud2, data)
+        orig_obj2 = Example.load(Example.generate_data(cloud=self.cloud2.name))
         object2_id = orig_obj2.object_id
         with model.Session() as session:
             session.store(orig_obj1)
             session.store(orig_obj2)
             # Validate retrieve working before commit
             self._validate_example_obj(object1_id,
-                                       session.list(Example, 'test_cloud')[0])
+                                       session.list(Example, self.cloud)[0])
             self._validate_example_obj(object2_id,
-                                       session.list(Example, 'test_cloud2')[0])
+                                       session.list(Example, self.cloud2)[0])
         # Validate retrieve working after commit
         with model.Session() as session:
             self._validate_example_obj(object1_id,
-                                       session.list(Example, 'test_cloud')[0])
+                                       session.list(Example, self.cloud)[0])
         with model.Session() as session:
             self._validate_example_obj(object2_id,
-                                       session.list(Example, 'test_cloud2')[0])
+                                       session.list(Example, self.cloud2)[0])
 
     def test_load_store(self):
-        data = Example.generate_cloud_data()
-        orig_obj = Example.load_from_cloud(self.cloud, data)
+        orig_obj = Example.load(Example.generate_data())
         object_id = orig_obj.object_id
         with model.Session() as session:
             session.store(orig_obj)
@@ -282,12 +249,11 @@ class ModelTestCase(test_local_db.DatabaseMockingTestCase):
 
     def test_many_nested(self):
         class ExampleMany(model.Model):
-            class Schema(model.Schema):
-                object_id = model.PrimaryKey()
-                many = model.Nested(Simple, many=True)
+            object_id = model.PrimaryKey()
+            many = model.Nested(Simple, many=True)
 
-        many = ExampleMany.load_from_cloud(self.cloud, {
-            'object_id': 'foo',
+        many = ExampleMany.load({
+            'object_id': self._make_id(ExampleMany, 'foo'),
             'many': [
                 {'foo': 'foo'},
                 {'foo': 'bar'},
@@ -309,27 +275,23 @@ class ModelTestCase(test_local_db.DatabaseMockingTestCase):
 
     def test_example_name_ref(self):
         class ExampleNameRef(model.Model):
-            class Schema(model.Schema):
-                object_id = model.PrimaryKey()
-                ref = model.Dependency('tests.lib.os.'
-                                       'discovery.test_model.Example')
+            object_id = model.PrimaryKey()
+            ref = model.Dependency(Example.get_class_qualname())
 
         with model.Session() as session:
-            example = Example.load_from_cloud(
-                self.cloud, Example.generate_cloud_data('foo-bar-baz'))
+            example = Example.load(Example.generate_data('foo-bar-baz'))
             session.store(example)
 
-        obj = ExampleNameRef.load_from_cloud(self.cloud, {
-            'object_id': 'ExampleNameRef-1',
-            'ref': str('foo-bar-baz'),
+        obj = ExampleNameRef.load({
+            'object_id': self._make_id(ExampleNameRef, 'ExampleNameRef-1'),
+            'ref': self._make_id(Example, 'foo-bar-baz'),
         })
         self.assertIs(Example, obj.ref.get_class())
 
     def test_nested_sessions(self):
-        data = Example.generate_cloud_data()
-        orig_obj1 = Example.load_from_cloud(self.cloud, data)
+        orig_obj1 = Example.load(Example.generate_data(cloud=self.cloud.name))
         object1_id = orig_obj1.object_id
-        orig_obj2 = Example.load_from_cloud(self.cloud2, data)
+        orig_obj2 = Example.load(Example.generate_data(cloud=self.cloud2.name))
         object2_id = orig_obj2.object_id
 
         with model.Session() as s1:
@@ -347,10 +309,9 @@ class ModelTestCase(test_local_db.DatabaseMockingTestCase):
                 object2_id, s2.retrieve(Example, object2_id))
 
     def test_nested_sessions_save_updates_after_nested(self):
-        data = Example.generate_cloud_data()
-        orig_obj1 = Example.load_from_cloud(self.cloud, data)
+        orig_obj1 = Example.load(Example.generate_data(cloud=self.cloud.name))
         object1_id = orig_obj1.object_id
-        orig_obj2 = Example.load_from_cloud(self.cloud2, data)
+        orig_obj2 = Example.load(Example.generate_data(cloud=self.cloud2.name))
         object2_id = orig_obj2.object_id
 
         with model.Session() as s1:


### PR DESCRIPTION
This patch decompose old discovery model into two separate entitis. One
is model which is responsible for model serialization, deserialization,
validation and storing this data into database. Other part is only
responsible for discovery. I hope this simplifies the code, make data
conversion from representation returned by OpenStack clients to
our internal representation explicit (no more magic) and makes discovery
process extensible.