### PR TITLE
CF-591 Check if bbcp is installed and allowed to be owerwritten

### DIFF
--- a/tests/lib/copy_engines/test_bbcp_copier.py
+++ b/tests/lib/copy_engines/test_bbcp_copier.py
@@ -80,9 +80,11 @@ class BbcpCopierTestCase(test_base.BaseTestCase):
             mock_run.assert_not_called()
 
             runner.reset_mock()
-            runner.run.side_effect = (remote_runner.RemoteExecutionError, None)
+            runner.run.side_effect = (remote_runner.RemoteExecutionError,
+                                      remote_runner.RemoteExecutionError,
+                                      None)
             self.copier.copy_bbcp('fake_host', 'src')
-            self.assertEqual(2, runner.run.call_count)
+            self.assertEqual(3, runner.run.call_count)
             self.assertCalledOnce(mock_run)
 
 


### PR DESCRIPTION
If migration is done with bbcp as copy engine, bbcp is being copied to
both source and destination nodes prior to ephemeral migration, but if
bbcp was previously copied to the node from different user, current
user may not have permissions to overwrite existing bbcp executable and
migration would fail. This patch resolves this issue by reusing existing
bbcp and assigning 777 permissions to the file so that it can be
overwritten by anyone.