### PR TITLE
[CF-480] VMs parameter validation functional test fails after icehouse to juno migration

### DIFF
--- a/cloudferry_devlab/cloudferry_devlab/tests/testcases/test_vm_migration.py
+++ b/cloudferry_devlab/cloudferry_devlab/tests/testcases/test_vm_migration.py
@@ -183,6 +183,7 @@ class VmMigration(functional_test.FunctionalTest):
         filtering_data = self.filtering_utils \
             .filter_vms_with_filter_config_file(src_vms)
         src_vms = filtering_data[0]
+        src_vms = [vm for vm in src_vms if vm.status != 'ERROR']
 
         def compare_vm_parameter(param, vm1, vm2):
             vm1_param = getattr(vm1, param, None)


### PR DESCRIPTION
Functional tests were failing because a VM, that was marked in ERROR state on source cloud as part of generate load, was not migrated and functional tests were trying to validate its params on destination cloud which was incorrect.