### PR TITLE
[CF-512] Add generate_load.py-ed boxes to Vagrantfile

### DIFF
--- a/cloudferry_devlab/Vagrantfile
+++ b/cloudferry_devlab/Vagrantfile
@@ -50,7 +50,69 @@ nodes = {
     "ip2" => "#{options['nfs_ip2']}",
     "memory" => 1024,
     "cpus" => 1
-  }
+  },
+  "grizzly_juno_src" => {
+    "box" => "grizzly_juno/src",
+    "url" => "http://172.18.236.71/grizzly_juno/src.json",
+    "ip" => "#{options['grizzly_ip']}",
+    "ip2" => "#{options['grizzly_ip2']}",
+    "memory" => 4096,
+    "role" => "openstack",
+    "hostname" => "grizzly",
+    "release" => "grizzly",
+    "cpus" => 2
+  },
+  "grizzly_juno_dst" => {
+    "box" => "grizzly_juno/dst",
+    "url" => "http://172.18.236.71/grizzly_juno/dst.json",
+    "ip" => "#{options['juno_ip']}",
+    "ip2" => "#{options['juno_ip2']}",
+    "memory" => 4096,
+    "role" => "openstack",
+    "hostname" => "juno",
+    "release" => "juno",
+    "cpus" => 2
+  },
+  "grizzly_juno_nfs" => {
+    "box" => "grizzly_juno/nfs",
+    "url" => "http://172.18.236.71/grizzly_juno/nfs.json",
+    "ip" => "#{options['nfs_ip']}",
+    "ip2" => "#{options['nfs_ip2']}",
+    "memory" => 1024,
+    "hostname" => "nfs",
+    "cpus" => 1
+  },
+  "icehouse_juno_src" => {
+    "box" => "icehouse_juno/src",
+    "url" => "http://172.18.236.71/icehouse_juno/src.json",
+    "ip" => "#{options['icehouse_ip']}",
+    "ip2" => "#{options['icehouse_ip2']}",
+    "memory" => 4096,
+    "role" => "openstack",
+    "hostname" => "icehouse",
+    "release" => "icehouse",
+    "cpus" => 2
+  },
+  "icehouse_juno_dst" => {
+    "box" => "icehouse_juno/dst",
+    "url" => "http://172.18.236.71/icehouse_juno/dst.json",
+    "ip" => "#{options['juno_ip']}",
+    "ip2" => "#{options['juno_ip2']}",
+    "memory" => 4096,
+    "role" => "openstack",
+    "hostname" => "juno",
+    "release" => "juno",
+    "cpus" => 2
+  },
+  "icehouse_juno_nfs" => {
+    "box" => "icehouse_juno/nfs",
+    "url" => "http://172.18.236.71/icehouse_juno/nfs.json",
+    "ip" => "#{options['nfs_ip']}",
+    "ip2" => "#{options['nfs_ip2']}",
+    "memory" => 1024,
+    "hostname" => "nfs",
+    "cpus" => 1
+  },
 }
 
 options['http_proxy'] ||= ""
@@ -83,8 +145,12 @@ Vagrant.configure(2) do |config|
 
   nodes.each do |nodename, nodedata|
     config.vm.define nodename do |thisnode|
+      if nodedata.key?("url")
+        thisnode.vm.box_url = nodedata["url"]
+      end
+
       thisnode.vm.box = nodedata['box']
-      thisnode.vm.hostname = nodename
+      thisnode.vm.hostname = nodedata.fetch("hostname", nodename)
       thisnode.vm.provision "shell", inline: "echo '#{etc_hosts}' >> /etc/hosts"
       thisnode.vm.provision "shell",
         path: "./provision/keys.sh",
@@ -100,7 +166,6 @@ Vagrant.configure(2) do |config|
           if nodename == "icehouse" then
             thisnode.vm.provision "shell", path: "./provision/cleanup_nova_instances.sh"
           end
-          thisnode.vm.provision "shell", path: "./provision/libvirt.sh"
         when "lab"
           config.vm.provision "shell", path: "./provision/prerequisites.sh"
           thisnode.vm.provision "shell",

--- a/cloudferry_devlab/provision/configure_openstack.sh
+++ b/cloudferry_devlab/provision/configure_openstack.sh
@@ -29,9 +29,11 @@ fi
 crudini --set /etc/nova/nova.conf DEFAULT vncserver_proxyclient_address ${SYSTEM_IP}
 crudini --set /etc/nova/nova.conf DEFAULT osapi_compute_workers 1
 crudini --set /etc/nova/nova.conf DEFAULT metadata_workers 1
+crudini --set /etc/nova/nova.conf DEFAULT allow_resize_to_same_host True
+crudini --set /etc/nova/nova.conf DEFAULT allow_migrate_to_same_host True
 crudini --set /etc/nova/nova.conf conductor workers 1
-service nova-api start
-service nova-conductor start
-service nova-compute start
+service nova-api restart
+service nova-conductor restart
+service nova-compute restart
 
 EOF


### PR DESCRIPTION
This patch allows to run VMs from boxes that were created from VMs
against which generate_load.py was executed.

Commands to run both SRC, DST and NFS VMs:

    $ vagrant up /icehouse_juno_.*/
    $ vagrant up /grizzly_juno_.*/