### PR TITLE
CF-503 Allow providing nova endpoint type

### DIFF
--- a/cloudferry/cfglib.py
+++ b/cloudferry/cfglib.py
@@ -39,6 +39,20 @@ src_opts = [
                help='Openstack region name'),
     cfg.StrOpt('service_tenant', default='service',
                help='Tenant name for services'),
+    cfg.StrOpt('endpoint_type', default='publicURL',
+               choices=['publicURL', 'internalURL', 'adminURL'],
+               help="Endpoint type for all openstack services. This can be "
+                    "overridden for nova by specifying `nova_endpoint_type` "
+                    "and for cinder by specifying `cinder_endpoint_type`. "
+                    "Use your openrc for reference."),
+    cfg.StrOpt('nova_endpoint_type', default=None,
+               choices=['publicURL', 'internalURL', 'adminURL'],
+               help="Endpoint type for nova. Overrides `endpoint_type` "
+                    "value. Use your openrc for reference."),
+    cfg.StrOpt('cinder_endpoint_type', default=None,
+               choices=['publicURL', 'internalURL', 'adminURL'],
+               help="Endpoint type for cinder. Overrides `endpoint_type` "
+                    "value. Use openrc for reference."),
     cfg.StrOpt('ssh_user', default='root',
                help='user to connect via ssh'),
     cfg.StrOpt('ssh_sudo_password', default='',
@@ -72,6 +86,20 @@ dst_opts = [
                help='Openstack region name'),
     cfg.StrOpt('service_tenant', default='service',
                help='Tenant name for services'),
+    cfg.StrOpt('endpoint_type', default='publicURL',
+               choices=['publicURL', 'internalURL', 'adminURL'],
+               help="Endpoint type for all openstack services. This can be "
+                    "overridden for nova by specifying `nova_endpoint_type` "
+                    "and for cinder by specifying `cinder_endpoint_type`. "
+                    "Use your openrc for reference."),
+    cfg.StrOpt('nova_endpoint_type', default=None,
+               choices=['publicURL', 'internalURL', 'adminURL'],
+               help="Endpoint type for nova. Overrides `endpoint_type` "
+                    "value. Use your openrc for reference."),
+    cfg.StrOpt('cinder_endpoint_type', default=None,
+               choices=['publicURL', 'internalURL', 'adminURL'],
+               help="Endpoint type for cinder. Overrides `endpoint_type` "
+                    "value. Use openrc for reference."),
     cfg.StrOpt('ssh_user', default='root',
                help='user to connect via ssh'),
     cfg.StrOpt('ssh_sudo_password', default='',

--- a/cloudferry/lib/os/compute/nova_compute.py
+++ b/cloudferry/lib/os/compute/nova_compute.py
@@ -114,7 +114,9 @@ class NovaCompute(compute.Compute):
             params.cloud.auth_url,
             cacert=params.cloud.cacert,
             insecure=params.cloud.insecure,
-            region_name=params.cloud.region
+            region_name=params.cloud.region,
+            endpoint_type=(params.cloud.nova_endpoint_type or
+                           params.cloud.endpoint_type)
         )
 
         LOG.debug("Authenticating as '%s' in tenant '%s' for Nova client "

--- a/cloudferry/lib/os/image/glance_image.py
+++ b/cloudferry/lib/os/image/glance_image.py
@@ -144,7 +144,7 @@ class GlanceImage(image.Image):
         """ Getting glance client. """
         endpoint_glance = self.identity_client.get_endpoint_by_service_type(
             service_type='image',
-            endpoint_type='publicURL')
+            endpoint_type=self.config.cloud.endpoint_type)
 
         # we can figure out what version of client to use from url
         # check if we have "v1" or "v2" in the end of url

--- a/cloudferry/lib/os/network/neutron.py
+++ b/cloudferry/lib/os/network/neutron.py
@@ -65,7 +65,8 @@ class NeutronNetwork(network.Network):
             auth_url=self.config.cloud.auth_url,
             cacert=self.config.cloud.cacert,
             insecure=self.config.cloud.insecure,
-            region_name=self.config.cloud.region
+            region_name=self.config.cloud.region,
+            endpoint_type=self.config.cloud.endpoint_type
         )
 
     def read_info(self, **kwargs):

--- a/cloudferry/lib/os/object_storage/swift_storage.py
+++ b/cloudferry/lib/os/object_storage/swift_storage.py
@@ -32,13 +32,15 @@ class SwiftStorage(objstorage.ObjStorage):
         if params is None:
             params = self.config.cloud
 
+        ep_type = {'endpoint_type': params.endpoint_type}
         conn = swift_client.Connection(user=params.user,
                                        key=params.password,
                                        tenant_name=params.tenant,
                                        authurl=params.auth_url,
                                        auth_version="2",
                                        cacert=params.cacert,
-                                       insecure=params.insecure)
+                                       insecure=params.insecure,
+                                       os_options=ep_type)
         return conn.get_auth()
 
     def read_info(self, **_):

--- a/cloudferry/lib/os/storage/cinder_storage.py
+++ b/cloudferry/lib/os/storage/cinder_storage.py
@@ -92,7 +92,9 @@ class CinderStorage(storage.Storage):
             params.cloud.auth_url,
             cacert=params.cloud.cacert,
             insecure=params.cloud.insecure,
-            region_name=params.cloud.region
+            region_name=params.cloud.region,
+            endpoint_type=(params.cloud.cinder_endpoint_type or
+                           params.cloud.endpoint_type)
         )
 
     def get_filter(self):

--- a/tests/lib/os/compute/test_nova.py
+++ b/tests/lib/os/compute/test_nova.py
@@ -87,7 +87,8 @@ class NovaComputeTestCase(BaseNovaComputeTestCase):
                                                  'fake_tenant',
                                                  'http://1.1.1.1:35357/v2.0/',
                                                  cacert='', insecure=False,
-                                                 region_name=None)
+                                                 region_name=None,
+                                                 endpoint_type='publicURL')
         self.assertEqual(self.mock_client(), client)
 
     def test_create_instance(self):
@@ -509,6 +510,7 @@ class NovaClientTestCase(test.TestCase):
         password = 'password'
         insecure = False
         cacert = ''
+        ep_type = 'internalURL'
 
         config.cloud.user = user
         config.cloud.tenant = tenant
@@ -518,6 +520,7 @@ class NovaClientTestCase(test.TestCase):
         config.cloud.insecure = insecure
         config.cloud.cacert = cacert
         config.migrate.override_rules = None
+        config.cloud.nova_endpoint_type = ep_type
 
         cloud.position = 'src'
 
@@ -526,7 +529,8 @@ class NovaClientTestCase(test.TestCase):
 
         n_client.assert_called_with(user, password, tenant, auth_url,
                                     region_name=region, cacert=cacert,
-                                    insecure=insecure)
+                                    insecure=insecure,
+                                    endpoint_type=ep_type)
 
     def test_does_not_add_region_if_not_set_in_config(self, n_client):
         cloud = mock.MagicMock()
@@ -538,6 +542,7 @@ class NovaClientTestCase(test.TestCase):
         password = 'password'
         insecure = False
         cacert = ''
+        ep_type = 'internalURL'
 
         config.cloud.region = None
         config.cloud.user = user
@@ -546,6 +551,7 @@ class NovaClientTestCase(test.TestCase):
         config.cloud.password = password
         config.cloud.insecure = insecure
         config.cloud.cacert = cacert
+        config.cloud.nova_endpoint_type = ep_type
         config.migrate.override_rules = None
 
         cloud.position = 'src'
@@ -555,4 +561,4 @@ class NovaClientTestCase(test.TestCase):
 
         n_client.assert_called_with(user, password, tenant, auth_url,
                                     cacert=cacert, insecure=insecure,
-                                    region_name=None)
+                                    region_name=None, endpoint_type=ep_type)

--- a/tests/lib/os/image/test_glance_image.py
+++ b/tests/lib/os/image/test_glance_image.py
@@ -31,7 +31,9 @@ FAKE_CONFIG = utils.ext_dict(cloud=utils.ext_dict({'user': 'fake_user',
                                                    'ssh_host': '1.1.1.10',
                                                    'ssh_user': 'fake_user',
                                                    'cacert': '',
-                                                   'insecure': False
+                                                   'insecure': False,
+                                                   'endpoint_type':
+                                                       'privateURL'
                                                    }),
                              migrate=utils.ext_dict({'retry': '7',
                                                      'time_wait': 5}))

--- a/tests/lib/os/network/test_neutron.py
+++ b/tests/lib/os/network/test_neutron.py
@@ -34,7 +34,8 @@ FAKE_CONFIG = utils.ext_dict(
                           'region': None,
                           'service_tenant': 'services',
                           'cacert': '',
-                          'insecure': False}),
+                          'insecure': False,
+                          'endpoint_type': 'internalURL'}),
     migrate=utils.ext_dict({'ext_net_map': 'fake_ext_net_map.yaml',
                             'retry': '7',
                             'time_wait': 5}),
@@ -173,7 +174,8 @@ class NeutronTestCase(test.TestCase):
             auth_url='http://1.1.1.1:35357/v2.0/',
             cacert='',
             insecure=False,
-            region_name=None
+            region_name=None,
+            endpoint_type='internalURL'
         )
         self.assertEqual(self.neutron_mock_client(), client)
 
@@ -961,6 +963,7 @@ class NeutronClientTestCase(test.TestCase):
         password = 'password'
         insecure = False
         cacert = ''
+        ep_type = 'publicURL'
 
         config.cloud.user = user
         config.cloud.tenant = tenant
@@ -969,6 +972,7 @@ class NeutronClientTestCase(test.TestCase):
         config.cloud.password = password
         config.cloud.insecure = insecure
         config.cloud.cacert = cacert
+        config.cloud.endpoint_type = ep_type
 
         n = neutron.NeutronNetwork(config, cloud)
         n.get_client()
@@ -980,7 +984,8 @@ class NeutronClientTestCase(test.TestCase):
             auth_url=auth_url,
             username=user,
             cacert=cacert,
-            insecure=insecure
+            insecure=insecure,
+            endpoint_type=ep_type
         )
 
     def test_does_not_add_region_if_not_set_in_config(self, n_client):
@@ -993,6 +998,7 @@ class NeutronClientTestCase(test.TestCase):
         password = 'password'
         insecure = False
         cacert = ''
+        ep_type = 'internalURL'
 
         config.cloud.region = None
         config.cloud.user = user
@@ -1001,6 +1007,7 @@ class NeutronClientTestCase(test.TestCase):
         config.cloud.password = password
         config.cloud.insecure = insecure
         config.cloud.cacert = cacert
+        config.cloud.endpoint_type = ep_type
 
         n = neutron.NeutronNetwork(config, cloud)
         n.get_client()
@@ -1012,5 +1019,6 @@ class NeutronClientTestCase(test.TestCase):
             username=user,
             cacert=cacert,
             insecure=insecure,
-            region_name=None
+            region_name=None,
+            endpoint_type=ep_type
         )

--- a/tests/lib/os/storage/test_cinder_storage.py
+++ b/tests/lib/os/storage/test_cinder_storage.py
@@ -32,7 +32,8 @@ FAKE_CONFIG = {
             'auth_url': 'http://1.1.1.1:35357/v2.0/',
             'region': None,
             'cacert': '',
-            'insecure': False},
+            'insecure': False,
+            'endpoint_type': 'publicURL'},
     'migrate': {'retry': '7',
                 'time_wait': 5,
                 'keep_volume_storage': False,
@@ -89,7 +90,8 @@ class CinderStorageTestCase(test.TestCase):
                                                  'fake_tenant',
                                                  'http://1.1.1.1:35357/v2.0/',
                                                  cacert='', insecure=False,
-                                                 region_name=None)
+                                                 region_name=None,
+                                                 endpoint_type='publicURL')
         self.assertEqual(self.mock_client(), client)
 
     def test_get_volumes_list(self):


### PR DESCRIPTION
In some cases `publicURL` used as nova endpoint type by default in nova
client returns empty list of services. This patch allows specifying nova
endpoint type for nova client to resolve these issues.