### PR TITLE
CF-641 Invalid report for tenant migration

### DIFF
--- a/cloudferry/lib/migration/notifiers.py
+++ b/cloudferry/lib/migration/notifiers.py
@@ -21,12 +21,12 @@ class MigrationStateNotifier(object):
     def add_observer(self, observer):
         self.observers.append(observer)
 
-    def success(self, object_type, src_object, dst_object, message=None):
+    def success(self, object_type, src_object, dst_object_id, message=None):
         self._update_state(object_type, src_object,
                            objects.MigrationState.SUCCESS,
                            message)
         for observer in self.observers:
-            observer.set_dst_uuid(object_type, src_object, dst_object)
+            observer.set_dst_uuid(object_type, src_object, dst_object_id)
 
     def fail(self, object_type, obj, message=None):
         self._update_state(object_type, obj,

--- a/cloudferry/lib/os/identity/keystone.py
+++ b/cloudferry/lib/os/identity/keystone.py
@@ -501,7 +501,7 @@ class KeystoneIdentity(identity.Identity):
                                                     tenant['description'])
                 _tenant['meta']['new_id'] = created_tenant.id
                 self.state_notifier.success(
-                    objs.MigrationObjectType.TENANT, tenant, created_tenant)
+                    objs.MigrationObjectType.TENANT, tenant, created_tenant.id)
             else:
                 msg = "Tenant '%s' is already present on destination, " \
                       "skipping" % tenant['name']
@@ -583,7 +583,7 @@ class KeystoneIdentity(identity.Identity):
                 LOG.debug("Creating role '%s'", role['name'])
                 new_role = self.create_role(role['name'])
                 self.state_notifier.success(
-                    objs.MigrationObjectType.ROLE, role, new_role)
+                    objs.MigrationObjectType.ROLE, role, new_role.id)
                 _role['meta']['new_id'] = new_role.id
             else:
                 msg = "Role '%s' is already present on destination, " \


### PR DESCRIPTION
Tenant migration resulted in full tenant object being printed in
"Destination ID" field, instead of tenant ID only, which was caused
by incorrect data being passed to notification observer.