### PR TITLE
CF-644 Make sure bbcp is installed on remote hosts in /tmp/bbcp

### DIFF
--- a/cloudferry/lib/copy_engines/bbcp_copier.py
+++ b/cloudferry/lib/copy_engines/bbcp_copier.py
@@ -56,10 +56,7 @@ class BbcpCopier(base.BaseCopier):
 
         LOG.debug("Checking if bbcp is installed on '%s' host", host)
 
-        bbcp_installed = (_bbcp_installed(runner, 'bbcp') or
-                          _bbcp_installed(runner, BBCP_PATH))
-
-        if bbcp_installed:
+        if _bbcp_installed(runner, BBCP_PATH):
             return
 
         if position == 'src':

--- a/tests/lib/copy_engines/test_bbcp_copier.py
+++ b/tests/lib/copy_engines/test_bbcp_copier.py
@@ -81,10 +81,9 @@ class BbcpCopierTestCase(test_base.BaseTestCase):
 
             runner.reset_mock()
             runner.run.side_effect = (remote_runner.RemoteExecutionError,
-                                      remote_runner.RemoteExecutionError,
                                       None)
             self.copier.copy_bbcp('fake_host', 'src')
-            self.assertEqual(3, runner.run.call_count)
+            self.assertEqual(2, runner.run.call_count)
             self.assertCalledOnce(mock_run)
 
 


### PR DESCRIPTION
bbcp must always be copied to /tmp/bbcp on remote hosts and executed there