### PR TITLE
CF-472 local_sudo_password pre-check

### DIFF
--- a/cloudferry/lib/utils/local.py
+++ b/cloudferry/lib/utils/local.py
@@ -14,6 +14,7 @@
 import logging
 
 from fabric import api
+from fabric.state import env
 
 LOG = logging.getLogger(__name__)
 
@@ -33,7 +34,7 @@ def run(cmd, capture_output=True):
     try:
         LOG.debug("Running '%s' locally", cmd)
         return api.local(cmd, capture=capture_output)
-    except SystemExit as e:
+    except (SystemExit, env.abort_exception) as e:
         LOG.debug("Command '%s' failed with '%s'", cmd, e.message)
         raise LocalExecutionFailed(e.message, e.code)
 


### PR DESCRIPTION
`local_sudo_password` config option used to introduce a lot of
mistakes into config file because it was unclear whether it's needed
or not and often migration failed with cryptic errors during ISCSI
discovery. This patch adds verification which suggests to set
`local_sudo_password` if it's not set and adds better error handling
for local command execution to avoid cryptic errors.