### PR TITLE
CF-519 Missing write permissions in destination for file copy

### DIFF
--- a/cloudferry/actions/helper/task_transfer.py
+++ b/cloudferry/actions/helper/task_transfer.py
@@ -28,8 +28,7 @@ class TaskTransfer(action.Action):
                  resource_name=utils.VOLUMES_TYPE,
                  resource_root_name=utils.VOLUME_BODY):
         super(TaskTransfer, self).__init__(init)
-        self.driver = base.get_copier_class(driver)(self.src_cloud,
-                                                    self.dst_cloud)
+        self.driver = base.get_copier(self.src_cloud, self.dst_cloud, driver)
         self.resource_name = resource_name
         self.resource_root_name = resource_root_name
         self.input_info = input_info

--- a/cloudferry/lib/copy_engines/bbcp_copier.py
+++ b/cloudferry/lib/copy_engines/bbcp_copier.py
@@ -84,10 +84,9 @@ class BbcpCopier(base.BaseCopier):
         additional_options = []
         # -f: forces the copy by first unlinking the target file before
         # copying.
-        # -p: preserve source mode, ownership, and dates.
         # -S: command to start bbcp on the source node.
         # -T: command to start bbcp on the target node.
-        forced_options = ['-f', '-p']
+        forced_options = ['-f']
         if CONF.migrate.copy_with_md5_verification:
             # -e: error check data for transmission errors using md5 checksum.
             forced_options.append('-e')

--- a/cloudferry/lib/copy_engines/rsync_copier.py
+++ b/cloudferry/lib/copy_engines/rsync_copier.py
@@ -47,8 +47,6 @@ class RsyncCopier(base.BaseCopier):
         cmd = ("rsync "
                "--partial "
                "--inplace "
-               "--perms "
-               "--times "
                "--compress "
                "--verbose "
                "--progress "

--- a/cloudferry/lib/os/storage/plugins/copy_mechanisms.py
+++ b/cloudferry/lib/os/storage/plugins/copy_mechanisms.py
@@ -57,9 +57,9 @@ class RemoteFileCopy(CopyMechanism):
         }
 
         try:
-            copier = base.get_copier(context.src_cloud,
-                                     context.dst_cloud,
-                                     data)
+            copier = base.get_copier_checked(context.src_cloud,
+                                             context.dst_cloud,
+                                             data)
 
             copier.transfer(data)
         except (base.FileCopyError,

--- a/tests/lib/copy_engines/test_base.py
+++ b/tests/lib/copy_engines/test_base.py
@@ -95,12 +95,12 @@ class GetCopierTestCase(test.TestCase):
 
     def get_copier(self, name):
         self.cfg.set_override('copy_backend', name, 'migrate')
-        return base.get_copier('fake_src_cloud', 'fake_dst_cloud',
-                               {'host_src': 'fake_host_src',
-                                'host_dst': 'fake_host_dst'})
+        return base.get_copier_checked('fake_src_cloud', 'fake_dst_cloud',
+                                       {'host_src': 'fake_host_src',
+                                        'host_dst': 'fake_host_dst'})
 
     def test_get_copier(self):
-        self.assertIsInstance(self.get_copier('fake'), FakeCopier)
+        self.assertIsInstance(self.get_copier('fake').copier, FakeCopier)
 
     def test_get_copier_not_found(self):
         self.assertRaises(base.CopierNotFound, self.get_copier, 'fake_fake')


### PR DESCRIPTION
When volumes or ephemerals are copied between compute nodes in source
and destination with non-root user, there might be no write
permissions in the destination folder, which leads to copy failures.
This patch resolves the issue by temporarily adding 777 permissions
for a folder in destination and reverting it back once copy is done.