### PR TITLE
[CF-394] Extend functional tests to verify migration of deleted flavors

### DIFF
--- a/cloudferry_devlab/cloudferry_devlab/generate_load.py
+++ b/cloudferry_devlab/cloudferry_devlab/generate_load.py
@@ -801,13 +801,14 @@ class Prerequisites(base.BasePrerequisites):
                                         conf.TIMEOUT)
         self.wait_until_objects(vms, self.check_vm_state, conf.TIMEOUT)
 
-    def delete_flavor(self, flavor='del_flvr'):
+    def delete_flavors(self):
         """
         Method for flavor deletion.
         """
         try:
-            self.novaclient.flavors.delete(
-                self.get_flavor_id(flavor))
+            for flavor in self.config.flavors_deleted_after_vm_boot:
+                self.novaclient.flavors.delete(
+                    self.get_flavor_id(flavor))
         except nv_exceptions.ClientException:
             self.log.warning("Flavor %s failed to delete:", flavor,
                              exc_info=True)
@@ -1101,8 +1102,8 @@ class Prerequisites(base.BasePrerequisites):
         self.create_invalid_cinder_objects()
         self.log.info('Create swift containers and objects')
         self.create_swift_container_and_objects()
-        self.log.info('Deleting flavor')
-        self.delete_flavor()
+        self.log.info('Deleting flavors which should be deleted')
+        self.delete_flavors()
         self.log.info('Modifying admin tenant quotas')
         self.modify_admin_tenant_quotas()
         self.log.info('Update network quotas')

--- a/cloudferry_devlab/cloudferry_devlab/tests/config.py
+++ b/cloudferry_devlab/cloudferry_devlab/tests/config.py
@@ -368,7 +368,8 @@ tenants = [
               {'cidr': '123.2.2.0/24', 'ip_version': 4, 'name': 't5_s2'}]}],
      'vms': [
          {'name': 'tn5server1', 'image': 'image1', 'flavor': 'flavorname2',
-          'nics': [{'net-id': 'tenant5net', 'v4-fixed-ip': '122.2.2.100'}]},
+          'nics': [{'net-id': 'tenant5net', 'v4-fixed-ip': '122.2.2.100'}],
+          'already_on_dst': True},
          {'name': 'tn5server2', 'image': 'image1', 'flavor': 'flavorname2',
           'nics': [{'net-id': 'tenant5net2', 'v4-fixed-ip': '123.2.2.100'}]},
          {'name': 'tn5server3', 'image': 'image1', 'flavor': 'flavorname2',
@@ -443,6 +444,9 @@ images_not_included_in_filter = ['image5']
 images_blacklisted = ['image7']
 """Images blacklisted"""
 
+flavors_deleted_after_vm_boot = ["del_flvr"]
+"""Flavors to be deleted after booting VM from them"""
+
 vms_not_in_filter = ['not_in_filter']
 """Instances not to be included in filter"""
 
@@ -457,6 +461,10 @@ flavors = [
      'is_public': False},
     {'name': 'flavorname2', 'disk': '2', 'ram': '48', 'vcpus': '2'},
     {'name': 'del_flvr', 'disk': '1', 'ram': '64', 'vcpus': '1'},
+    {'name': 'diffattrib_flvr', 'flavorid': '666', 'disk': '5', 'ram': '96',
+     'vcpus': '1', "ephemeral": '0', 'is_public': True, 'is_deleted': True},
+    {'name': 'diffattrib_flvr', 'flavorid': '666', 'disk': '4', 'ram': '64',
+     'vcpus': '2', "ephemeral": '0', 'is_public': False},
     {'name': 'deleted_flavor', 'flavorid': '777', 'disk': '1', 'ram': '48',
      'vcpus': '1', "ephemeral": '0', 'is_deleted': True},
     {'name': 'recreated_flavor', 'flavorid': '777', 'disk': '1', 'ram': '48',
@@ -590,7 +598,7 @@ vms = [
     {'name': 'server1', 'image': 'image1', 'flavor': 'flavorname1'},
     {'name': 'server2', 'image': 'deleted_on_dst', 'flavor': 'del_flvr',
      'server_group': 'admin_server_group', 'config_drive': True, 'fip': True},
-    {'name': 'server3', 'image': 'deleted_image', 'flavor': 'flavorname2'},
+    {'name': 'server3', 'image': 'deleted_image', 'flavor': 'diffattrib_flvr'},
     {'name': 'server4', 'image': 'broken_image', 'flavor': 'flavorname2'},
     {'name': 'server5', 'image': 'image1', 'flavor': 'flavorname1',
      'broken': True},


### PR DESCRIPTION
Scenario added -

1. Create flavor with some specific ID in source cloud with some attributes.
2. Delete that flavor
3. Create flavor with the same ID, but with different attributes
4. Boot VM from 'deletedflavor' flavor
5. Run migration for VM
6. Verify VM migrated successfully to destination and is booted from correct flavor