### PR TITLE
CF-572 Migrate volumes to non-default backends

### DIFF
--- a/cloudferry/actions/block_storage/migrate_volumes.py
+++ b/cloudferry/actions/block_storage/migrate_volumes.py
@@ -163,6 +163,7 @@ class MigrateVolumes(action.Action):
                     retrying.TimeoutExceeded,
                     exception.TenantNotPresentInDestination,
                     cinder_exceptions.OverLimit,
+                    cinder_exceptions.NotFound,
                     copy_mechanisms.CopyFailed) as e:
                 LOG.warning("%(error)s, volume %(name)s will be skipped",
                             {'error': e.message,

--- a/cloudferry/lib/os/compute/nova_compute.py
+++ b/cloudferry/lib/os/compute/nova_compute.py
@@ -94,11 +94,8 @@ class NovaCompute(compute.Compute):
         self.tenant_name_map = mapper.Mapper('tenant_map')
         self.instance_info_caches = instance_info_caches.InstanceInfoCaches(
             self.get_db_connection())
-        if config.migrate.override_rules is None:
-            self.attr_override = override.AttributeOverrides.zero()
-        else:
-            self.attr_override = override.AttributeOverrides.from_filename(
-                config.migrate.override_rules)
+        self.attr_override = override.AttributeOverrides.from_filename(
+            config.migrate.override_rules, 'servers')
 
     @property
     def nova_client(self):

--- a/cloudferry/lib/utils/override.py
+++ b/cloudferry/lib/utils/override.py
@@ -70,18 +70,30 @@ class AttributeOverrides(object):
                     'list): %s' % (attr, repr(rules)))
 
     @classmethod
-    def from_filename(cls, mapping_filename):
+    def from_filename(cls, mapping_filename, object_type):
         """
         Create AttributeOverrides based on YAML file
         :param mapping_filename: YAML config path
+        :param object_type: The type of objects
         :return: AttributeOverrides instance
         """
+        if mapping_filename is None:
+            return cls.zero()
+
         with open(mapping_filename, 'r') as f:
             data = yaml.load(f)
             if not isinstance(data, dict):
                 raise TypeError('%s root object must be dictionary!' %
                                 (mapping_filename,))
-        return cls(data)
+            object_data = data.get(object_type, {})
+            if not isinstance(object_data, dict):
+                raise TypeError('%s object in mapping file %s must be '
+                                'dictionary!' % (object_type,
+                                                 mapping_filename))
+            if not object_data:
+                return cls.zero()
+
+            return cls(object_data)
 
     @classmethod
     def zero(cls):

--- a/cloudferry/lib/utils/override.py
+++ b/cloudferry/lib/utils/override.py
@@ -13,7 +13,13 @@
 # limitations under the License.
 import yaml
 
+from cloudferry.lib.base import exception
+
 ABSENT = object()
+
+
+class InvalidOverrideConfigError(exception.AbortMigrationError):
+    pass
 
 
 class OverrideRule(object):
@@ -57,7 +63,13 @@ class OverrideRule(object):
                     (attribute, repr(match)))
 
 
+def get_filename_from_stream(stream):
+    return getattr(stream, 'name', 'stream')
+
+
 class AttributeOverrides(object):
+    ALLOWED_OBJECT_TYPES = ['volumes', 'servers']
+
     def __init__(self, mapping):
         self.mapping = {}
         for attr, rules in mapping.items():
@@ -68,6 +80,29 @@ class AttributeOverrides(object):
                 raise TypeError(
                     'Invalid value for attribute "%s" rules (must be '
                     'list): %s' % (attr, repr(rules)))
+
+    @classmethod
+    def from_stream(cls, stream, object_type):
+        data = yaml.load(stream)
+        if not isinstance(data, dict):
+            raise TypeError('%s root object must be dictionary!' %
+                            (get_filename_from_stream(stream),))
+        object_data = data.get(object_type, {})
+
+        if not set(data.keys()).issubset(set(cls.ALLOWED_OBJECT_TYPES)):
+            raise InvalidOverrideConfigError(
+                "Mapping file '%s' has unsupported entries: '%s'. "
+                "Please make sure you follow template config." % (
+                    get_filename_from_stream(stream), data.keys()))
+
+        if not isinstance(object_data, dict):
+            raise TypeError('%s object in mapping file %s must be '
+                            'dictionary!' % (object_type,
+                                             get_filename_from_stream(stream)))
+        if not object_data:
+            return cls.zero()
+
+        return cls(object_data)
 
     @classmethod
     def from_filename(cls, mapping_filename, object_type):
@@ -81,19 +116,7 @@ class AttributeOverrides(object):
             return cls.zero()
 
         with open(mapping_filename, 'r') as f:
-            data = yaml.load(f)
-            if not isinstance(data, dict):
-                raise TypeError('%s root object must be dictionary!' %
-                                (mapping_filename,))
-            object_data = data.get(object_type, {})
-            if not isinstance(object_data, dict):
-                raise TypeError('%s object in mapping file %s must be '
-                                'dictionary!' % (object_type,
-                                                 mapping_filename))
-            if not object_data:
-                return cls.zero()
-
-            return cls(object_data)
+            return cls.from_stream(f, object_type)
 
     @classmethod
     def zero(cls):

--- a/configs/config.ini
+++ b/configs/config.ini
@@ -204,6 +204,10 @@ storage_backend_timeout = 300
 #         the filter config file.
 migrate_whole_cloud = False
 
+# Time to wait for image backed to save an image.
+# Value is in seconds.
+image_save_timeout = 600
+
 
 #==============================================================================
 # Source cloud configuration
@@ -597,7 +601,6 @@ db_name = <cinder_database_name>
 # iscsi_my_ip
 # initiator_name
 
-
 [dst_image]
 service = glance
 backend = swift
@@ -630,12 +633,6 @@ service = swift
 
 [import_rules]
 key = {name:dest-key-1}
-
-
-[snapshot]
-
-#Default path "dump.sql". Which will create a backup inside Cloudferry directory.
-snapshot_path = dump.sql
 
 
 [initial_check]

--- a/configs/override_rules.yaml
+++ b/configs/override_rules.yaml
@@ -1,53 +1,64 @@
 ---
 
 # Examples:
-#server_group:
-#- when:
-#    id:
-#    - 14ba292e-f0bb-4eec-9b3a-abb775db7ff4
-#    - 533d5840-8584-47bc-be16-2825536e9027
-#    - 7398b91f-e1c2-4378-9943-391318981aee
-#    - 1da4d59e-06de-4d34-b0e7-655e886e0183
-#  replace: 66e76c27-874d-48e1-bca2-b0eb0ea95ff3
+#servers:
+#  server_group:
+#    - when:
+#      id:
+#        - 14ba292e-f0bb-4eec-9b3a-abb775db7ff4
+#        - 533d5840-8584-47bc-be16-2825536e9027
+#        - 7398b91f-e1c2-4378-9943-391318981aee
+#        - 1da4d59e-06de-4d34-b0e7-655e886e0183
+#      replace: 66e76c27-874d-48e1-bca2-b0eb0ea95ff3
 
 
 # Change AZ:
 #  1) from us_west_dc1_ssd to us_west_dc2_ssd
 #  2) us_west_dc3, us_west_dc4, us_west_dc5 to us_east_dc1
 #  3) if no AZ with same name as in SRC cloud, change AZ to us_west_dc2
-#availability_zone:
-#- when: us_west_dc1_ssd
-#  replace: us_west_dc2_ssd
-#- when:
+#servers:
+#  availability_zone:
+#  - when: us_west_dc1_ssd
+#    replace: us_west_dc2_ssd
+#  - when:
 #    availability_zone:
 #    - us_west_dc3
 #    - us_west_dc4
 #    - us_west_dc5
-#  replace: us_east_dc1
-#- when: null
-#  replace: us_west_dc2
+#    replace: us_east_dc1
+#  - when: null
+#    replace: us_west_dc2
 
 # Change falvor for instances with listed IDs to "4"
-#flavor:
-#- when:
-#    id:
-#    - 14ba292e-f0bb-4eec-9b3a-abb775db7ff4
-#    - 533d5840-8584-47bc-be16-2825536e9027
-#    - 7398b91f-e1c2-4378-9943-391318981aee
-#    - 1da4d59e-06de-4d34-b0e7-655e886e0183
-#  replace: 4
+#servers:
+#  flavor:
+#  - when:
+#      id:
+#      - 14ba292e-f0bb-4eec-9b3a-abb775db7ff4
+#      - 533d5840-8584-47bc-be16-2825536e9027
+#      - 7398b91f-e1c2-4378-9943-391318981aee
+#      - 1da4d59e-06de-4d34-b0e7-655e886e0183
+#    replace: 4
 
 # Change key_name from 'admin' to 'h4x0r'
-#key_name:
-#- when: admin
-#  replace: h4x0r
+#servers:
+#  key_name:
+#  - when: admin
+#    replace: h4x0r
 
 # Change AZ to us_west_dc2_ssd when source AZ is us_west_dc1 and source flavor
 # is "5"
-#availability_zone:
-#- when:
-#    availability_zone:
-#    - us_west_dc1
-#    flavor:
-#    - 5
-#  replace: us_west_dc2_ssd
+#servers:
+#  availability_zone:
+#  - when:
+#      availability_zone:
+#      - us_west_dc1
+#      flavor:
+#      - 5
+#    replace: us_west_dc2_ssd
+
+# Specify non default volume type for volumes
+#volumes:
+#  volume_type:
+#  - when: null
+#    replace: netapp

--- a/configs/override_rules.yaml
+++ b/configs/override_rules.yaml
@@ -62,3 +62,6 @@
 #  volume_type:
 #  - when: null
 #    replace: netapp
+#  availability_zone:
+#  - when: source_cloud_az
+#    replace: dest_cloud_az

--- a/tests/lib/os/storage/test_cinder_storage.py
+++ b/tests/lib/os/storage/test_cinder_storage.py
@@ -104,8 +104,8 @@ class CinderStorageTestCase(test.TestCase):
 
         volume = self.cinder_client.create_volume(100500, name='fake')
 
-        self.mock_client().volumes.create.assert_called_once_with(100500,
-                                                                  name='fake')
+        self.mock_client().volumes.create.assert_called_once_with(
+            100500, name='fake', volume_type=None)
         self.assertEqual(self.fake_volume_0, volume)
 
     def test_get_volume_by_id(self):


### PR DESCRIPTION
Adds support to migrate cinder volumes to non-default cinder backends.
This resolves cinder migration issues when source cloud has NFS backend
but destination cloud has NFS and non-NFS backend, and non-NFS backend
is configured as default.