### PR TITLE
[CF-603] Extend functional tests to verify migration of user quota migration

### DIFF
--- a/cloudferry_devlab/cloudferry_devlab/generate_load.py
+++ b/cloudferry_devlab/cloudferry_devlab/generate_load.py
@@ -177,6 +177,17 @@ class Prerequisites(base.BasePrerequisites):
         self.switch_user(user=self.username, password=self.password,
                          tenant=self.tenant)
 
+    def modify_user_quotas(self):
+        """ Modify user's custom nova quotas
+        """
+        for user in self.config.users:
+            if 'quota' in user:
+                self.log.debug("Updating custom nova quota for user %s,"
+                               " tenant %s.", user['name'], user['tenant'])
+                self.novaclient.quotas.update(tenant_id=self.get_tenant_id(
+                    user['tenant']), user_id=self.get_user_id(user['name']),
+                    **user['quota'])
+
     def modify_quotas(self):
         """ Modify nova and cinder quotas
         """
@@ -1134,6 +1145,9 @@ class Prerequisites(base.BasePrerequisites):
         self.create_keypairs()
         self.log.info('Modifying quotas.')
         self.modify_quotas()
+        if self.openstack_release in ['icehouse', 'juno']:
+            self.log.info('Modifying custom user quotas.')
+            self.modify_user_quotas()
         self.log.info('Creating flavors.')
         self.create_flavors()
         self.log.info('Uploading images.')

--- a/cloudferry_devlab/cloudferry_devlab/tests/config.py
+++ b/cloudferry_devlab/cloudferry_devlab/tests/config.py
@@ -96,9 +96,17 @@ case_sensitivity_test_user = 'user10'
 case_sensitivity_test_tenant = 'tenant6'
 """Tenant to be created in upper case on DST Cloud."""
 
+user_with_quotas = 'user1'
+"""User with custom nova quotas"""
+
 users = [
-    {'name': 'user1', 'password': 'passwd1', 'email': 'mail@example.com',
-     'tenant': 'tenant1', 'enabled': True},
+    {'name': user_with_quotas, 'password': 'passwd1',
+     'email': 'mail@example.com', 'tenant': 'tenant1', 'enabled': True,
+     'quota': {'instances': '19', 'cores': '18', 'ram': '52198',
+               'floating_ips': '8', 'fixed_ips': '15', 'metadata_items': '127',
+               'injected_files': '4', 'injected_file_content_bytes': '10239',
+               'injected_file_path_bytes': '254', 'key_pairs': '4',
+               'security_groups': '8', 'security_group_rules': '19'}},
     {'name': 'user2', 'password': 'passwd2', 'email': 'aa@example.com',
      'tenant': 'tenant2', 'enabled': True},
     {'name': 'user3', 'password': 'paafdssswd1', 'email': 'mdsail@example.com',
@@ -148,7 +156,7 @@ roles = [
 tenants = [
     {'name': 'tenant1', 'description': 'None', 'enabled': True,
      'quota': {'instances': '20', 'cores': '19', 'ram': '52199',
-               'floating_ips': '9', 'fixed_ips': '', 'metadata_items': '',
+               'floating_ips': '9', 'fixed_ips': '16', 'metadata_items': '',
                'injected_files': '', 'injected_file_content_bytes': '',
                'injected_file_path_bytes': '', 'key_pairs': '5',
                'security_groups': '9', 'security_group_rules': ''},


### PR DESCRIPTION
Below is the test case for Icehouse to Juno migration (Grizzly does not support user quotas)

-     Set `[migrate] migrate_user_quotas = True` in config
-     Create user user_with_quotas in source cloud
-     Add custom user quotas to user_with_quotas user
-     Run migration with 4_transport_compute_resources.yaml scenario
-     Verify user quotas appear in destination cloud
