### PR TITLE
[CF-545] Add ability to map different tenant names in src and dst

### DIFF
--- a/cloudferry/actions/prechecks/check_networks.py
+++ b/cloudferry/actions/prechecks/check_networks.py
@@ -24,6 +24,7 @@ from cloudferry.lib.base import exception
 from cloudferry.lib.base.action import action
 from cloudferry.lib.os.network import neutron
 from cloudferry.lib.utils import log
+from cloudferry.lib.utils import mapper
 from cloudferry.lib.utils import proxy_client
 from cloudferry.lib.utils import utils
 
@@ -65,7 +66,7 @@ class CheckNetworks(action.Action):
         LOG.debug("Retrieving Compute information from Source cloud...")
         src_compute_info = ComputeInfo(src_compute, search_opts, tenant_ids)
 
-        ext_net_map = utils.read_yaml_file(self.cfg.migrate.ext_net_map) or {}
+        ext_net_map = mapper.Mapper('ext_network_map')
 
         # Check external networks mapping
         if ext_net_map:

--- a/cloudferry/cfglib.py
+++ b/cloudferry/cfglib.py
@@ -130,7 +130,12 @@ migrate_opts = [
                help="Path to YAML file which maps source cloud external "
                     "networks to destination cloud external networks. "
                     "Required in case external networks in source and "
-                    "destination don't match."),
+                    "destination don't match.",
+               deprecated_for_removal=True,
+               deprecated_reason='Please use resource_map option'),
+    cfg.StrOpt('resource_map', default='configs/resource_map.yaml',
+               help="Path to YAML file which maps source cloud objects to "
+                    "destination cloud objects."),
     cfg.BoolOpt('keep_floatingip', default=False,
                 help='Specifies whether floating IPs will be kept the same '
                      'in destination cloud. Requires low-level neutron DB '

--- a/cloudferry/lib/base/action/action.py
+++ b/cloudferry/lib/base/action/action.py
@@ -14,6 +14,7 @@
 
 
 from cloudferry.lib.scheduler import task
+from cloudferry.lib.utils import mapper
 from cloudferry.lib.utils import utils
 
 
@@ -48,6 +49,7 @@ class Action(task.Task):
 
         src_identity = self.src_cloud.resources[utils.IDENTITY_RESOURCE]
         dst_identity = self.dst_cloud.resources[utils.IDENTITY_RESOURCE]
+        tenant_name_map = mapper.Mapper('tenant_map')
 
         src_tenants = src_identity.get_tenants_list()
         dst_tenants = dst_identity.get_tenants_list()
@@ -58,7 +60,7 @@ class Action(task.Task):
         similar_tenants = {}
 
         for src_tenant in src_tenants:
-            src_tnt_name = src_tenant.name.lower()
+            src_tnt_name = tenant_name_map.map(src_tenant.name).lower()
             if src_tnt_name in dst_tenant_map:
                 similar_tenants[src_tenant.id] = dst_tenant_map[src_tnt_name]
 

--- a/cloudferry/lib/os/compute/server_groups.py
+++ b/cloudferry/lib/os/compute/server_groups.py
@@ -32,6 +32,7 @@ from novaclient import exceptions as nova_exc
 from cloudferry.lib.base import compute
 from cloudferry.lib.os.identity import keystone
 from cloudferry.lib.utils import log
+from cloudferry.lib.utils import mapper
 from cloudferry.lib.utils import proxy_client
 from cloudferry.lib.utils import utils
 
@@ -64,6 +65,7 @@ class ServerGroupsHandler(compute.Compute):
         self.compute = self.cloud.resources[utils.COMPUTE_RESOURCE]
         self.identity = self.cloud.resources[utils.IDENTITY_RESOURCE]
         self.config = copy.deepcopy(self.identity.config)
+        self.tenant_name_map = mapper.Mapper('tenant_map')
 
     def _execute(self, sql):
         """
@@ -118,7 +120,7 @@ class ServerGroupsHandler(compute.Compute):
 
                 groups.append(
                     {"user": self.identity.try_get_username_by_id(row[0]),
-                     "tenant": tenant_name,
+                     "tenant": self.tenant_name_map.map(tenant_name),
                      "uuid": row[2],
                      "name": row[3],
                      "policies": policies})

--- a/cloudferry/lib/os/storage/cinder_storage.py
+++ b/cloudferry/lib/os/storage/cinder_storage.py
@@ -22,6 +22,7 @@ from cloudferry.lib.os.identity import keystone
 from cloudferry.lib.os.storage import filters as cinder_filters
 from cloudferry.lib.utils import filters
 from cloudferry.lib.utils import log
+from cloudferry.lib.utils import mapper
 from cloudferry.lib.utils import proxy_client
 from cloudferry.lib.utils import retrying
 from cloudferry.lib.utils import utils
@@ -77,6 +78,7 @@ class CinderStorage(storage.Storage):
         self.mysql_connector = cloud.mysql_connector('cinder')
         self.volume_filter = None
         self.filter_tenant_id = None
+        self.tenant_name_map = mapper.Mapper('tenant_map')
 
     @property
     def cinder_client(self):
@@ -185,7 +187,7 @@ class CinderStorage(storage.Storage):
             LOG.debug("Retrieved cinder quota for tenant '%s' (%s): %s",
                       t.name, t.id, quota)
 
-            quota['tenant_name'] = t.name
+            quota['tenant_name'] = self.tenant_name_map.map(t.name)
 
             quotas.append(quota)
         return quotas

--- a/cloudferry/lib/utils/mapper.py
+++ b/cloudferry/lib/utils/mapper.py
@@ -1,0 +1,80 @@
+# Copyright (c) 2016 Mirantis Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the License);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an AS IS BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and#
+# limitations under the License.
+import logging
+import os
+import yaml
+
+from cloudferry import cfglib
+
+LOG = logging.getLogger(__name__)
+CONF = cfglib.CONF
+
+
+class Mapper(object):
+    _config = None
+
+    @classmethod
+    def _load_configuration(cls):
+        resource_map_file = CONF.migrate.resource_map
+        if not os.path.exists(resource_map_file):
+            cls._load_deprecated_configuration()
+            return
+
+        with open(resource_map_file, 'r') as f:
+            data = yaml.load(f)
+            if data is None:
+                cls._load_deprecated_configuration()
+            else:
+                if not isinstance(data, dict):
+                    raise TypeError('%s root object must be dictionary!' %
+                                    (resource_map_file,))
+                cls._config = data
+
+    @classmethod
+    def _load_deprecated_configuration(cls):
+        ext_net_map_file = CONF.migrate.ext_net_map
+        if not os.path.exists(ext_net_map_file):
+            LOG.warning('Mapping configuration is absent!')
+            cls._config = {}
+            return
+
+        with open(ext_net_map_file, 'r') as f:
+            data = yaml.load(f)
+            if data is None:
+                cls._config = {}
+            else:
+                if not isinstance(data, dict):
+                    raise TypeError('%s root object must be dictionary!' %
+                                    (ext_net_map_file,))
+                cls._config = {'ext_network_map': data}
+
+    def __init__(self, mapping_name):
+        if self._config is None:
+            self._load_configuration()
+        self._mapping = self._config.get(mapping_name, {})
+
+    def __getitem__(self, item):
+        return self._mapping[item]
+
+    def __contains__(self, item):
+        return item in self._mapping
+
+    def get(self, item, default=None):
+        return self._mapping.get(item, default)
+
+    def map(self, value):
+        return self._mapping.get(value, value)
+
+    def iteritems(self):
+        return self._mapping.iteritems()

--- a/configs/ext_net_map.yaml
+++ b/configs/ext_net_map.yaml
@@ -1,3 +1,7 @@
+###############################################################################
+### !!! THIS FILE IS DEPRECATED, USE resource_map.yaml INSTEAD !!!          ###
+###############################################################################
+#
 # This file contains map of relationships between
 # external networks on source and destination clouds.
 #

--- a/configs/resource_map.yaml
+++ b/configs/resource_map.yaml
@@ -1,0 +1,15 @@
+# This file contains map of relationships between objects on source and
+# destination clouds.
+#
+# Use the following format:
+# ext_network_map:
+#   <old external network id>: <new external network id>
+# tenant_map:
+#   <old tenant name>: <new tenant name>
+#
+# F.e.:
+#ext_network_map:
+#  cfd33270-8a4c-4fb9-8af9-7c83f82b8a5b: 7c325f53-b12b-4b07-b78a-0478d863f625
+#
+#tenant_map:
+#  WTFaaS_BBQoD_Dev_Test: WTFBBQ-313373-V-PZD-05

--- a/tests/lib/os/network/test_neutron.py
+++ b/tests/lib/os/network/test_neutron.py
@@ -949,8 +949,6 @@ class NeutronRouterTestCase(test.TestCase):
 
 
 @mock.patch("cloudferry.lib.os.network.neutron.neutron_client.Client")
-@mock.patch("cloudferry.lib.os.network.neutron.utl.read_yaml_file",
-            mock.MagicMock())
 class NeutronClientTestCase(test.TestCase):
     def test_adds_region_if_set_in_config(self, n_client):
         cloud = mock.MagicMock()


### PR DESCRIPTION
This patch adds ability to map some tenant name on source to
some tenant name on destination meaning that CloudFerry will
assume that mapped tenant on source is the same as tenant on
destination even though they have different names.