### PR TITLE
CF-657 restore_vms_state fails with ImportError

### DIFF
--- a/cloudferry_devlab/requirements.txt
+++ b/cloudferry_devlab/requirements.txt
@@ -3,6 +3,7 @@ oslo.config==3.9.0
 oslo.i18n==3.7.0
 oslo.serialization==2.7.0
 oslo.utils==3.15.0
+pycrypto==2.6.1
 python-cinderclient==1.3.1
 python-glanceclient==1.1.0
 python-keystoneclient==1.6.0

--- a/cloudferry_devlab/setup.py
+++ b/cloudferry_devlab/setup.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from pip.req import parse_requirements
+from setuptools import find_packages
 from setuptools import setup
 
 all_reqs = parse_requirements('requirements.txt', session=False)
@@ -26,8 +27,7 @@ setup(name='cloudferry_devlab',
       author='Mirantis Workload Mobility',
       author_email='workloadmobility@mirantis.com',
       license='Apache',
-      packages=['cloudferry_devlab', 'cloudferry_devlab.tests',
-                'cloudferry_devlab.tests.testcases'],
+      packages=find_packages(),
       entry_points={
           'console_scripts': [
               'generate_load = cloudferry_devlab.bin.main:main',


### PR DESCRIPTION
restore_vms_state script fails with ImportError:

```
$ restore_vms_state
Traceback (most recent call last):
  File
"CloudFerry/cloudferry_devlab/.venv/bin/restore_vms_state",
line 9, in <module>
    load_entry_point(Userscloudferry-devlab==0.0.0', 'console_scripts',
Usersrestore_vms_state')()
  File
"CloudFerry/cloudferry_devlab/.venv/lib/python2.7/site-packages/pkg_resources/__init__.py",
line 558, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File
"CloudFerry/cloudferry_devlab/.venv/lib/python2.7/site-packages/pkg_resources/__init__.py",
line 2682, in load_entry_point
    return ep.load()
  File
"CloudFerry/cloudferry_devlab/.venv/lib/python2.7/site-packages/pkg_resources/__init__.py",
line 2355, in load
    return self.resolve()
  File
"CloudFerry/cloudferry_devlab/.venv/lib/python2.7/site-packages/pkg_resources/__init__.py",
line 2361, in resolve
    module = __import__(self.module_name, fromlist=[Users__name__'],
level=0)
ImportError: No module named bin.main
```

The problem was with invalid setup.py which provided incorrect
installation path for binary files.