### PR TITLE
[CF-473] Add filter-path, scenario and copy-backend options to migrate command

### DIFF
--- a/cloudferry_devlab/README.md
+++ b/cloudferry_devlab/README.md
@@ -116,14 +116,12 @@ for ((i=0;i<${#filters[@]};++i))
 # This loop is for changing filtering files in configuration.ini and executing
 # specific functional tests for each migrated tenant.
 do
-    sed -i 's|filter_path = .*|filter_path = '${CF_DIR}'/'${filters[$i]}'|g' \
-     ${CONFIGURATION_INI}
     for scenario in `ls  scenario/stages/*.yaml; ls scenario/migrate_vms.yaml`
     # This loop is for changing scenario in configuration.ini and running
     # migration process.
     do
-        sed -i 's|scenario = .*|scenario = '$scenario'|g' ${CONFIGURATION_INI}
-        cloudferry migrate configuration.ini --debug
+        cloudferry migrate configuration.ini --debug \
+            --filter-path ${CF_DIR}'/'${filters[$i]} --scenario ${scenario}
     done
     pushd ${TESTS_DIR}
     nosetests -d -v --ignore-files=test_verify_dst_functionality \
@@ -132,8 +130,10 @@ do
                 --xunit-file=nosetests.xml \
                 --tc-file ${CONFIGURATION_INI} \
                 --tc=general.cloudferry_dir:${CF_DIR} \
-                --tc=general.configuration_ini_path:${CONFIGURATION_INI}
+                --tc=general.configuration_ini_path:${CONFIGURATION_INI} \
+                --tc=general.filter_path:${filters[$i]}
     popd
+    last_filter=${filters[$i]}
 done
 ```
 
@@ -147,6 +147,7 @@ nosetests -d -v --with-xunit \
                 --tc-file ${CONFIGURATION_INI} \
                 --tc=general.cloudferry_dir:${CF_DIR} \
                 --tc=general.configuration_ini_path:${CONFIGURATION_INI}
+                --tc=general.filter_path:${last_filter}
 ```
 
 ## CloudFerry usage

--- a/cloudferry_devlab/cloudferry_devlab/tests/functional_test.py
+++ b/cloudferry_devlab/cloudferry_devlab/tests/functional_test.py
@@ -61,9 +61,11 @@ class FunctionalTest(unittest.TestCase):
         self.migration_utils = utils.MigrationUtils(config)
         self.config_ini_path = config_ini['general']['configuration_ini_path']
         self.cloudferry_dir = config_ini['general']['cloudferry_dir']
+        filter_path = config_ini['general'].get(
+            'filter_path',
+            get_option_from_config_ini('filter_path'))
         self.filtering_utils = utils.FilteringUtils(
-            os.path.join(self.cloudferry_dir, get_option_from_config_ini(
-                'filter_path')))
+            os.path.join(self.cloudferry_dir, filter_path))
 
     def filter_networks(self):
         networks = [i['name'] for i in config.networks]


### PR DESCRIPTION
It allows to override migrate.filter_path, migrate.scenario and migrate.copy_backend options.