### PR TITLE
[CF-493] Fix checking that VMs spawned in external networks

### DIFF
--- a/cloudferry/cloud/grouping.py
+++ b/cloudferry/cloud/grouping.py
@@ -78,8 +78,7 @@ class Grouping(object):
 
         tenant_list = self.identity.get_tenants_list()
         search_list = (instances_list if instances_list else
-                       self.compute.get_instances_list(
-                           search_opts={"all_tenants": True}))
+                       self.compute.get_instances_list())
         for tenant in tenant_list:
             LOG.info('Processing tenant %s', tenant.id)
             groups[str(tenant.id)] = [vm for vm in search_list
@@ -94,8 +93,7 @@ class Grouping(object):
         subnets_list = self.network.get_subnets_list()
 
         search_list = (instances_list if instances_list else
-                       self.compute.get_instances_list(
-                           search_opts={"all_tenants": True}))
+                       self.compute.get_instances_list())
         for instance in search_list:
             LOG.info('Processing instance %s', instance.name)
             for network_ips in instance.networks.values():

--- a/tests/lib/os/actions/test_check_networks.py
+++ b/tests/lib/os/actions/test_check_networks.py
@@ -340,7 +340,9 @@ class CheckNetworksTestCase(test.TestCase):
         src_cmp_info = [mock.Mock(id='fake_instance_id')]
 
         action = self.get_action(src_net_info, src_compute_info=src_cmp_info)
-        self.assertRaises(exception.AbortMigrationError, action.run)
+        with mock.patch.object(check_networks.LOG, 'warning') as warning:
+            action.run()
+            warning.assert_called_once_with(mock.ANY, ['fake_instance_id'])
 
     def test_allocation_pools_overlap(self):
         src_net_info = {'networks': [{'id': 'id1',


### PR DESCRIPTION
ComputeInfo class correctly passes search_opts parameters to get_instances_list function.
get_instances_list function of NovaCompute returns list of servers according to the filters,
also it supports several tenants in filters.