### PR TITLE
[CF-542] Extend functional tests to verify migration of VM with attached deleted volume

### DIFF
--- a/cloudferry_devlab/cloudferry_devlab/generate_load.py
+++ b/cloudferry_devlab/cloudferry_devlab/generate_load.py
@@ -80,6 +80,11 @@ class Prerequisites(base.BasePrerequisites):
                 configuration_ini=self.configuration_ini,
                 config=self.config)
 
+    def delete_volumes_from_db(self):
+        for volume in self.config.volumes_deleted_by_name_from_db:
+            vol_id = self.get_volume_id(volume)
+            self.clean_tools.delete_volume_by_id_from_db(vol_id, 'src')
+
     @clean_if_exists
     def create_users(self, users=None):
         def get_params_for_user_creating(_user):
@@ -1202,3 +1207,5 @@ class Prerequisites(base.BasePrerequisites):
         for vm in [self.get_vm_id(vm['name']) for vm in
                    self.src_vms_from_config if vm.get('broken')]:
             self.break_vm(vm)
+        self.log.info('Delete volumes from cinder database on SRC cloud.')
+        self.delete_volumes_from_db()

--- a/cloudferry_devlab/cloudferry_devlab/tests/cleanup.py
+++ b/cloudferry_devlab/cloudferry_devlab/tests/cleanup.py
@@ -80,6 +80,16 @@ class CleanEnv(base.BasePrerequisites):
                 self.get_volume_id(volume.display_name))
             LOG.info('Volume "%s" has been deleted', volume.display_name)
 
+    def delete_volume_by_id_from_db(self, vol_id, position):
+        cinder_mysql = self.mysql_connector('cinder', position)
+        if self.openstack_release == 'icehouse':
+            sql_vol_delete_by_id = "DELETE FROM volume_admin_metadata WHERE"\
+                " volume_id='{vol_id}'".format(vol_id=vol_id)
+            cinder_mysql.execute(sql_vol_delete_by_id)
+        sql_vol_delete_by_id = "DELETE FROM volumes WHERE"\
+            " id='{vol_id}'".format(vol_id=vol_id)
+        cinder_mysql.execute(sql_vol_delete_by_id)
+
     def clean_swift_containers_and_objects(self):
         containers = self.config.swift_containers
         for container in containers:

--- a/cloudferry_devlab/cloudferry_devlab/tests/config.py
+++ b/cloudferry_devlab/cloudferry_devlab/tests/config.py
@@ -499,6 +499,9 @@ images_blacklisted = ['image7']
 flavors_deleted_after_vm_boot = ["del_flvr"]
 """Flavors to be deleted after booting VM from them"""
 
+volumes_deleted_by_name_from_db = ['deleted_volume']
+"""Volumes deleted by name from cinder database on SRC cloud"""
+
 vms_not_in_filter = ['not_in_filter']
 """Instances not to be included in filter"""
 
@@ -650,7 +653,8 @@ vms = [
     {'name': 'server1', 'image': 'image1', 'flavor': 'flavorname1'},
     {'name': 'server2', 'image': 'deleted_on_dst', 'flavor': 'del_flvr',
      'server_group': 'admin_server_group', 'config_drive': True, 'fip': True},
-    {'name': 'server3', 'image': 'deleted_image', 'flavor': 'diffattrib_flvr'},
+    {'name': 'server3', 'image': 'deleted_image', 'flavor': 'diffattrib_flvr',
+     'fip': True},
     {'name': 'server4', 'image': 'broken_image', 'flavor': 'flavorname2'},
     {'name': 'server5', 'image': 'image1', 'flavor': 'flavorname1',
      'broken': True},
@@ -694,7 +698,9 @@ cinder_volumes = [
      'volume_type': 'nfs2',  'metadata': {'data': 'nope', 'enabled': "False"},
      'server_to_attach': 'server2', 'device': '/dev/vdb'},
     {'display_name': 'cinder_volume3', 'size': 1,
-     'user': 'test_volume_migration'}
+     'user': 'test_volume_migration'},
+    {'display_name': 'deleted_volume', 'size': 1, 'volume_type': 'nfs1',
+     'server_to_attach': 'server3', 'device': '/dev/vdb'}
 ]
 """Cinder images to create/delete.
 To write some date, use "write_to_file" parameter. Now only string could be

--- a/cloudferry_devlab/cloudferry_devlab/tests/mysql_connector.py
+++ b/cloudferry_devlab/cloudferry_devlab/tests/mysql_connector.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2016 Mirantis Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the License);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an AS IS BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and#
+# limitations under the License.
+
+
+import pymysql
+
+
+class MysqlConnector(object):
+    def __init__(self, config, db):
+        self.config = config
+        self.db = db
+        self.connection_dict = self.compose_connection_dict()
+
+    def compose_connection_dict(self):
+        data = {
+            'host': self.config['db_host'],
+            'port': int(self.config['db_port']),
+            'user': self.config['db_user'],
+            'password': self.config['db_password'],
+            'db': self.db,
+            'cursorclass': pymysql.cursors.DictCursor
+        }
+        return data
+
+    def execute(self, command):
+        connection = pymysql.connect(**self.connection_dict)
+        try:
+            with connection.cursor() as cursor:
+                cursor.execute(command)
+                connection.commit()
+                return cursor
+        finally:
+            connection.close()


### PR DESCRIPTION
Below scenario is automated:

- Create a VM on the source cloud.
- Create a volume on the source cloud and attach to the above VM.
- Delete the above volume from the database.
- Run migration. Verify that the VM migrated successfully to the destination cloud without the above volume attached.