### PR TITLE
CF-467 Cinder quotas are not verified in functional tests.

### DIFF
--- a/cloudferry_devlab/cloudferry_devlab/generate_load.py
+++ b/cloudferry_devlab/cloudferry_devlab/generate_load.py
@@ -173,9 +173,8 @@ class Prerequisites(base.BasePrerequisites):
                 self.novaclient.quotas.update(tenant_id=self.get_tenant_id(
                     tenant['name']), **tenant['quota'])
             if 'quota_cinder' in tenant:
-                self.cinderclient.quotas.update(
-                    tenant_id=self.get_tenant_id(tenant['name']),
-                    **tenant['quota_cinder'])
+                self.cinderclient.quotas.update(tenant_id=tenant['name'],
+                                                **tenant['quota_cinder'])
 
     def upload_image(self):
 


### PR DESCRIPTION
Fixed generate_load to use tenant name for cinder quota updating.