### PR TITLE
CF-661 Invalid glance image URL breaks VM migration

### DIFF
--- a/cloudferry/lib/os/image/glance_image.py
+++ b/cloudferry/lib/os/image/glance_image.py
@@ -304,11 +304,13 @@ class GlanceImage(image.Image):
             with proxy_client.expect_exception(
                 ssl.ZeroReturnError,
                 glance_exceptions.HTTPException,
+                glance_exceptions.CommunicationError,
                 IOError
             ):
                 return self.glance_client.images.data(image_id)
         except (ssl.ZeroReturnError,
                 glance_exceptions.HTTPException,
+                glance_exceptions.CommunicationError,
                 IOError):
             raise exception.ImageDownloadError
 


### PR DESCRIPTION
Some images may raise CommunicationError during download:

```
CommunicationError: Error finding address for
https://some.openstack.deployment.com/v1/images/4c5d0874-933d-4eef-859e-697d44d51bd1
```

This exception was not handled properly and resulted in VM migration
failures. This patch resolves the issue by correclty handling this
exception.