### PR TITLE
[CF-479] Match VMs by vm_hash instead of name

### DIFF
--- a/cloudferry_devlab/cloudferry_devlab/tests/config.py
+++ b/cloudferry_devlab/cloudferry_devlab/tests/config.py
@@ -658,8 +658,7 @@ vm_states = [
     {'name': 'server8', 'state': 'active'},
     {'name': 'tn1server1', 'state': 'active'},
     {'name': 'tn1server2', 'state': 'active'},
-    {'name': 'tn2server1', 'state': 'active'},
-    {'name': 'tn4server1', 'state': 'active'}
+    {'name': 'tn2server1', 'state': 'active'}
 ]
 """Emulate different VM states"""
 

--- a/cloudferry_devlab/cloudferry_devlab/tests/testcases/test_resource_migration.py
+++ b/cloudferry_devlab/cloudferry_devlab/tests/testcases/test_resource_migration.py
@@ -683,7 +683,7 @@ class ResourceMigrationTests(functional_test.FunctionalTest):
             vm_ip = self.migration_utils.get_vm_fip(vm)
             self.migration_utils.open_ssh_port_secgroup(self.dst_cloud,
                                                         vm.tenant_id)
-            base.BasePrerequisites.wait_until_objects_created(
+            base.BasePrerequisites.wait_until_objects(
                 [(vm_ip, 'pwd')],
                 self.migration_utils.wait_until_vm_accessible_via_ssh,
                 config.TIMEOUT)

--- a/cloudferry_devlab/cloudferry_devlab/tests/testcases/test_verify_dst_functionality.py
+++ b/cloudferry_devlab/cloudferry_devlab/tests/testcases/test_verify_dst_functionality.py
@@ -286,12 +286,12 @@ class VerifyDstCloudFunctionality(functional_test.FunctionalTest):
         """Validate destination cloud's volumes running and attaching
         successfully."""
         vm = self.dst_cloud.novaclient.servers.create(**self.TST_IMAGE)
-        base.BasePrerequisites.wait_until_objects_created(
+        base.BasePrerequisites.wait_until_objects(
             [vm], self.check_vm_state, config.TIMEOUT)
 
         vm.add_floating_ip(self.float_ip_address)
 
-        base.BasePrerequisites.wait_until_objects_created(
+        base.BasePrerequisites.wait_until_objects(
             [(vm, self.float_ip_address)],
             base.BasePrerequisites.check_floating_ip_assigned, config.TIMEOUT)
         self.wait_service_on_vm_to_be_ready(config.TIMEOUT,
@@ -312,12 +312,12 @@ class VerifyDstCloudFunctionality(functional_test.FunctionalTest):
     def test_create_vm(self):
         """Validate destination cloud's VMs running successfully."""
         vm = self.dst_cloud.novaclient.servers.create(**self.TST_IMAGE)
-        base.BasePrerequisites.wait_until_objects_created(
+        base.BasePrerequisites.wait_until_objects(
             [vm], self.check_vm_state, config.TIMEOUT)
 
         vm.add_floating_ip(self.float_ip_address)
 
-        base.BasePrerequisites.wait_until_objects_created(
+        base.BasePrerequisites.wait_until_objects(
             [(vm, self.float_ip_address)],
             base.BasePrerequisites.check_floating_ip_assigned, config.TIMEOUT)
         self.wait_service_on_vm_to_be_ready(config.TIMEOUT,


### PR DESCRIPTION
Preparing src_dst_vms list by matching the vms by vm_hash.
Add additional information to the message on failure.
Add calling a wait_until function for emulate_vm_states.
Rename wait_until_objects_created function to wait_until_objects.