### PR TITLE
[CF-561] Add cffi to requirements.txt for offline CF deployments

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ redis==2.10.5
 sqlalchemy==1.0.12
 marshmallow==2.4.2
 jmespath==0.9.0
+cffi==1.7.0
 pyOpenSSL==16.0.0
 paramiko==1.16.0
 taskflow==1.30.0


### PR DESCRIPTION
This allows to deploy CloudFerry from local mirrors.