### PR TITLE
CF-524 Unit tests don't spawn ssh-agent anymore

### DIFF
--- a/tests/lib/copy_engines/test_bbcp_copier.py
+++ b/tests/lib/copy_engines/test_bbcp_copier.py
@@ -30,8 +30,9 @@ class BbcpCopierTestCase(test_base.BaseTestCase):
         self.src_cloud.hosts_with_bbcp = set()
         self.dst_cloud.hosts_with_bbcp = set()
 
+    @mock.patch('cloudferry.lib.utils.utils.forward_agent')
     @mock.patch('os.path.isfile')
-    def test_usage_false(self, mock_isfile):
+    def test_usage_false(self, mock_isfile, _):
         mock_isfile.return_value = False
         self.assertFalse(self.copier.check_usage(self.data))
 

--- a/tests/lib/utils/test_runner.py
+++ b/tests/lib/utils/test_runner.py
@@ -20,7 +20,8 @@ from tests import test
 
 
 class RemoteRunnerTestCase(test.TestCase):
-    def test_remote_runner_raises_error_if_errors_are_not_ignored(self):
+    @mock.patch('cloudferry.lib.utils.utils.forward_agent')
+    def test_remote_runner_raises_error_if_errors_are_not_ignored(self, _):
         rr = remote_runner.RemoteRunner('host', 'user', 'password',
                                         ignore_errors=False)
 


### PR DESCRIPTION
Unittests previously spawned ssh-agent on each run which resulted in
hundreds of ssh-agent processes on CI nodes.