### PR TITLE
[CF-528] Use proxy client in NovaCompute.change_status

### DIFF
--- a/tests/lib/os/compute/test_nova.py
+++ b/tests/lib/os/compute/test_nova.py
@@ -113,58 +113,74 @@ class NovaComputeTestCase(BaseNovaComputeTestCase):
     @mock.patch('cloudferry.lib.base.resource.time.sleep')
     @mock.patch('cloudferry.lib.os.compute.nova_compute.NovaCompute.'
                 'get_status')
-    def test_change_status_active(self, mock_get, mock_sleep):
+    @mock.patch('cloudferry.lib.os.compute.nova_compute.NovaCompute.'
+                'nova_client')
+    def test_change_status_active(self, mock_client, mock_get, mock_sleep):
         mock_get.return_value = 'shutoff'
         self.nova_client.change_status('active', instance=self.fake_instance_0)
-        self.fake_instance_0.start.assert_called_once_with()
+        mock_client.servers.start.assert_called_once_with(
+            self.fake_instance_0)
         mock_sleep.assert_called_with(256)
 
     @mock.patch('cloudferry.lib.base.resource.time.sleep')
     @mock.patch('cloudferry.lib.os.compute.nova_compute.NovaCompute.'
                 'get_status')
-    def test_change_status_shutoff(self, mock_get, mock_sleep):
+    @mock.patch('cloudferry.lib.os.compute.nova_compute.NovaCompute.'
+                'nova_client')
+    def test_change_status_shutoff(self, mock_client, mock_get, mock_sleep):
         mock_get.return_value = 'active'
         self.nova_client.change_status('shutoff',
                                        instance=self.fake_instance_0)
-        self.fake_instance_0.stop.assert_called_once_with()
+        mock_client.servers.stop.assert_called_once_with(self.fake_instance_0)
         mock_sleep.assert_called_with(256)
 
     @mock.patch('cloudferry.lib.base.resource.time.sleep')
     @mock.patch('cloudferry.lib.os.compute.nova_compute.NovaCompute.'
                 'get_status')
-    def test_change_status_resume(self, mock_get, mock_sleep):
+    @mock.patch('cloudferry.lib.os.compute.nova_compute.NovaCompute.'
+                'nova_client')
+    def test_change_status_resume(self, mock_client, mock_get, mock_sleep):
         mock_get.return_value = 'suspended'
         self.nova_client.change_status('active', instance=self.fake_instance_0)
-        self.fake_instance_0.resume.assert_called_once_with()
+        mock_client.servers.resume.assert_called_once_with(
+            self.fake_instance_0)
         mock_sleep.assert_called_with(256)
 
     @mock.patch('cloudferry.lib.base.resource.time.sleep')
     @mock.patch('cloudferry.lib.os.compute.nova_compute.NovaCompute.'
                 'get_status')
-    def test_change_status_paused(self, mock_get, mock_sleep):
+    @mock.patch('cloudferry.lib.os.compute.nova_compute.NovaCompute.'
+                'nova_client')
+    def test_change_status_paused(self, mock_client, mock_get, mock_sleep):
         mock_get.return_value = 'active'
         self.nova_client.change_status('paused', instance=self.fake_instance_0)
-        self.fake_instance_0.pause.assert_called_once_with()
+        mock_client.servers.pause.assert_called_once_with(self.fake_instance_0)
         mock_sleep.assert_called_with(256)
 
     @mock.patch('cloudferry.lib.base.resource.time.sleep')
     @mock.patch('cloudferry.lib.os.compute.nova_compute.NovaCompute.'
                 'get_status')
-    def test_change_status_unpaused(self, mock_get, mock_sleep):
+    @mock.patch('cloudferry.lib.os.compute.nova_compute.NovaCompute.'
+                'nova_client')
+    def test_change_status_unpaused(self, mock_client, mock_get, mock_sleep):
         mock_get.return_value = 'paused'
         self.nova_client.change_status('active',
                                        instance=self.fake_instance_0)
-        self.fake_instance_0.unpause.assert_called_once_with()
+        mock_client.servers.unpause.assert_called_once_with(
+            self.fake_instance_0)
         mock_sleep.assert_called_with(256)
 
     @mock.patch('cloudferry.lib.base.resource.time.sleep')
     @mock.patch('cloudferry.lib.os.compute.nova_compute.NovaCompute.'
                 'get_status')
-    def test_change_status_suspend(self, mock_get, mock_sleep):
+    @mock.patch('cloudferry.lib.os.compute.nova_compute.NovaCompute.'
+                'nova_client')
+    def test_change_status_suspend(self, mock_client, mock_get, mock_sleep):
         mock_get.return_value = 'active'
         self.nova_client.change_status('suspended',
                                        instance=self.fake_instance_0)
-        self.fake_instance_0.suspend.assert_called_once_with()
+        mock_client.servers.suspend.assert_called_once_with(
+            self.fake_instance_0)
         mock_sleep.assert_called_with(256)
 
     def test_change_status_same(self):
@@ -175,13 +191,16 @@ class NovaComputeTestCase(BaseNovaComputeTestCase):
 
     @mock.patch('cloudferry.lib.os.compute.nova_compute.NovaCompute.'
                 'wait_for_status')
-    def test_shutoff_to_verify_resize_brings_instance_active(self, _):
-        self.mock_client().servers.get('fake_instance_id').status = 'shutoff'
-
+    @mock.patch('cloudferry.lib.os.compute.nova_compute.NovaCompute.'
+                'get_status')
+    @mock.patch('cloudferry.lib.os.compute.nova_compute.NovaCompute.'
+                'nova_client')
+    def test_shutoff_to_verify_resize_brings_instance_active(
+            self, mock_client, mock_get, _):
+        mock_get.return_value = 'shutoff'
         self.nova_client.change_status('verify_resize',
                                        instance=self.fake_instance_0)
-
-        self.assertTrue(self.fake_instance_0.start.called)
+        mock_client.servers.start.assert_called_once_with(self.fake_instance_0)
 
     def test_get_flavor_from_id(self):
         self.mock_client().flavors.find.return_value = self.fake_flavor_0


### PR DESCRIPTION
Because proxy client wasn't used in NovaCompute.change_status it
didn't retry request on failure. This could fail migration because
of HTTP 413 "Request was rate limited" error. This patch make this
method to use proxy client.