### PR TITLE
[CF-543] Functional Tests should not verify flavor ID for VMs not migrated

### DIFF
--- a/cloudferry_devlab/cloudferry_devlab/tests/testcases/test_vm_migration.py
+++ b/cloudferry_devlab/cloudferry_devlab/tests/testcases/test_vm_migration.py
@@ -219,6 +219,7 @@ class VmMigration(functional_test.FunctionalTest):
         filtering_data = self.filtering_utils \
             .filter_vms_with_filter_config_file(src_vms)
         src_vms = filtering_data[0]
+        src_vms = [vm for vm in src_vms if vm.status != 'ERROR']
 
         fail_msg = []
         self.set_hash_for_vms(src_vms)


### PR DESCRIPTION
For the VMs created in ERROR state on source cloud, Fixed Functional Tests to not verify flavor ID for those VMs after migration as these VMs are not migrated.