### PR TITLE
CF-574 VM migration when backing file is not present

### DIFF
--- a/cloudferry/actions/compute/transport_ephemeral.py
+++ b/cloudferry/actions/compute/transport_ephemeral.py
@@ -81,6 +81,11 @@ class TransportEphemeral(action.Action):
                                              host)
             diff_path = diff['path_dst']
             backing_path = qemu_img.detect_backing_file(diff_path, None)
+
+            if backing_path is None:
+                # Ignore missing ephemeral backing file
+                continue
+
             LOG.debug('Transport Ephemeral rebase diff: diff_path=%s, '
                       'backing_path=%s', diff_path, backing_path)
             backing_dir = os.path.dirname(backing_path)


### PR DESCRIPTION
VM migration fails if backing file for the ephemeral drive is somehow
missing in source cloud. The patch resolves this problem by ignoring
missing backing file and only copying the base ephemeral.