### PR TITLE
[CF-588] Update test-generator that fixes functional tests skipping issue

### DIFF
--- a/cloudferry_devlab/requirements.txt
+++ b/cloudferry_devlab/requirements.txt
@@ -14,4 +14,4 @@ nose==1.3.7
 nose-testconfig==0.9.1
 sqlalchemy==1.0.12
 PyMySQL==0.6.7
--e git+https://github.com/kevinastone/generator.git@nose-attribs#egg=test-generator
+test-generator==0.1.2


### PR DESCRIPTION
Update test-generator to 0.1.2 version which fixes [this issue](https://github.com/kevinastone/generator/issues/1) related to functional tests being skipped when both @generate and @attr decorators have been used.