### PR TITLE
[CF-551] Extend functional tests to verify tenant mapping functionality

### DIFF
--- a/cloudferry_devlab/cloudferry_devlab/tests/config.py
+++ b/cloudferry_devlab/cloudferry_devlab/tests/config.py
@@ -70,6 +70,13 @@ filters_file_naming_template = 'filter_{tenant_name}.yaml'
 all_tenants_filter_filename = 'all_tenants_filter.yaml'
 """All tenants filter file."""
 
+rsc_map_filename = 'configs/resource_map.yaml'
+"""Resource Map file."""
+
+mapped_tenant_dict = {'tenant2': 'tenant2_mapped_in_resource_map_yaml'}
+"""SRC to DST Mapped Tenant Dictionary where key is SRC tenant name
+and value is the corresponding DST tenant name"""
+
 ext_net_map = 'ext_net_map.yaml'
 """This file contains map of relationships between external networks on source
 and destination clouds."""
@@ -270,6 +277,7 @@ tenants = [
               {'filename': 'test/dir/test_data.txt',
                'data': 'test data string'}]}
          ],
+     'images': [{'name': 'image9', 'copy_from': img_url, 'is_public': False}],
      'unassociated_fip': 3
      },
     {'name': 'tenant3', 'description': 'This tenant will be deleted',

--- a/cloudferry_devlab/cloudferry_devlab/tests/testcases/test_glance_image_migration.py
+++ b/cloudferry_devlab/cloudferry_devlab/tests/testcases/test_glance_image_migration.py
@@ -45,6 +45,8 @@ class GlanceMigrationTests(functional_test.FunctionalTest):
                 mbr_list = []
                 for mem in members:
                     mem_name = auth_client.tenants.find(id=mem.member_id).name
+                    mem_name = self.migration_utils.check_mapped_tenant(
+                        tenant_name=mem_name)
                     mbr_list.append(mem_name)
                 _members.append({img.name: sorted(mbr_list)})
             return sorted(_members)

--- a/cloudferry_devlab/cloudferry_devlab/tests/testcases/test_keystone_migration.py
+++ b/cloudferry_devlab/cloudferry_devlab/tests/testcases/test_keystone_migration.py
@@ -49,6 +49,8 @@ class KeystoneMigrationTests(functional_test.FunctionalTest):
     def test_migrate_keystone_user_tenant_roles(self):
         """Validate user's tenant roles were migrated with correct name."""
         tenant = base.get_nosetest_cmd_attribute_val('migrated_tenant')
+        dst_tenant = self.migration_utils.check_mapped_tenant(
+            tenant_name=tenant)
         for dst_user in self.dst_users:
             src_user = None
             for user in self.src_users:
@@ -66,7 +68,7 @@ class KeystoneMigrationTests(functional_test.FunctionalTest):
                 src_user_tnt_roles = self.src_cloud.get_roles_for_user(
                                          src_user, tenant)
                 dst_user_tnt_roles = self.dst_cloud.get_roles_for_user(
-                                         dst_user, tenant)
+                                         dst_user, dst_tenant)
             if len(src_user_tnt_roles) == 0 and len(dst_user_tnt_roles) == 0:
                 continue
             self.validate_resource_parameter_in_dst(
@@ -107,7 +109,9 @@ class KeystoneMigrationTests(functional_test.FunctionalTest):
         src_tenants = filtering_data[0]
         src_tenants = [tenant for tenant in src_tenants
                        if getattr(tenant, "name") !=
-                       config.case_sensitivity_test_tenant]
+                       config.case_sensitivity_test_tenant and
+                       getattr(tenant, "name") not in
+                       config.mapped_tenant_dict.keys()]
 
         self.validate_resource_parameter_in_dst(src_tenants, dst_tenants,
                                                 resource_name='tenant',

--- a/cloudferry_devlab/cloudferry_devlab/tests/testcases/test_networking_migration.py
+++ b/cloudferry_devlab/cloudferry_devlab/tests/testcases/test_networking_migration.py
@@ -153,6 +153,8 @@ class NetrworkingMigrationTests(functional_test.FunctionalTest):
                 if src_router['name'] == dst_router['name']:
                     src_tenant_name = self.src_cloud.get_tenant_name(
                         src_router['tenant_id'])
+                    src_tenant_name = self.migration_utils.check_mapped_tenant(
+                        tenant_name=src_tenant_name)
                     self.assertTrue(src_tenant_name == dst_tenant_name,
                                     msg='DST tenant name %s is not equal to '
                                         'SRC %s' %

--- a/cloudferry_devlab/cloudferry_devlab/tests/testcases/test_nova_resource_migration.py
+++ b/cloudferry_devlab/cloudferry_devlab/tests/testcases/test_nova_resource_migration.py
@@ -133,10 +133,12 @@ class NovaResourceMigrationTests(functional_test.FunctionalTest):
             self.dst_cloud.keystoneclient.tenants.list(), self.dst_cloud)
         tenants_with_missed_quotas = []
         for tenant in src_quotas:
-            self.assertIn(tenant, dst_quotas,
-                          'Tenant %s is missing on dst' % tenant)
-            if src_quotas[tenant][param] != dst_quotas[tenant][param]:
-                tenants_with_missed_quotas.append(tenant)
+            tnt_name = self.migration_utils.check_mapped_tenant(
+                tenant_name=tenant)
+            self.assertIn(tnt_name, dst_quotas,
+                          'Tenant %s is missing on dst' % tnt_name)
+            if src_quotas[tenant][param] != dst_quotas[tnt_name][param]:
+                tenants_with_missed_quotas.append(tnt_name)
         if tenants_with_missed_quotas:
             self.fail(msg='%s quotas for tenants %s migrated not successfully'
                           % (param, tenants_with_missed_quotas))

--- a/cloudferry_devlab/cloudferry_devlab/tests/testcases/test_verify_dst_del_tenant_resources.py
+++ b/cloudferry_devlab/cloudferry_devlab/tests/testcases/test_verify_dst_del_tenant_resources.py
@@ -118,8 +118,11 @@ class VerifyDstDeletedTenantResources(functional_test.FunctionalTest):
         """Validate deleted tenant weren't migrated."""
         undeleted_tenants = []
         for tenant_name, _ in self.deleted_tenants:
-            if tenant_name in self.dst_tenants:
-                undeleted_tenants.append(tenant_name)
+            tnt_name = self.migration_utils.check_mapped_tenant(
+                tenant_name=tenant_name)
+
+            if tnt_name in self.dst_tenants:
+                undeleted_tenants.append(tnt_name)
 
         if undeleted_tenants:
             msg = 'Tenants {0} exist on destination, but should be deleted!'
@@ -137,8 +140,11 @@ class VerifyDstDeletedTenantResources(functional_test.FunctionalTest):
             tenant_users_dst = \
                 self._tenant_users_exist_on_dst(tenant_users_list_src)
 
+            tnt_name = self.migration_utils.check_mapped_tenant(
+                tenant_name=tenant_name)
+
             if tenant_users_dst:
-                undeleted_users.append({tenant_name: tenant_users_dst})
+                undeleted_users.append({tnt_name: tenant_users_dst})
 
         if undeleted_users:
             msg = 'Tenant\'s users {0} exist on destination,' \
@@ -152,8 +158,10 @@ class VerifyDstDeletedTenantResources(functional_test.FunctionalTest):
         for tenant_name, tenant in self.deleted_tenants:
             undeleted_net_ids_list = \
                 self._tenant_nets_exist_on_dst(tenant['networks'])
+            tnt_name = self.migration_utils.check_mapped_tenant(
+                tenant_name=tenant_name)
             if undeleted_net_ids_list:
-                tenant_nets_ids.append({tenant_name: undeleted_net_ids_list})
+                tenant_nets_ids.append({tnt_name: undeleted_net_ids_list})
 
         if tenant_nets_ids:
             msg = 'Tenant\'s network {0} exists on destination,' \
@@ -168,8 +176,10 @@ class VerifyDstDeletedTenantResources(functional_test.FunctionalTest):
         for tenant_name, tenant in self.deleted_tenants:
             non_migrated_vms = self._tenant_vm_exists_on_dst(tenant['vms'])
 
+            tnt_name = self.migration_utils.check_mapped_tenant(
+                tenant_name=tenant_name)
             if non_migrated_vms:
-                tenants_vms.append({tenant_name: non_migrated_vms})
+                tenants_vms.append({tnt_name: non_migrated_vms})
 
         if tenants_vms:
             msg = 'Tenant\'s vm {0} does not exist on destination,' \
@@ -184,9 +194,11 @@ class VerifyDstDeletedTenantResources(functional_test.FunctionalTest):
 
             tenant_undeleted_volumes = \
                 self._tenant_volumes_exist_on_dst(tenant['cinder_volumes'])
+            tnt_name = self.migration_utils.check_mapped_tenant(
+                tenant_name=tenant_name)
             if tenant_undeleted_volumes:
                 undeleted_volumes.append(
-                    {tenant_name: tenant_undeleted_volumes})
+                    {tnt_name: tenant_undeleted_volumes})
 
         if undeleted_volumes:
             msg = ("Tenant's cinder volumes with ids {0} exist on "
@@ -210,8 +222,10 @@ class VerifyDstDeletedTenantResources(functional_test.FunctionalTest):
                             continue
                         if dst_vm.key_name not in migrated_keys:
                             keys_list.append(dst_vm.key_name)
+            tnt_name = self.migration_utils.check_mapped_tenant(
+                tenant_name=tenant_name)
             if keys_list:
-                unused_keypairs.append({tenant_name: keys_list})
+                unused_keypairs.append({tnt_name: keys_list})
 
         if unused_keypairs:
             msg = 'Tenant\'s key_pairs {0} exist on destination,' \
@@ -231,8 +245,10 @@ class VerifyDstDeletedTenantResources(functional_test.FunctionalTest):
             for src_vm in tenant['vms']:
                 if not src_vm['flavor'] in dst_flavors_list:
                     flvlist.append(src_vm['flavor'])
+            tnt_name = self.migration_utils.check_mapped_tenant(
+                tenant_name=tenant_name)
             if flvlist:
-                unused_flavors.append({tenant_name: flvlist})
+                unused_flavors.append({tnt_name: flvlist})
 
         if unused_flavors:
             msg = 'Tenant\'s flavors {0} do not exist on destination,' \
@@ -270,8 +286,11 @@ class VerifyDstDeletedTenantResources(functional_test.FunctionalTest):
             non_migrated_subnets = set(
                 src_tenant_net_names) ^ set(migrated_subnets)
 
+            tnt_name = self.migration_utils.check_mapped_tenant(
+                tenant_name=tenant_name)
+
             if non_migrated_subnets:
-                tenants_subnets.append({tenant_name: non_migrated_subnets})
+                tenants_subnets.append({tnt_name: non_migrated_subnets})
 
         if tenants_subnets:
             msg = 'Tenant\'s subnets do not exist on destination,' \

--- a/cloudferry_devlab/cloudferry_devlab/tests/testcases/test_verify_dst_functionality.py
+++ b/cloudferry_devlab/cloudferry_devlab/tests/testcases/test_verify_dst_functionality.py
@@ -64,9 +64,12 @@ class VerifyDstCloudFunctionality(functional_test.FunctionalTest):
         except ks_exceptions.Conflict:
             pass
 
+        tnt_name = self.migration_utils.check_mapped_tenant(
+            tenant_name=TEST_TENANT_NAME)
+
         self.dst_cloud.switch_user(user=self.dst_cloud.username,
                                    password=self.dst_cloud.password,
-                                   tenant=TEST_TENANT_NAME)
+                                   tenant=tnt_name)
 
         # declare vars in case if condition below will not be satisfied
         image_name = ''
@@ -76,7 +79,7 @@ class VerifyDstCloudFunctionality(functional_test.FunctionalTest):
         # create vm parameters
         flavor_name = config.flavors[0]['name']
         for tenant in config.tenants:
-            if tenant['name'] == TEST_TENANT_NAME:
+            if tenant['name'] == tnt_name:
                 image_name = tenant['images'][0]['name']
                 nic_name = tenant['networks'][0]['name']
                 self.neutron_float_ip_quota = \
@@ -133,9 +136,12 @@ class VerifyDstCloudFunctionality(functional_test.FunctionalTest):
 
     def tearDown(self):
 
+        tnt_name = self.migration_utils.check_mapped_tenant(
+            tenant_name=TEST_TENANT_NAME)
+
         self.dst_cloud.switch_user(user=self.dst_cloud.username,
                                    password=self.dst_cloud.password,
-                                   tenant=TEST_TENANT_NAME)
+                                   tenant=tnt_name)
 
         cinder_volumes = self.dst_cloud.cinderclient.volumes.list()
         for volume in cinder_volumes:
@@ -155,7 +161,7 @@ class VerifyDstCloudFunctionality(functional_test.FunctionalTest):
         self.release_fips_tenant()
 
         self.update_floatip_neutron_quota(self.fip_quota_neutron,
-                                          TEST_TENANT_NAME)
+                                          tnt_name)
 
         try:
             # remove admin role of the dst admin account for test tenant
@@ -335,8 +341,11 @@ class VerifyDstCloudFunctionality(functional_test.FunctionalTest):
     def test_floating_ips_neutron_quota(self):
         """Validate destination cloud's floating IP quota information."""
         self.release_fips_tenant()
+        tnt_name = self.migration_utils.check_mapped_tenant(
+            tenant_name=TEST_TENANT_NAME)
+
         self.update_floatip_neutron_quota(self.neutron_float_ip_quota,
-                                          TEST_TENANT_NAME)
+                                          tnt_name)
         self.release_fips_tenant()
 
         for _ in xrange(self.neutron_float_ip_quota):

--- a/cloudferry_devlab/cloudferry_devlab/tests/testcases/test_verify_dst_net_segm_id.py
+++ b/cloudferry_devlab/cloudferry_devlab/tests/testcases/test_verify_dst_net_segm_id.py
@@ -37,8 +37,12 @@ class VerifyDstCloudFunctionality(functional_test.FunctionalTest):
         self.dst_cloud.switch_user(user=self.dst_cloud.username,
                                    password=self.dst_cloud.password,
                                    tenant=self.dst_cloud.tenant)
+
+        tnt_name = self.migration_utils.check_mapped_tenant(
+            tenant_name=TEST_TENANT_NAME)
+
         self.dst_test_tenant_id = \
-            self.dst_cloud.get_tenant_id(TEST_TENANT_NAME)
+            self.dst_cloud.get_tenant_id(tnt_name)
 
         self.dst_net_sid_mapping = []
         self.dst_all_nets_sids = []

--- a/cloudferry_devlab/cloudferry_devlab/tests/utils.py
+++ b/cloudferry_devlab/cloudferry_devlab/tests/utils.py
@@ -199,6 +199,13 @@ class MigrationUtils(object):
             return False
         return True
 
+    def check_mapped_tenant(self, tenant_name, cloud_prefix=''):
+        tnt_name = tenant_name
+        if cloud_prefix in ['', 'dst']:
+            tnt_name = self.config.mapped_tenant_dict.get(tenant_name,
+                                                          tenant_name)
+        return tnt_name
+
     @staticmethod
     def open_ssh_port_secgroup(client, tenant_id):
         sec_grps = client.get_sec_group_id_by_tenant_id(tenant_id)


### PR DESCRIPTION
Added the below scenario:

-     Create tenant "tenant2" in source cloud
-     Map "tenant2" to "tenant-2" in configs/resource_map.yaml mapping file
-     Create image, network, VM with attached volume in "tenant2" tenant
-     Run migration
-     Verify all created objects successfully migrated to destination tenant "tenant-2"
